### PR TITLE
docs: reflect deferred tool loading default and BM25-default ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,9 @@ ctx = await session.context.messages(strategy="recent").assemble()
 | Problem | Without Agentified | With Agentified |
 |---------|-------------------|-----------------|
 | **Context assembly** | Hand-wire tools + messages per turn | `session.context.assemble()` — one call |
-| **Tool selection** | Dump all tools in prompt | Hybrid-ranked selection based on intent |
+| **Tool selection** | Dump all tools in prompt | Deferred by default — ranked (BM25 / semantic / hybrid) on demand; `alwaysInclude` exempts critical tools |
 | **Token costs** | Pay for irrelevant tools | Only load what's needed |
+| **Cross-turn tool state** | Re-discover every turn | Discovered tools persist within and across turns of the session |
 | **Multi-turn context** | No memory across turns | Session continuity via turn tracking |
 | **Framework switching** | Rebuild context layer | Plug and play |
 | **Context debugging** | Black box | Inspector with full visibility |
@@ -146,9 +147,11 @@ ctx = await session.context.messages(strategy="recent").assemble()
 
 **[Context Assembly](./docs/)** — `session.context.tools(...).messages(...).recall(...).limitTokens(n).assemble()` — one fluent call assembles the right tools, messages, and memory for each agent turn. Supports `recent`, `full`, `summary`, and `recent+summary` strategies. Tool recall auto-discovers relevant tools based on the last user message. Returns an `AssembledContext` you pass straight to your framework.
 
-**[Hybrid Ranking](./docs/server/ranking.md)** — Semantic similarity (70%) + BM25 keyword matching (30%) across tool name, description, and schemas.
+**[Ranking](./docs/server/ranking.md)** — Three strategies: `bm25` (default — field-aware keyword matching, no embedding call per query), `semantic` (OpenAI embeddings across 4 weighted fields), and `hybrid` (`0.7 × semantic + 0.3 × BM25`). Pick per request via the `strategy` field.
 
-**[Session Continuity](./docs/server/session-continuity.md)** — Capture turns to track tool usage. Previously-used tools are prioritized automatically.
+**Deferred Tool Loading** — Registered tools cost zero tokens until discovered. Mark critical tools with `alwaysInclude` to keep them unconditionally available; everything else is surfaced on demand via ranking or `agentified_discover`. Discovered tools persist within and across turns.
+
+**[Session Continuity](./docs/server/session-continuity.md)** — Tools discovered mid-turn stay available for the rest of the turn, and previously-used tools carry into subsequent turns. No context amnesia, no re-discovery cost.
 
 **[Graph Expansion](./docs/server/graph-expansion.md)** — Tools declare `requires`/`provides` metadata. Dependencies are auto-injected.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -10,14 +10,15 @@ Most teams solve this by manually curating tool subsets and stitching context to
 
 ## Agentified's solution
 
-1. You **register all your tools once** inside Agentified
+1. You **register all your tools once** inside Agentified — they're indexed but cost zero tokens until needed
 2. On every turn, the agent calls `session.context.assemble()`
-3. Agentified **returns exactly what your agent needs**: a ranked set of relevant tools, conversation history, and recalled context, **in a single call**
+3. Agentified **returns exactly what your agent needs**: the tools marked `alwaysInclude`, the tools accumulated this session, any tools discovered for the current intent, plus conversation history and recalled context — **in a single call**
 
 Every primitive Agentified stores exists because **it makes the next `assemble()` call smarter**:
  - Memories inform which tools surface
  - Tool usage creates memories
- - Session history shapes ranking 
+ - Session history shapes ranking
+ - Tools discovered mid-turn persist into subsequent turns
 
 As the system grows, entity relationships and knowledge graphs feed back into assembly too. Ultimately, **one call gets progressively more intelligent**.
 
@@ -43,20 +44,23 @@ Your Agent (any framework, any language)
 
 Three steps:
 
-1. **Register** (*once*): You give Agentified your full tool catalog. The server computes embeddings for each tool's name, description, and schemas, then indexes them for fast retrieval.
-2. **Assemble**: Agentified takes the conversation context and runs a **hybrid ranking algorithm** to score every tool against the current intent while **cross-referencing memories and session history** to refine results. With **tool recall**, the system auto-discovers relevant tools based on the last user message. **Message strategies** (`recent`, `full`, `compacted`) control how conversation history is assembled — the `compacted` strategy uses LLM summarization for older messages, with long tool results pruned before summarization. **Token budgets** via `.limitTokens()` cap total assembly output.
-3. **Execute**: Agentified passes the assembled context (tools + messages) to your agent framework. Your framework calls the tools as usual. Agentified **tracks which tools were used so it can prioritize them in subsequent turns**.
+1. **Register** (*once*): You give Agentified your full tool catalog. The server indexes each tool for BM25 retrieval and computes embeddings for semantic retrieval. By default, **every registered tool is deferred** — it costs zero tokens until discovered. Mark critical tools with `alwaysInclude: true` to keep them unconditionally present in every turn.
+2. **Assemble**: Agentified takes the conversation context and ranks the deferred tools against the current intent, while **cross-referencing memories and session history** to refine results. With **tool recall**, the system auto-discovers relevant tools from the last user message. Discovered tools **persist within the turn and across subsequent turns** of the same session. **Message strategies** (`recent`, `full`, `summary`, `recent+summary`) control how conversation history is assembled — the summary strategies use LLM summarization for older messages, with long tool results pruned first. **Token budgets** via `.limitTokens()` cap total assembly output.
+3. **Execute**: Agentified passes the assembled context (tools + messages) to your agent framework. Your framework calls the tools as usual. Agentified **tracks which tools were used so they stay available in subsequent turns**.
 
 ## What Makes the Ranking Smart
 
-**Hybrid ranking algorithm**:
+**Three ranking strategies, BM25 by default:**
 
-- **Semantic similarity (70%)**: Understands intent. "Cancel my subscription" finds `process_refund` even though the words don't overlap. Powered by OpenAI embeddings across four tool fields (description, input schema, name, output schema), each weighted by importance
-- **Keyword matching (30%)**: Catches exact terms the embedding model might underweight. "PTO" matches `get_pto_balance` directly
+- **BM25** *(default)* — pure keyword matching with field-aware extraction from JSON Schema `properties`. No embedding call per query, so it's fast and cheap. Works well when tool names, descriptions, and parameter keys share vocabulary with the query (e.g. "PTO" → `get_pto_balance`).
+- **Semantic** — OpenAI embeddings across four tool fields (description, input schema, name, output schema), each weighted by importance. Catches intent even when words don't overlap ("cancel my subscription" → `process_refund`).
+- **Hybrid** — `0.7 × semantic + 0.3 × BM25`. Best of both when exact-match recall and intent-matching both matter.
+
+Pick per use case via the `strategy` field on `discover`. See [Ranking](./server/ranking.md) for the full breakdown.
 
 **Two more mechanisms make your agent smarter**:
 
-- **Session continuity**: If the agent used `get_employee_details` in turn 1, it stays available in turn 2. No context amnesia mid-conversation.
+- **Session continuity**: Tools discovered mid-turn stay available for the rest of the turn, and previously-used tools carry into the next turn. No context amnesia mid-conversation, and no re-discovery cost.
 - **Graph expansion**: If a selected tool declares it *requires* another tool's output, that dependency gets auto-injected. You define the relationships once; Agentified handles the wiring.
 
 ## A real example
@@ -91,7 +95,7 @@ Same accuracy — and massively fewer resources:
 
 - *Runtime tool discovery*: An agent-callable tool that lets the LLM itself search for additional tools mid-conversation. Useful for open-ended workflows where the needed tools aren't predictable upfront.
 
-- *Deferred tool loading*: Register hundreds of tools but only surface them when needed. Mark critical tools with `alwaysInclude` to keep them always available; all other tools are discovered on demand via ranking or agent-initiated search. Discovered tools persist within the session for cross-turn continuity.
+- *Deferred tool loading*: The default. Registered tools cost zero tokens until discovered via ranking or `agentified_discover`. Use `alwaysInclude` to pin critical tools. Discovered tools accumulate within and across turns of the session.
 
 - *A fast Rust core*: The server is built with Axum, uses read-write locks for concurrent access, caches embeddings by content hash, and runs ranking in sub-milliseconds for hundreds of tools. Storage is in-memory by default, with optional SQLite persistence and more storage backends coming soon.
 

--- a/docs/server/ranking.md
+++ b/docs/server/ranking.md
@@ -1,27 +1,37 @@
-# Hybrid Ranking
+# Ranking
 
-Agentified uses a hybrid ranking algorithm that combines semantic similarity with BM25 keyword matching to select the most relevant tools for a query.
+Agentified offers three ranking strategies for tool discovery. **BM25 is the default** — it requires no embedding call per query, runs in sub-milliseconds, and works well whenever tool metadata shares vocabulary with the query. `semantic` and `hybrid` are opt-in via the `strategy` field on `discover`.
 
-## How It Works
+## Strategies
 
-```
-final_score = 0.7 × semantic_score + 0.3 × normalized_bm25
-```
+| Strategy | How it scores | When to use |
+|----------|---------------|-------------|
+| `bm25` *(default)* | Keyword matching with field-aware extraction from JSON Schema | Fast, cheap; works when the query shares terms with tool metadata |
+| `semantic` | Weighted cosine similarity across 4 embedded fields | Intent-heavy queries where wording diverges from tool metadata |
+| `hybrid` | `0.7 × semantic + 0.3 × normalized_bm25` | Both exact-match and intent-matching matter; worth the embedding cost |
 
-Two signals, complementary strengths:
+If `semantic` or `hybrid` is requested and a tool has no embeddings available, the request falls back to `bm25` automatically.
 
-- **Semantic** (70%) — catches intent even with different wording ("cancel my subscription" → `process_refund`)
-- **BM25** (30%) — catches exact keyword matches the embedding model might under-weight ("PTO" → `get_pto_balance`)
+## BM25
 
-## Semantic Scoring
+Standard [BM25](https://en.wikipedia.org/wiki/Okapi_BM25) with tuned parameters:
+
+- `k1 = 0.9` — term frequency saturation
+- `b = 0.4` — document length normalization
+
+Each tool's BM25 document is built by concatenating its name, description, input-schema field names, and output-schema field names. Field names are extracted from JSON Schema `properties` so parameter keys contribute as first-class terms (e.g. `city`, `employee_id`) rather than getting lost inside raw JSON.
+
+Raw BM25 scores are min-max normalized to `[0, 1]` across the tools in the dataset.
+
+## Semantic
 
 Each tool is embedded across 4 fields using OpenAI `text-embedding-3-small` (1536 dimensions). The query is embedded the same way, then cosine similarity is computed per field:
 
 | Field | Default Weight | Why |
 |-------|---------------|-----|
 | `description` | 0.5 | Primary signal — describes what the tool does |
-| `input_schema` | 0.3 | Matches parameter structure (e.g., "city" aligns with weather tools) |
-| `name` | 0.1 | Tool name — short, often abbreviated |
+| `input_schema` | 0.3 | Matches parameter structure |
+| `name` | 0.1 | Short, often abbreviated |
 | `output_schema` | 0.1 | Return type — useful for chaining |
 
 ```
@@ -37,6 +47,7 @@ Pass `embedding_weights` on any discover request:
 ```json
 {
   "query": "get employee salary details",
+  "strategy": "semantic",
   "embedding_weights": {
     "name": 0.05,
     "description": 0.4,
@@ -48,28 +59,20 @@ Pass `embedding_weights` on any discover request:
 
 Use case: bump `input_schema` weight when the query describes parameters rather than intent.
 
-## BM25 Scoring
-
-Standard [BM25](https://en.wikipedia.org/wiki/Okapi_BM25) with parameters:
-
-- `k1 = 1.2` — term frequency saturation
-- `b = 0.75` — document length normalization
-
-Each tool's BM25 document is the concatenation of all its field texts (name + description + input_schema + output_schema). The query is tokenized by splitting on non-alphanumeric characters and lowercasing.
-
-### Normalization
-
-Raw BM25 scores are min-max normalized to [0, 1] across all tools in the dataset:
+## Hybrid
 
 ```
-normalized = (raw - min) / (max - min)
+final_score = 0.7 × semantic_score + 0.3 × normalized_bm25
 ```
 
-If all scores are equal (range = 0), all normalized scores are 0.
+BM25 acts as a tiebreaker and safety net:
+
+- Two tools with similar embeddings → BM25 picks the one with exact keyword matches
+- A tool with a generic description but exact parameter names → BM25 boosts it
 
 ## Worked Example
 
-Given 3 tools and the query `"process a refund"`:
+Given 3 tools and the query `"process a refund"` with `strategy: "hybrid"`:
 
 | Tool | Semantic | BM25 (normalized) | Final |
 |------|----------|-------------------|-------|
@@ -77,14 +80,7 @@ Given 3 tools and the query `"process a refund"`:
 | `get_order_details` | 0.72 | 0.30 | 0.7 × 0.72 + 0.3 × 0.30 = **0.594** |
 | `send_email` | 0.35 | 0.00 | 0.7 × 0.35 + 0.3 × 0.00 = **0.245** |
 
-`process_refund` ranks first — both signals agree. `get_order_details` ranks second — semantically related (orders context) with some keyword overlap.
-
-## When Semantic and BM25 Disagree
-
-The 70/30 split means semantic usually dominates. BM25 acts as a tiebreaker and safety net:
-
-- Two tools with similar embeddings → BM25 picks the one with exact keyword matches
-- A tool with a generic description but exact parameter names → BM25 boosts it
+`process_refund` ranks first — both signals agree. `get_order_details` ranks second — semantically related with some keyword overlap.
 
 ## See Also
 

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,6 +1,6 @@
 # agentified-core
 
-Rust server. Hybrid ranking. Sub-millisecond discovery.
+Rust server. BM25 / semantic / hybrid ranking. Sub-millisecond discovery.
 
 Registers tools, computes embeddings, and serves the most relevant subset for any query via a REST API. See [Architecture](../../docs/server/architecture.md) for the full system design.
 
@@ -86,13 +86,14 @@ List all registered tools in a dataset.
 
 ### `POST /api/v1/datasets/{id}/discover`
 
-Discover the most relevant tools for a query using hybrid ranking. See [Ranking docs](../../docs/server/ranking.md).
+Discover the most relevant tools for a query. The `strategy` field selects the ranker — **BM25 is the default**. See [Ranking docs](../../docs/server/ranking.md).
 
 **Request:**
 
 ```json
 {
   "query": "What's the weather in Rome?",
+  "strategy": "bm25",
   "limit": 5,
   "exclude": ["irrelevant_tool"],
   "turn_id": "prev-turn-uuid",
@@ -108,21 +109,25 @@ Discover the most relevant tools for a query using hybrid ranking. See [Ranking 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `query` | string | required | Natural language query |
+| `strategy` | string | `"bm25"` | Ranker to use: `"bm25"`, `"semantic"`, or `"hybrid"` |
 | `limit` | number | 5 | Max tools to return (max 100) |
 | `exclude` | string[] | [] | Tool names to exclude |
 | `turn_id` | string | — | Previous turn ID for [session continuity](../../docs/server/session-continuity.md) |
-| `embedding_weights` | object | see below | Field weights for semantic scoring |
+| `embedding_weights` | object | see below | Field weights for `semantic` / `hybrid` scoring |
 
 **Default embedding weights:** name=0.1, description=0.5, input_schema=0.3, output_schema=0.1
 
 **Ranking algorithm:**
-1. Embed query using `text-embedding-3-small`
-2. Compute weighted cosine similarity across tool fields (name, description, input_schema, output_schema)
-3. Compute BM25 scores over concatenated tool text
-4. Normalize BM25 to [0, 1]
-5. Final score = `0.7 × semantic + 0.3 × BM25`
-6. If `turn_id` provided, tools from that turn are prepended with score=1.0
-7. [Graph expansion](../../docs/server/graph-expansion.md) injects dependency tools
+
+The `strategy` field selects the ranker (default `bm25`). See [Ranking docs](../../docs/server/ranking.md) for the full comparison.
+
+1. If `strategy = "bm25"`: tokenize the query, compute BM25 (`k1=0.9`, `b=0.4`) over per-tool documents (name + description + JSON Schema field names), min-max normalize to `[0, 1]`.
+2. If `strategy = "semantic"`: embed the query via `text-embedding-3-small`, compute weighted cosine similarity across tool fields (name, description, input_schema, output_schema).
+3. If `strategy = "hybrid"`: compute both of the above; `final_score = 0.7 × semantic + 0.3 × normalized_bm25`.
+4. `always_include` tools are excluded from ranked results — they are injected unconditionally by the SDK.
+5. If `turn_id` is provided, tools from that turn are prepended with `score = 1.0`.
+6. [Graph expansion](../../docs/server/graph-expansion.md) injects dependency tools.
+7. `semantic` / `hybrid` fall back to `bm25` if embeddings are unavailable.
 
 **Response:**
 


### PR DESCRIPTION
## Summary

PR #39 (AGE-116, model-agnostic deferred tool loading) shipped two behavioural changes that weren't reflected in the documentation. This PR closes that gap.

**What changed in behaviour (from #39):**
- All registered tools are **deferred by default** — zero tokens until discovered via ranking or \`agentified_discover\`. Critical tools opt in with \`alwaysInclude\`.
- Discovered tools now **persist within and across turns** of the same session.
- **BM25 is the default ranker**, with field-aware extraction from JSON Schema and tuned \`k1=0.9\`, \`b=0.4\`. \`semantic\` and \`hybrid\` (\`0.7 × semantic + 0.3 × BM25\`) are opt-in via the \`strategy\` field on \`discover\`.

**Doc updates:**
- \`README.md\` — new Deferred Tool Loading feature bullet; Ranking bullet rewritten for the three strategies; Session Continuity bullet expanded to within-turn; Why-table row updated + new cross-turn row.
- \`docs/overview.md\` — promotes deferral into "Solution" and "How It Works"; ranking section rewritten as three-strategy BM25-default; message-strategy list corrected to \`recent/full/summary/recent+summary\`.
- \`docs/server/ranking.md\` — full rewrite. Three strategies documented, correct \`k1=0.9 / b=0.4\`, JSON-Schema field extraction documented.
- \`src/core/README.md\` — \`strategy\` field added to discover request table; algorithm section rewritten to cover all three strategies.

Benchmark numbers intentionally left untouched in this PR — separate pass.

## Test plan

- [ ] Sanity-check that the \`strategy\` / default-BM25 wording matches behaviour in \`src/core/agentified-lib/src/ranking.rs\` and \`lib.rs\`
- [ ] Confirm message-strategy list (\`recent/full/summary/recent+summary\`) matches what the SDK actually accepts
- [ ] Confirm within-turn + cross-turn tool accumulation wording is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)