### PR TITLE
multi-field embeddings + bug fixes

### DIFF
--- a/core/src/embedding.rs
+++ b/core/src/embedding.rs
@@ -35,7 +35,10 @@ pub struct OpenAIEmbedding {
 impl OpenAIEmbedding {
     pub fn new(api_key: String) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(10))
+                .build()
+                .expect("failed to build HTTP client"),
             api_key,
         }
     }
@@ -92,8 +95,70 @@ impl FakeEmbedding {
 #[cfg(test)]
 #[async_trait]
 impl EmbeddingService for FakeEmbedding {
-    async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
+    async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
         self.call_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        Ok(vec![0.1; 1536])
+
+        const DIMS: usize = 256;
+        let mut vec = Vec::with_capacity(DIMS);
+        for i in 0..DIMS {
+            let mut hasher = DefaultHasher::new();
+            text.hash(&mut hasher);
+            i.hash(&mut hasher);
+            let h = hasher.finish();
+            // Map hash to [-1, 1]
+            vec.push((h as f64 / u64::MAX as f64) * 2.0 - 1.0);
+        }
+
+        // Normalize to unit vector
+        let norm: f64 = vec.iter().map(|x| x * x).sum::<f64>().sqrt();
+        Ok(vec.into_iter().map(|x| (x / norm) as f32).collect())
+    }
+}
+
+#[cfg(test)]
+pub struct FailingEmbedding;
+
+#[cfg(test)]
+#[async_trait]
+impl EmbeddingService for FailingEmbedding {
+    async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
+        anyhow::bail!("embedding service unavailable")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn fake_embedding_returns_distinct_vectors() {
+        let fake = FakeEmbedding::new();
+        let a = fake.embed("hello world").await.unwrap();
+        let b = fake.embed("goodbye moon").await.unwrap();
+
+        // Cosine similarity should be < 1.0 for distinct inputs
+        let dot: f32 = a.iter().zip(&b).map(|(x, y)| x * y).sum();
+        let norm_a = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let norm_b = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let cosine = dot / (norm_a * norm_b);
+        assert!(cosine < 0.99, "distinct texts should produce cosine < 0.99, got {cosine}");
+    }
+
+    #[tokio::test]
+    async fn fake_embedding_is_deterministic() {
+        let fake = FakeEmbedding::new();
+        let a = fake.embed("same text").await.unwrap();
+        let b = fake.embed("same text").await.unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[tokio::test]
+    async fn failing_embedding_returns_error() {
+        let failing = FailingEmbedding;
+        let result = failing.embed("anything").await;
+        assert!(result.is_err());
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,10 +12,10 @@ use tokio::sync::RwLock;
 pub use embedding::{EmbeddingService, OpenAIEmbedding};
 
 use models::{
-    DiscoverRequest, DiscoverResponse, ListToolsResponse, RankedTool, RegisterToolsRequest,
-    RegisterToolsResponse, StoredTool,
+    DiscoverRequest, DiscoverResponse, ErrorResponse, FieldEmbeddings, ListToolsResponse,
+    RankedTool, RegisterToolsRequest, RegisterToolsResponse, StoredTool,
 };
-use ranking::{bm25_scores, cosine_similarity};
+use ranking::{bm25_scores, weighted_semantic_score};
 
 // Types
 
@@ -55,26 +55,63 @@ async fn health() -> Json<HealthResponse> {
 async fn register_tools(
     State(state): State<Arc<AppState>>,
     Json(body): Json<RegisterToolsRequest>,
-) -> (StatusCode, Json<RegisterToolsResponse>) {
-    let mut tools = state.tools.write().await;
-    let mut cache = state.embedding_cache.write().await;
+) -> Result<(StatusCode, Json<RegisterToolsResponse>), (StatusCode, Json<ErrorResponse>)> {
     let count = body.tools.len();
 
-    for tool in body.tools {
-        let embed_text = format!("{}: {}", tool.name, tool.description);
-
-        let embedding = if let Some(cached) = cache.get(&embed_text) {
-            cached.clone()
+    // Compute embeddings outside the tools write lock
+    let mut tool_data = Vec::with_capacity(count);
+    for tool in &body.tools {
+        let (name_text, desc_text, input_text, output_text) = if let Some(ref fields) = tool.fields {
+            (
+                fields.name.clone(),
+                fields.description.clone(),
+                fields.input_schema.clone(),
+                fields.output_schema.clone(),
+            )
         } else {
-            let emb = state.embedding.embed(&embed_text).await.unwrap_or_default();
-            cache.insert(embed_text, emb.clone());
-            emb
+            (tool.name.clone(), tool.description.clone(), None, None)
         };
 
-        tools.insert(tool.name.clone(), StoredTool { tool, embedding });
+        let name_emb = embed_cached(&state, &name_text).await.map_err(embed_err)?;
+        let desc_emb = embed_cached(&state, &desc_text).await.map_err(embed_err)?;
+        let input_emb = match &input_text {
+            Some(t) => Some(embed_cached(&state, t).await.map_err(embed_err)?),
+            None => None,
+        };
+        let output_emb = match &output_text {
+            Some(t) => Some(embed_cached(&state, t).await.map_err(embed_err)?),
+            None => None,
+        };
+
+        let bm25_text = [
+            Some(name_text),
+            Some(desc_text),
+            input_text,
+            output_text,
+        ]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
+        .join(" ");
+
+        tool_data.push((
+            FieldEmbeddings {
+                name: name_emb,
+                description: desc_emb,
+                input_schema: input_emb,
+                output_schema: output_emb,
+            },
+            bm25_text,
+        ));
     }
 
-    (StatusCode::CREATED, Json(RegisterToolsResponse { registered: count }))
+    // Batch insert with write lock
+    let mut tools = state.tools.write().await;
+    for (tool, (embeddings, bm25_text)) in body.tools.into_iter().zip(tool_data) {
+        tools.insert(tool.name.clone(), StoredTool { tool, embeddings, bm25_text });
+    }
+
+    Ok((StatusCode::CREATED, Json(RegisterToolsResponse { registered: count })))
 }
 
 async fn list_tools(State(state): State<Arc<AppState>>) -> Json<ListToolsResponse> {
@@ -86,36 +123,26 @@ async fn list_tools(State(state): State<Arc<AppState>>) -> Json<ListToolsRespons
 async fn discover(
     State(state): State<Arc<AppState>>,
     Json(body): Json<DiscoverRequest>,
-) -> Json<DiscoverResponse> {
+) -> Result<Json<DiscoverResponse>, (StatusCode, Json<ErrorResponse>)> {
+    // Compute query embedding before acquiring tools lock
+    let query_embedding = embed_cached(&state, &body.query).await.map_err(embed_err)?;
+
     let tools = state.tools.read().await;
     if tools.is_empty() {
-        return Json(DiscoverResponse { tools: vec![] });
+        return Ok(Json(DiscoverResponse { tools: vec![] }));
     }
 
-    // Compute query embedding (use cache)
-    let mut cache = state.embedding_cache.write().await;
-    let query_embedding = if let Some(cached) = cache.get(&body.query) {
-        cached.clone()
-    } else {
-        let emb = state.embedding.embed(&body.query).await.unwrap_or_default();
-        cache.insert(body.query.clone(), emb.clone());
-        emb
-    };
-    drop(cache);
-
+    let weights = body.embedding_weights.unwrap_or_default();
     let stored: Vec<&StoredTool> = tools.values().collect();
 
-    // Semantic scores
+    // Semantic scores (weighted multi-field)
     let semantic_scores: Vec<f32> = stored
         .iter()
-        .map(|t| cosine_similarity(&query_embedding, &t.embedding))
+        .map(|t| weighted_semantic_score(&query_embedding, &t.embeddings, &weights))
         .collect();
 
     // BM25 scores
-    let documents: Vec<String> = stored
-        .iter()
-        .map(|t| format!("{} {}", t.tool.name, t.tool.description))
-        .collect();
+    let documents: Vec<String> = stored.iter().map(|t| t.bm25_text.clone()).collect();
     let raw_bm25 = bm25_scores(&body.query, &documents);
 
     // Normalize BM25 to [0, 1]
@@ -139,10 +166,26 @@ async fn discover(
 
     ranked.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
 
-    let limit = body.limit.unwrap_or(5);
+    let limit = body.limit.unwrap_or(5).min(100);
     ranked.truncate(limit);
 
-    Json(DiscoverResponse { tools: ranked })
+    Ok(Json(DiscoverResponse { tools: ranked }))
+}
+
+// Helpers
+
+async fn embed_cached(state: &AppState, text: &str) -> anyhow::Result<Vec<f32>> {
+    let cached = { state.embedding_cache.read().await.get(text).cloned() };
+    if let Some(emb) = cached {
+        return Ok(emb);
+    }
+    let emb = state.embedding.embed(text).await?;
+    state.embedding_cache.write().await.insert(text.to_string(), emb.clone());
+    Ok(emb)
+}
+
+fn embed_err(e: anyhow::Error) -> (StatusCode, Json<ErrorResponse>) {
+    (StatusCode::BAD_GATEWAY, Json(ErrorResponse { error: format!("embedding failed: {e}") }))
 }
 
 #[cfg(test)]
@@ -150,7 +193,7 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
-    use embedding::FakeEmbedding;
+    use embedding::{FailingEmbedding, FakeEmbedding};
     use tower::ServiceExt;
 
     fn test_app() -> Router {
@@ -202,7 +245,6 @@ mod tests {
     async fn list_tools_returns_registered_tools() {
         let app = test_app();
 
-        // Register a tool
         let body = serde_json::json!({
             "tools": [{
                 "name": "getAccountInfo",
@@ -223,7 +265,6 @@ mod tests {
             .await
             .unwrap();
 
-        // List tools
         let response = app
             .oneshot(Request::builder().uri("/api/v1/tools").body(Body::empty()).unwrap())
             .await
@@ -254,7 +295,6 @@ mod tests {
 
         let json_str = serde_json::to_string(&body).unwrap();
 
-        // Register same tool twice
         for _ in 0..2 {
             app.clone()
                 .oneshot(
@@ -269,10 +309,10 @@ mod tests {
                 .unwrap();
         }
 
-        // Embedding computed only once (cached on second call)
+        // 2 fields (name + description) embedded once each, cached on second call
         assert_eq!(
             embedding.call_count.load(std::sync::atomic::Ordering::SeqCst),
-            1
+            2
         );
     }
 
@@ -280,7 +320,6 @@ mod tests {
     async fn discover_ranks_matching_tool_first() {
         let app = test_app();
 
-        // Register two tools
         let register = serde_json::json!({
             "tools": [
                 {
@@ -308,7 +347,6 @@ mod tests {
             .await
             .unwrap();
 
-        // Discover with refund query
         let query = serde_json::json!({ "query": "I want a refund", "limit": 5 });
 
         let response = app
@@ -334,5 +372,357 @@ mod tests {
         assert_eq!(tools.len(), 2);
         assert_eq!(tools[0]["name"], "processRefund");
         assert!(tools[0]["score"].as_f64().unwrap() > tools[1]["score"].as_f64().unwrap());
+    }
+
+    #[tokio::test]
+    async fn register_tools_returns_error_on_embedding_failure() {
+        let app = app(Arc::new(FailingEmbedding));
+
+        let body = serde_json::json!({
+            "tools": [{"name": "t", "description": "d", "parameters": {}}]
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/tools")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["error"].as_str().unwrap().contains("embedding"));
+    }
+
+    #[tokio::test]
+    async fn discover_returns_error_on_embedding_failure() {
+        let fake = FakeEmbedding::new();
+        let name_emb = fake.embed("test").await.unwrap();
+        let desc_emb = fake.embed("test desc").await.unwrap();
+
+        let mut tools_map = HashMap::new();
+        tools_map.insert(
+            "test".to_string(),
+            StoredTool {
+                tool: models::Tool {
+                    name: "test".to_string(),
+                    description: "test desc".to_string(),
+                    parameters: serde_json::Value::Null,
+                    metadata: None,
+                    fields: None,
+                },
+                embeddings: FieldEmbeddings {
+                    name: name_emb,
+                    description: desc_emb,
+                    input_schema: None,
+                    output_schema: None,
+                },
+                bm25_text: "test test desc".to_string(),
+            },
+        );
+
+        let state = Arc::new(AppState {
+            tools: RwLock::new(tools_map),
+            embedding_cache: RwLock::new(HashMap::new()),
+            embedding: Arc::new(FailingEmbedding),
+        });
+
+        let app = Router::new()
+            .route("/api/v1/discover", post(discover))
+            .with_state(state);
+
+        let query = serde_json::json!({ "query": "anything" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/discover")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&query).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["error"].as_str().unwrap().contains("embedding"));
+    }
+
+    #[tokio::test]
+    async fn discover_limit_capped() {
+        let app = test_app();
+
+        let reg = serde_json::json!({
+            "tools": [{"name": "t", "description": "d", "parameters": {}}]
+        });
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/tools")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&reg).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let query = serde_json::json!({ "query": "test", "limit": 500 });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/discover")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&query).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["tools"].as_array().unwrap().len() <= 100);
+    }
+
+    #[tokio::test]
+    async fn register_with_multi_field_embeddings() {
+        let app = test_app();
+
+        let body = serde_json::json!({
+            "tools": [{
+                "name": "getAccountInfo",
+                "description": "Get customer account details",
+                "parameters": {},
+                "fields": {
+                    "name": "getAccountInfo",
+                    "description": "Get customer account details including name and email",
+                    "input_schema": "{ accountId: string }",
+                    "output_schema": "{ name: string, email: string }"
+                }
+            }]
+        });
+
+        let response = app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/tools")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        // List and verify tool is stored
+        let response = app
+            .oneshot(Request::builder().uri("/api/v1/tools").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["tools"].as_array().unwrap().len(), 1);
+        assert_eq!(json["tools"][0]["name"], "getAccountInfo");
+        // Verify fields are stored
+        assert!(json["tools"][0]["fields"].is_object());
+        assert_eq!(json["tools"][0]["fields"]["input_schema"], "{ accountId: string }");
+    }
+
+    #[tokio::test]
+    async fn register_backward_compat_no_fields() {
+        let app = test_app();
+
+        // Register without fields — should still work (backward compat)
+        let body = serde_json::json!({
+            "tools": [{
+                "name": "processRefund",
+                "description": "Process a refund",
+                "parameters": {}
+            }]
+        });
+
+        let response = app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/tools")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        // Discover should still work
+        let query = serde_json::json!({ "query": "refund" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/discover")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&query).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["tools"].as_array().unwrap().len(), 1);
+        assert_eq!(json["tools"][0]["name"], "processRefund");
+    }
+
+    #[tokio::test]
+    async fn discover_with_multi_field_weights() {
+        let app = test_app();
+
+        // Register two tools with distinct field content
+        let reg = serde_json::json!({
+            "tools": [
+                {
+                    "name": "processRefund",
+                    "description": "Process a refund for a specific invoice",
+                    "parameters": {},
+                    "fields": {
+                        "name": "processRefund",
+                        "description": "Process a refund for a specific invoice",
+                        "input_schema": "{ invoiceId: string, amount: number }",
+                        "output_schema": "{ success: boolean, refundId: string }"
+                    }
+                },
+                {
+                    "name": "getAccountInfo",
+                    "description": "Get customer account details including name and email",
+                    "parameters": {},
+                    "fields": {
+                        "name": "getAccountInfo",
+                        "description": "Get customer account details including name and email",
+                        "input_schema": "{ accountId: string }",
+                        "output_schema": "{ name: string, email: string, plan: string }"
+                    }
+                }
+            ]
+        });
+
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/tools")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&reg).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Discover with refund query
+        let query = serde_json::json!({ "query": "I need a refund on my invoice", "limit": 5 });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/discover")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&query).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let tools = json["tools"].as_array().unwrap();
+        assert_eq!(tools[0]["name"], "processRefund");
+    }
+
+    #[tokio::test]
+    async fn discover_with_custom_weights() {
+        let app = test_app();
+
+        let reg = serde_json::json!({
+            "tools": [
+                {
+                    "name": "processRefund",
+                    "description": "Process a refund for a specific invoice",
+                    "parameters": {},
+                    "fields": {
+                        "name": "processRefund",
+                        "description": "Process a refund for a specific invoice"
+                    }
+                },
+                {
+                    "name": "getAccountInfo",
+                    "description": "Get customer account details",
+                    "parameters": {},
+                    "fields": {
+                        "name": "getAccountInfo",
+                        "description": "Get customer account details"
+                    }
+                }
+            ]
+        });
+
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/tools")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&reg).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Discover with custom weights (high name weight)
+        let query = serde_json::json!({
+            "query": "refund",
+            "limit": 5,
+            "embedding_weights": {
+                "name": 0.8,
+                "description": 0.2,
+                "input_schema": 0.0,
+                "output_schema": 0.0
+            }
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/discover")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&query).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let tools = json["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 2);
+        // processRefund name matches "refund" better
+        assert_eq!(tools[0]["name"], "processRefund");
     }
 }

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -1,5 +1,55 @@
 use serde::{Deserialize, Serialize};
 
+// Tool fields for multi-field embeddings
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolFields {
+    pub name: String,
+    pub description: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_schema: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FieldEmbeddings {
+    pub name: Vec<f32>,
+    pub description: Vec<f32>,
+    pub input_schema: Option<Vec<f32>>,
+    pub output_schema: Option<Vec<f32>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct EmbeddingFieldWeights {
+    #[serde(default = "default_name_weight")]
+    pub name: f32,
+    #[serde(default = "default_description_weight")]
+    pub description: f32,
+    #[serde(default = "default_input_schema_weight")]
+    pub input_schema: f32,
+    #[serde(default = "default_output_schema_weight")]
+    pub output_schema: f32,
+}
+
+fn default_name_weight() -> f32 { 0.1 }
+fn default_description_weight() -> f32 { 0.5 }
+fn default_input_schema_weight() -> f32 { 0.3 }
+fn default_output_schema_weight() -> f32 { 0.1 }
+
+impl Default for EmbeddingFieldWeights {
+    fn default() -> Self {
+        Self {
+            name: 0.1,
+            description: 0.5,
+            input_schema: 0.3,
+            output_schema: 0.1,
+        }
+    }
+}
+
+// API types
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Tool {
     pub name: String,
@@ -8,12 +58,15 @@ pub struct Tool {
     pub parameters: serde_json::Value,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fields: Option<ToolFields>,
 }
 
 #[derive(Debug, Clone)]
 pub struct StoredTool {
     pub tool: Tool,
-    pub embedding: Vec<f32>,
+    pub embeddings: FieldEmbeddings,
+    pub bm25_text: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -37,7 +90,7 @@ pub struct DiscoverRequest {
     #[serde(default)]
     pub limit: Option<usize>,
     #[serde(default)]
-    pub history: Option<Vec<String>>,
+    pub embedding_weights: Option<EmbeddingFieldWeights>,
 }
 
 #[derive(Debug, Serialize)]
@@ -50,4 +103,9 @@ pub struct RankedTool {
     #[serde(flatten)]
     pub tool: Tool,
     pub score: f32,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ErrorResponse {
+    pub error: String,
 }

--- a/core/src/ranking.rs
+++ b/core/src/ranking.rs
@@ -1,6 +1,38 @@
 use std::collections::HashMap;
 
+use crate::models::{EmbeddingFieldWeights, FieldEmbeddings};
+
+pub fn weighted_semantic_score(
+    query_emb: &[f32],
+    field_embs: &FieldEmbeddings,
+    weights: &EmbeddingFieldWeights,
+) -> f32 {
+    let mut total_score = 0.0;
+    let mut total_weight = 0.0;
+
+    // Name field (always present)
+    total_score += weights.name * cosine_similarity(query_emb, &field_embs.name);
+    total_weight += weights.name;
+
+    // Description field (always present)
+    total_score += weights.description * cosine_similarity(query_emb, &field_embs.description);
+    total_weight += weights.description;
+
+    // Optional fields
+    if let Some(ref emb) = field_embs.input_schema {
+        total_score += weights.input_schema * cosine_similarity(query_emb, emb);
+        total_weight += weights.input_schema;
+    }
+    if let Some(ref emb) = field_embs.output_schema {
+        total_score += weights.output_schema * cosine_similarity(query_emb, emb);
+        total_weight += weights.output_schema;
+    }
+
+    if total_weight > 0.0 { total_score / total_weight } else { 0.0 }
+}
+
 pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    debug_assert_eq!(a.len(), b.len(), "cosine_similarity: vector length mismatch");
     let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
     let norm_a = a.iter().map(|x| x * x).sum::<f32>().sqrt();
     let norm_b = b.iter().map(|x| x * x).sum::<f32>().sqrt();
@@ -23,7 +55,6 @@ pub fn bm25_scores(query: &str, documents: &[String]) -> Vec<f32> {
     let doc_terms: Vec<Vec<String>> = documents.iter().map(|d| tokenize(d)).collect();
     let avg_dl = doc_terms.iter().map(|d| d.len()).sum::<usize>() as f32 / n as f32;
 
-    // Document frequency: how many docs contain each term
     let mut df: HashMap<String, usize> = HashMap::new();
     for terms in &doc_terms {
         let unique: std::collections::HashSet<&str> = terms.iter().map(|s| s.as_str()).collect();
@@ -37,7 +68,6 @@ pub fn bm25_scores(query: &str, documents: &[String]) -> Vec<f32> {
         .map(|terms| {
             let dl = terms.len() as f32;
 
-            // Term frequencies in this doc
             let mut tf: HashMap<&str, f32> = HashMap::new();
             for t in terms {
                 *tf.entry(t.as_str()).or_default() += 1.0;
@@ -104,5 +134,62 @@ mod tests {
         let docs = vec!["get customer account details".to_string()];
         let scores = bm25_scores("refund", &docs);
         assert!((scores[0]).abs() < 1e-6, "no match should score ~0: {:?}", scores);
+    }
+
+    #[test]
+    fn weighted_semantic_score_uses_field_weights() {
+        // Query vector aligned with name_emb
+        let query = vec![1.0, 0.0, 0.0];
+        let name_emb = vec![1.0, 0.0, 0.0]; // cosine = 1.0
+        let desc_emb = vec![0.0, 1.0, 0.0]; // cosine = 0.0
+
+        let field_embs = FieldEmbeddings {
+            name: name_emb,
+            description: desc_emb,
+            input_schema: None,
+            output_schema: None,
+        };
+
+        // Heavy name weight
+        let weights = EmbeddingFieldWeights {
+            name: 0.9,
+            description: 0.1,
+            input_schema: 0.0,
+            output_schema: 0.0,
+        };
+
+        let score = weighted_semantic_score(&query, &field_embs, &weights);
+        // Expected: (0.9 * 1.0 + 0.1 * 0.0) / (0.9 + 0.1) = 0.9
+        assert!((score - 0.9).abs() < 1e-6, "expected ~0.9, got {score}");
+
+        // Heavy description weight
+        let weights2 = EmbeddingFieldWeights {
+            name: 0.1,
+            description: 0.9,
+            input_schema: 0.0,
+            output_schema: 0.0,
+        };
+        let score2 = weighted_semantic_score(&query, &field_embs, &weights2);
+        // Expected: (0.1 * 1.0 + 0.9 * 0.0) / (0.1 + 0.9) = 0.1
+        assert!((score2 - 0.1).abs() < 1e-6, "expected ~0.1, got {score2}");
+    }
+
+    #[test]
+    fn weighted_semantic_score_handles_missing_fields() {
+        let query = vec![1.0, 0.0, 0.0];
+        let field_embs = FieldEmbeddings {
+            name: vec![1.0, 0.0, 0.0],
+            description: vec![0.5, 0.5, 0.0],
+            input_schema: None,
+            output_schema: None,
+        };
+
+        let weights = EmbeddingFieldWeights::default();
+        let score = weighted_semantic_score(&query, &field_embs, &weights);
+
+        // Only name (0.1) + description (0.5) active, total weight = 0.6
+        let desc_cos = cosine_similarity(&query, &field_embs.description);
+        let expected = (0.1 * 1.0 + 0.5 * desc_cos) / 0.6;
+        assert!((score - expected).abs() < 1e-6, "expected {expected}, got {score}");
     }
 }

--- a/scripts/test-server.sh
+++ b/scripts/test-server.sh
@@ -59,44 +59,92 @@ HEALTH=$(curl -sf "$BASE_URL/health" 2>&1) || { fail "Health check — server no
 assert_contains "$HEALTH" '"status":"ok"' "Health endpoint returns ok"
 
 # -------------------------------------------------------------------
-# 2. Register sample tools
+# 2. Register sample tools (with multi-field embeddings)
 # -------------------------------------------------------------------
-log "Registering tools..."
+log "Registering tools with fields..."
 REG_RESPONSE=$(curl -sf -X POST "$BASE_URL/api/v1/tools" \
   -H "Content-Type: application/json" \
   -d '{
     "tools": [
       {
         "name": "getAccountInfo",
-        "description": "Get customer account details including name, email, and plan"
+        "description": "Get customer account details including name, email, and plan",
+        "fields": {
+          "name": "getAccountInfo",
+          "description": "Get customer account details including name, email, and plan",
+          "input_schema": "{ accountId: string }",
+          "output_schema": "{ name: string, email: string, plan: string }"
+        }
       },
       {
         "name": "processRefund",
-        "description": "Process a refund for a specific invoice or purchase"
+        "description": "Process a refund for a specific invoice or purchase",
+        "fields": {
+          "name": "processRefund",
+          "description": "Process a refund for a specific invoice or purchase",
+          "input_schema": "{ invoiceId: string, amount: number, reason: string }",
+          "output_schema": "{ success: boolean, refundId: string }"
+        }
       },
       {
         "name": "getInvoices",
-        "description": "List invoices and billing history for a customer account"
+        "description": "List invoices and billing history for a customer account",
+        "fields": {
+          "name": "getInvoices",
+          "description": "List invoices and billing history for a customer account",
+          "input_schema": "{ accountId: string, limit?: number }",
+          "output_schema": "{ invoices: Array<{ id: string, amount: number, date: string }> }"
+        }
       },
       {
         "name": "resetPassword",
-        "description": "Reset user password and send a recovery email"
+        "description": "Reset user password and send a recovery email",
+        "fields": {
+          "name": "resetPassword",
+          "description": "Reset user password and send a recovery email",
+          "input_schema": "{ email: string }",
+          "output_schema": "{ success: boolean, message: string }"
+        }
       },
       {
         "name": "runDiagnostics",
-        "description": "Run diagnostics on a service, check for errors and outages"
+        "description": "Run diagnostics on a service, check for errors and outages",
+        "fields": {
+          "name": "runDiagnostics",
+          "description": "Run diagnostics on a service, check for errors and outages",
+          "input_schema": "{ serviceId: string }",
+          "output_schema": "{ status: string, errors: string[], uptime: number }"
+        }
       },
       {
         "name": "checkServiceStatus",
-        "description": "Check the current status of API services and uptime"
+        "description": "Check the current status of API services and uptime",
+        "fields": {
+          "name": "checkServiceStatus",
+          "description": "Check the current status of API services and uptime",
+          "input_schema": "{ serviceId?: string }",
+          "output_schema": "{ services: Array<{ name: string, status: string, uptime: number }> }"
+        }
       },
       {
         "name": "updateBillingInfo",
-        "description": "Update payment method or billing address for an account"
+        "description": "Update payment method or billing address for an account",
+        "fields": {
+          "name": "updateBillingInfo",
+          "description": "Update payment method or billing address for an account",
+          "input_schema": "{ accountId: string, paymentMethod?: object, address?: object }",
+          "output_schema": "{ success: boolean }"
+        }
       },
       {
         "name": "sendNotification",
-        "description": "Send a push notification or email to a user"
+        "description": "Send a push notification or email to a user",
+        "fields": {
+          "name": "sendNotification",
+          "description": "Send a push notification or email to a user",
+          "input_schema": "{ userId: string, type: \"push\" | \"email\", message: string }",
+          "output_schema": "{ sent: boolean, messageId: string }"
+        }
       }
     ]
   }')
@@ -114,13 +162,27 @@ else
   fail "GET /api/v1/tools — expected 8 tools, got $TOOL_COUNT"
 fi
 
+# Verify fields are present in response
+HAS_FIELDS=$(echo "$LIST_RESPONSE" | jq '[.tools[].fields] | map(select(. != null)) | length')
+if [ "$HAS_FIELDS" -eq 8 ]; then
+  pass "All tools have fields in response"
+else
+  fail "Expected 8 tools with fields, got $HAS_FIELDS"
+fi
+
 # -------------------------------------------------------------------
-# 4. Discover — test scenarios from PRD
+# 4. Discover — test scenarios
 # -------------------------------------------------------------------
 discover() {
   curl -sf -X POST "$BASE_URL/api/v1/discover" \
     -H "Content-Type: application/json" \
     -d "{\"query\": \"$1\", \"limit\": $2}"
+}
+
+discover_with_weights() {
+  curl -sf -X POST "$BASE_URL/api/v1/discover" \
+    -H "Content-Type: application/json" \
+    -d "{\"query\": \"$1\", \"limit\": $2, \"embedding_weights\": $3}"
 }
 
 log "Testing discover: 'I want a refund'"
@@ -150,6 +212,10 @@ if [ "$RETURNED" -le 2 ]; then
 else
   fail "Limit=2 returned $RETURNED tools"
 fi
+
+log "Testing discover: custom weights"
+R6=$(discover_with_weights "refund" 5 '{"name": 0.9, "description": 0.1, "input_schema": 0.0, "output_schema": 0.0}')
+assert_top_tool "$R6" "processRefund" "Custom weights (high name) → processRefund top"
 
 # -------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
- FakeEmbedding: hash-based distinct deterministic vectors
- FailingEmbedding test double
- OpenAI client 10s timeout
- error propagation: handlers return 502 + ErrorResponse
- discover limit capped at 100
- locks restructured outside I/O
- ToolFields, FieldEmbeddings, EmbeddingFieldWeights types
- weighted_semantic_score for per-field scoring
- register embeds each field separately w/ caching
- discover uses weighted multi-field + BM25 hybrid
- test-server.sh updated w/ fields payloads