### PR TITLE
feat(sdk): observer hooks for context assembly + agent steps

### DIFF
--- a/src/py-packages/langchain/README.md
+++ b/src/py-packages/langchain/README.md
@@ -128,6 +128,31 @@ tool = session.get_messages_tool
 # StructuredTool wrapping agentified_get_messages
 ```
 
+## Observability
+
+`LangchainAgentified` forwards `context_assembled` / `recall` events from the underlying SDK. `LangchainInstance` exposes a `step` event that fires once per agent step. Wire it from your LangGraph node post-hook (or any per-step callback).
+
+```python
+lc = LangchainAgentified()
+await lc.connect("http://localhost:9119")
+instance = await lc.register(RegisterInput(tools=[...]))
+
+unsub = lc.on("context_assembled", lambda evt: metrics.emit("ctx", evt))
+instance.on("step", lambda evt: metrics.emit("step", evt))
+
+# Inside your LangGraph post-hook:
+def post_hook(state, node_name):
+    instance.on_step_finish({
+        "step_index": state["step_index"],
+        "tool_calls": state.get("tool_calls", []),
+        "tool_results": state.get("tool_results", []),
+        "usage": state.get("usage"),
+        "finish_reason": state.get("finish_reason"),
+    })
+```
+
+Supported events: `context_assembled`, `recall`, `step`. See the [Python SDK README](../sdk/README.md#observability) for payload details.
+
 ## Links
 
 - [Root README](../../../README.md)

--- a/src/py-packages/langchain/src/agentified_langchain/agentified.py
+++ b/src/py-packages/langchain/src/agentified_langchain/agentified.py
@@ -15,6 +15,11 @@ from agentified import (
     RegisterInput,
     Session,
 )
+from agentified.events import (
+    Listener,
+    ObserverEventName,
+    Unsubscribe,
+)
 from agentified.models import (
     AgentifiedTool,
     BackendTool,
@@ -263,6 +268,12 @@ class LangchainInstance:
     def dataset_id(self) -> str:
         return self._inst.dataset_id
 
+    def on(self, name: ObserverEventName, cb: Listener) -> Unsubscribe:
+        return self._inst.on(name, cb)
+
+    def on_step_finish(self, data: dict) -> None:
+        self._inst.on_step_finish(data)
+
     def get_tools(self) -> list[StructuredTool]:
         tools: list[StructuredTool] = [self.discover_tool]
         for name in self._inst.discover_tool.discovered_names:
@@ -301,6 +312,9 @@ class LangchainAgentified:
 
     async def disconnect(self) -> None:
         await self._ag.disconnect()
+
+    def on(self, name: ObserverEventName, cb: Listener) -> Unsubscribe:
+        return self._ag.on(name, cb)
 
     def dataset(self, name: str) -> LangchainDatasetRef:
         return LangchainDatasetRef(self._ag.dataset(name))

--- a/src/py-packages/langchain/tests/test_events.py
+++ b/src/py-packages/langchain/tests/test_events.py
@@ -1,0 +1,57 @@
+"""Observer-hook tests on the LangChain adapter pass-through."""
+from unittest.mock import AsyncMock, MagicMock
+
+from agentified.events import ObserverEmitter, StepEvent
+from agentified_langchain.agentified import LangchainAgentified, LangchainInstance
+
+
+class TestLangchainAgentifiedOn:
+    def test_on_delegates_to_underlying_agentified(self):
+        fake_ag = MagicMock()
+        fake_ag.on.return_value = lambda: None
+        lc = LangchainAgentified(fake_ag)
+
+        cb = lambda e: None
+        lc.on("context_assembled", cb)
+        fake_ag.on.assert_called_once_with("context_assembled", cb)
+
+
+class TestLangchainInstanceSteps:
+    def test_on_step_finish_forwards_event(self):
+        emitter = ObserverEmitter()
+        events: list[StepEvent] = []
+        emitter.on("step", lambda e: events.append(e))
+
+        # Fake underlying Instance so we don't need a real ApiClient
+        fake_inst = MagicMock()
+        fake_inst.discover_tool.definition.name = "agentified_discover"
+        fake_inst.discover_tool.definition.description = ""
+        fake_inst.discover_tool.definition.parameters = {}
+
+        def on_wrapper(name, cb):
+            return emitter.on(name, cb)
+
+        fake_inst.on = on_wrapper
+
+        def on_step_wrapper(data):
+            emitter.emit("step", StepEvent(
+                step_index=0,
+                tool_calls=data.get("tool_calls", []),
+                tool_results=data.get("tool_results", []),
+                usage=data.get("usage"),
+                finish_reason=data.get("finish_reason"),
+            ))
+
+        fake_inst.on_step_finish = on_step_wrapper
+
+        lc_inst = LangchainInstance(fake_inst, [])
+        lc_inst.on("step", lambda e: None)  # smoke: disposer type
+        lc_inst.on_step_finish({
+            "tool_calls": [{"name": "x"}],
+            "tool_results": [{"result": 1}],
+            "finish_reason": "stop",
+        })
+
+        assert len(events) == 1
+        assert events[0].tool_calls == [{"name": "x"}]
+        assert events[0].finish_reason == "stop"

--- a/src/py-packages/sdk/README.md
+++ b/src/py-packages/sdk/README.md
@@ -305,6 +305,36 @@ result = await agent.ainvoke({"messages": ctx.messages})
 
 See [agentified-langchain README](../../py-packages/langchain/README.md) for full docs, or [py-langchain-sdk-smoke](../../../examples/py-langchain-sdk-smoke/) for a working example.
 
+## Observability
+
+Subscribe once at startup to receive events from every `.recall()` / `.assemble()`. Listeners can be sync or async (coroutines are scheduled on the running event loop).
+
+```python
+from agentified import Agentified
+
+ag = Agentified()
+await ag.connect("http://localhost:9119")
+
+def on_ctx(evt):
+    metrics.emit("ctx", evt)
+
+unsub = ag.on("context_assembled", on_ctx)
+ag.on("recall", lambda evt: print(f"recalled {len(evt.matches)} tools in {evt.duration_ms}ms"))
+
+# later
+unsub()
+```
+
+### Event names + payloads
+
+| Event | Payload fields |
+| --- | --- |
+| `context_assembled` | `session_id`, `dataset_id`, `strategy_used`, `total_messages`, `included_messages`, `token_estimate`, `fallback`, `recalled: {"tools": [...]}`, `duration_ms` |
+| `recall` | `session_id`, `dataset_id`, `config`, `matches`, `duration_ms` (only fires when `.recall(...)` was configured) |
+| `step` | `session_id`, `step_index`, `tool_calls`, `tool_results`, `usage`, `finish_reason`, `duration_ms` — wire via `instance.on_step_finish(data)` from your agent's per-step callback (e.g. LangGraph node post-hook) |
+
+Callbacks are fire-and-forget; errors are swallowed. `on(...)` returns a zero-arg disposer.
+
 ## Links
 
 - [Root README](../../../README.md)

--- a/src/py-packages/sdk/src/agentified/__init__.py
+++ b/src/py-packages/sdk/src/agentified/__init__.py
@@ -4,6 +4,13 @@ from .api_client import ApiClient
 from .context_builder import ContextBuilder
 from .conversation import Conversation
 from .dataset_ref import DatasetRef
+from .events import (
+    ContextAssembledEvent,
+    ObserverEmitter,
+    ObserverEventName,
+    RecallEvent,
+    StepEvent,
+)
 from .instance import Instance
 from .namespace import Namespace
 from .session import Session
@@ -64,7 +71,12 @@ __all__ = [
     "ApiClient",
     "ContextBuilder",
     "Conversation",
+    "ContextAssembledEvent",
     "DatasetRef",
+    "ObserverEmitter",
+    "ObserverEventName",
+    "RecallEvent",
+    "StepEvent",
     "Instance",
     "Namespace",
     "Session",

--- a/src/py-packages/sdk/src/agentified/client.py
+++ b/src/py-packages/sdk/src/agentified/client.py
@@ -6,6 +6,7 @@ import httpx
 
 from .api_client import ApiClient
 from .dataset_ref import DatasetRef
+from .events import Listener, ObserverEmitter, ObserverEventName, Unsubscribe
 from .instance import Instance
 from .models import ApiClientConfig, RegisterInput, SearchStrategy
 
@@ -16,6 +17,14 @@ class Agentified:
         self._server_url: str | None = None
         self._connected = False
         self._http_client: httpx.AsyncClient | None = None
+        self._emitter = ObserverEmitter()
+
+    @property
+    def emitter(self) -> ObserverEmitter:
+        return self._emitter
+
+    def on(self, name: ObserverEventName, cb: Listener) -> Unsubscribe:
+        return self._emitter.on(name, cb)
 
     async def connect(
         self,

--- a/src/py-packages/sdk/src/agentified/context_builder.py
+++ b/src/py-packages/sdk/src/agentified/context_builder.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import time
 from typing import Any, Awaitable, Callable, TYPE_CHECKING
 
+from .events import ContextAssembledEvent, ObserverEmitter, RecallEvent
 from .models import (
     AssembledContext,
     BackendTool,
@@ -29,6 +31,7 @@ class ContextBuilder:
         session_id: str,
         registered_tools: list[Any] | None = None,
         discovered_names: set[str] | None = None,
+        emitter: ObserverEmitter | None = None,
     ) -> None:
         self._sdk = sdk
         self._dataset_id = dataset_id
@@ -44,6 +47,7 @@ class ContextBuilder:
         self._recall_config: RecallConfig | None = None
         self._token_limit: int | None = None
         self._explicit_tools: dict[str, Any] = {}
+        self._emitter = emitter
 
     def messages(
         self,
@@ -77,6 +81,7 @@ class ContextBuilder:
             self._compaction_strategy is not None
             and self._strategy == "compacted"
         )
+        started_at = time.perf_counter()
 
         res = await self._sdk.get_context(
             self._dataset_id, self._namespace_id, self._session_id,
@@ -87,6 +92,16 @@ class ContextBuilder:
             recall=self._recall_config,
             limit_tokens=self._token_limit,
         )
+
+        if self._emitter is not None and self._recall_config is not None:
+            matches = (res.recalled or {}).get("tools", []) if isinstance(res.recalled, dict) else []
+            self._emitter.emit("recall", RecallEvent(
+                session_id=self._session_id,
+                dataset_id=self._dataset_id,
+                config=self._recall_config,
+                matches=list(matches),
+                duration_ms=(time.perf_counter() - started_at) * 1000,
+            ))
 
         # Client-side compaction
         if is_client_compaction and self._compaction_strategy:
@@ -143,7 +158,7 @@ class ContextBuilder:
             if name and name in self._discovered_names and name not in resolved:
                 resolved[name] = tool
 
-        return AssembledContext(
+        assembled = AssembledContext(
             messages=final_messages,
             recalled=res.recalled,
             strategy_used=res.strategy_used,
@@ -156,3 +171,19 @@ class ContextBuilder:
             summary=res.summary,
             summary_range=res.summary_range,
         )
+
+        if self._emitter is not None:
+            recalled_tools = (res.recalled or {}).get("tools", []) if isinstance(res.recalled, dict) else []
+            self._emitter.emit("context_assembled", ContextAssembledEvent(
+                session_id=self._session_id,
+                dataset_id=self._dataset_id,
+                strategy_used=assembled.strategy_used,
+                total_messages=assembled.total_messages,
+                included_messages=assembled.included_messages,
+                token_estimate=assembled.token_estimate,
+                fallback=assembled.fallback,
+                recalled={"tools": list(recalled_tools)},
+                duration_ms=(time.perf_counter() - started_at) * 1000,
+            ))
+
+        return assembled

--- a/src/py-packages/sdk/src/agentified/dataset_ref.py
+++ b/src/py-packages/sdk/src/agentified/dataset_ref.py
@@ -50,7 +50,10 @@ class DatasetRef:
         )
         await reg_sdk.register(self.dataset_name)
 
-        return Instance(self.dataset_name, self.dataset_name, sdk, input.tools)
+        return Instance(
+            self.dataset_name, self.dataset_name, sdk, input.tools,
+            emitter=self._agentified.emitter,
+        )
 
 
 def _validate_tools(tools: list[AgentifiedTool]) -> None:

--- a/src/py-packages/sdk/src/agentified/events.py
+++ b/src/py-packages/sdk/src/agentified/events.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+from dataclasses import dataclass, field
+from typing import Any, Callable, Literal
+
+from .models import ContextStrategy, RankedTool, RecallConfig
+
+
+ObserverEventName = Literal["context_assembled", "recall", "step"]
+
+Listener = Callable[[Any], Any]
+Unsubscribe = Callable[[], None]
+
+
+@dataclass
+class ContextAssembledEvent:
+    session_id: str
+    dataset_id: str
+    strategy_used: ContextStrategy
+    total_messages: int
+    included_messages: int
+    token_estimate: int
+    fallback: bool
+    recalled: dict[str, Any]
+    duration_ms: float
+
+
+@dataclass
+class RecallEvent:
+    session_id: str
+    dataset_id: str
+    config: RecallConfig | None
+    matches: list[RankedTool]
+    duration_ms: float
+
+
+@dataclass
+class StepEvent:
+    step_index: int
+    tool_calls: list[Any]
+    tool_results: list[Any]
+    session_id: str | None = None
+    usage: Any | None = None
+    finish_reason: str | None = None
+    duration_ms: float | None = None
+
+
+class ObserverEmitter:
+    """Fire-and-forget event emitter. Supports sync + async listeners."""
+
+    def __init__(self) -> None:
+        self._listeners: dict[str, list[Listener]] = {}
+
+    def on(self, name: ObserverEventName, cb: Listener) -> Unsubscribe:
+        self._listeners.setdefault(name, []).append(cb)
+
+        def unsub() -> None:
+            lst = self._listeners.get(name)
+            if lst and cb in lst:
+                lst.remove(cb)
+
+        return unsub
+
+    def emit(self, name: ObserverEventName, evt: Any) -> None:
+        for cb in list(self._listeners.get(name, [])):
+            try:
+                result = cb(evt)
+            except Exception:
+                continue
+            if inspect.iscoroutine(result):
+                try:
+                    loop = asyncio.get_running_loop()
+                    task = loop.create_task(result)
+                    task.add_done_callback(lambda t: t.exception())
+                except RuntimeError:
+                    # No running loop — run the coroutine to completion.
+                    try:
+                        asyncio.run(result)
+                    except Exception:
+                        pass

--- a/src/py-packages/sdk/src/agentified/instance.py
+++ b/src/py-packages/sdk/src/agentified/instance.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from .events import Listener, ObserverEmitter, ObserverEventName, StepEvent, Unsubscribe
 from .models import AgentifiedTool, DiscoverTool
 from .namespace import Namespace
 from .session import Session
@@ -17,15 +18,45 @@ class Instance:
         dataset_id: str,
         sdk: ApiClient,
         registered_tools: list[AgentifiedTool],
+        emitter: ObserverEmitter | None = None,
     ) -> None:
         self.instance_id = instance_id
         self.dataset_id = dataset_id
         self._sdk = sdk
         self._registered_tools = registered_tools
         self.discover_tool: DiscoverTool = sdk.as_discover_tool(dataset_id)
+        self._emitter = emitter
+        self._step_count = 0
+
+    @property
+    def emitter(self) -> ObserverEmitter | None:
+        return self._emitter
+
+    def on(self, name: ObserverEventName, cb: Listener) -> Unsubscribe:
+        if self._emitter is None:
+            return lambda: None
+        return self._emitter.on(name, cb)
+
+    def on_step_finish(self, data: dict) -> None:
+        """Forward a step event to registered listeners. Call from your agent's
+        per-step callback (e.g. LangGraph node post-hook)."""
+        if self._emitter is None:
+            return
+        step_index = int(data.get("step_index", self._step_count))
+        self._step_count = step_index + 1
+        evt = StepEvent(
+            step_index=step_index,
+            tool_calls=list(data.get("tool_calls", [])),
+            tool_results=list(data.get("tool_results", [])),
+            session_id=data.get("session_id"),
+            usage=data.get("usage"),
+            finish_reason=data.get("finish_reason"),
+            duration_ms=data.get("duration_ms"),
+        )
+        self._emitter.emit("step", evt)
 
     def session(self, id: str) -> Session:
-        return Session(id, "default", self._sdk, self.dataset_id, self._registered_tools)
+        return Session(id, "default", self._sdk, self.dataset_id, self._registered_tools, emitter=self._emitter)
 
     def namespace(self, id: str) -> Namespace:
-        return Namespace(id, self._sdk, self.dataset_id, self._registered_tools)
+        return Namespace(id, self._sdk, self.dataset_id, self._registered_tools, emitter=self._emitter)

--- a/src/py-packages/sdk/src/agentified/namespace.py
+++ b/src/py-packages/sdk/src/agentified/namespace.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from .events import ObserverEmitter
 from .models import BackendTool
 from .session import Session
 
@@ -16,11 +17,16 @@ class Namespace:
         sdk: ApiClient,
         dataset_id: str,
         registered_tools: list[BackendTool],
+        emitter: ObserverEmitter | None = None,
     ) -> None:
         self.id = id
         self._sdk = sdk
         self._dataset_id = dataset_id
         self._registered_tools = registered_tools
+        self._emitter = emitter
 
     def session(self, id: str) -> Session:
-        return Session(id, self.id, self._sdk, self._dataset_id, self._registered_tools)
+        return Session(
+            id, self.id, self._sdk, self._dataset_id, self._registered_tools,
+            emitter=self._emitter,
+        )

--- a/src/py-packages/sdk/src/agentified/session.py
+++ b/src/py-packages/sdk/src/agentified/session.py
@@ -4,6 +4,7 @@ from typing import Any, TYPE_CHECKING
 
 from .context_builder import ContextBuilder
 from .conversation import Conversation
+from .events import ObserverEmitter
 from .models import (
     AgentifiedTool,
     DiscoverTool,
@@ -24,6 +25,7 @@ class Session:
         sdk: ApiClient,
         dataset_id: str,
         registered_tools: list[AgentifiedTool],
+        emitter: ObserverEmitter | None = None,
     ) -> None:
         self.id = id
         self.namespace_id = namespace_id
@@ -33,6 +35,15 @@ class Session:
         self.conversation = Conversation(sdk, dataset_id, namespace_id, id)
         self._discover_tool = sdk.as_discover_tool(dataset_id, namespace_id, id)
         self._get_messages_tool: GetMessagesTool | None = None
+        self._emitter = emitter
+
+    @property
+    def dataset_id(self) -> str:
+        return self._dataset_id
+
+    @property
+    def emitter(self) -> ObserverEmitter | None:
+        return self._emitter
 
     @property
     def context(self) -> ContextBuilder:
@@ -40,6 +51,7 @@ class Session:
             self._sdk, self._dataset_id, self.namespace_id, self.id,
             registered_tools=self._registered_tools,
             discovered_names=self._discover_tool.discovered_names,
+            emitter=self._emitter,
         )
 
     @property

--- a/src/py-packages/sdk/tests/test_events.py
+++ b/src/py-packages/sdk/tests/test_events.py
@@ -1,0 +1,224 @@
+import asyncio
+
+import httpx
+import pytest
+import respx
+
+from agentified.api_client import ApiClient
+from agentified.context_builder import ContextBuilder
+from agentified.events import (
+    ContextAssembledEvent,
+    ObserverEmitter,
+    RecallEvent,
+    StepEvent,
+)
+from agentified.instance import Instance
+from agentified.models import ApiClientConfig, BackendTool, RecallConfig
+
+TEST_URL = "http://localhost:9119"
+
+CONTEXT_RESPONSE_BASE = {
+    "messages": [{
+        "id": "m1", "role": "user", "content": "hi",
+        "tool_call_id": None, "tool_calls": None,
+        "created_at": "2026-01-01T00:00:00Z", "seq": 1,
+    }],
+    "strategy_used": "recent",
+    "total_messages": 1,
+    "included_messages": 1,
+    "recalled": {"tools": [], "memories": []},
+    "token_estimate": 5,
+    "conversation_messages": 1,
+    "fallback": False,
+}
+
+RANKED = {
+    "name": "get_weather",
+    "description": "",
+    "parameters": {},
+    "score": 0.9,
+}
+
+
+class TestObserverEmitter:
+    def test_calls_sync_listener(self):
+        emitter = ObserverEmitter()
+        calls = []
+        emitter.on("context_assembled", lambda e: calls.append(e))
+        emitter.emit("context_assembled", {"x": 1})
+        assert calls == [{"x": 1}]
+
+    def test_disposer_removes_listener(self):
+        emitter = ObserverEmitter()
+        calls = []
+        off = emitter.on("context_assembled", lambda e: calls.append(e))
+        off()
+        emitter.emit("context_assembled", {})
+        assert calls == []
+
+    def test_swallows_listener_errors(self):
+        emitter = ObserverEmitter()
+        good = []
+
+        def bad(_e):
+            raise RuntimeError("boom")
+
+        emitter.on("context_assembled", bad)
+        emitter.on("context_assembled", lambda e: good.append(e))
+        emitter.emit("context_assembled", {})
+        assert good == [{}]
+
+    async def test_async_listener_is_scheduled(self):
+        emitter = ObserverEmitter()
+        received: list[dict] = []
+
+        async def async_cb(evt):
+            await asyncio.sleep(0)
+            received.append(evt)
+
+        emitter.on("context_assembled", async_cb)
+        emitter.emit("context_assembled", {"k": 1})
+        # Let the scheduled task run
+        for _ in range(3):
+            await asyncio.sleep(0)
+        assert received == [{"k": 1}]
+
+
+class TestContextBuilderEvents:
+    @respx.mock
+    async def test_emits_context_assembled_once(self):
+        respx.post(f"{TEST_URL}/api/v1/context").mock(
+            return_value=httpx.Response(200, json=CONTEXT_RESPONSE_BASE)
+        )
+        emitter = ObserverEmitter()
+        events: list[ContextAssembledEvent] = []
+        emitter.on("context_assembled", lambda e: events.append(e))
+
+        sdk = ApiClient(ApiClientConfig(server_url=TEST_URL, tools=[]))
+        cb = ContextBuilder(sdk, "ds", "ns", "sess-1", emitter=emitter)
+        await cb.messages(strategy="recent").assemble()
+
+        assert len(events) == 1
+        assert events[0].session_id == "sess-1"
+        assert events[0].dataset_id == "ds"
+        assert events[0].strategy_used == "recent"
+        assert events[0].total_messages == 1
+        assert events[0].included_messages == 1
+        assert events[0].token_estimate == 5
+        assert events[0].fallback is False
+        assert events[0].recalled == {"tools": []}
+        assert events[0].duration_ms >= 0
+
+    @respx.mock
+    async def test_does_not_emit_recall_when_not_configured(self):
+        respx.post(f"{TEST_URL}/api/v1/context").mock(
+            return_value=httpx.Response(200, json=CONTEXT_RESPONSE_BASE)
+        )
+        emitter = ObserverEmitter()
+        recall_events: list[RecallEvent] = []
+        emitter.on("recall", lambda e: recall_events.append(e))
+
+        sdk = ApiClient(ApiClientConfig(server_url=TEST_URL, tools=[]))
+        cb = ContextBuilder(sdk, "ds", "ns", "sess", emitter=emitter)
+        await cb.assemble()
+        assert recall_events == []
+
+    @respx.mock
+    async def test_emits_recall_when_configured(self):
+        resp = dict(CONTEXT_RESPONSE_BASE)
+        resp["recalled"] = {"tools": [RANKED], "memories": []}
+        respx.post(f"{TEST_URL}/api/v1/context").mock(
+            return_value=httpx.Response(200, json=resp)
+        )
+        emitter = ObserverEmitter()
+        recall_events: list[RecallEvent] = []
+        ctx_events: list[ContextAssembledEvent] = []
+        emitter.on("recall", lambda e: recall_events.append(e))
+        emitter.on("context_assembled", lambda e: ctx_events.append(e))
+
+        sdk = ApiClient(ApiClientConfig(server_url=TEST_URL, tools=[]))
+        cb = ContextBuilder(sdk, "ds", "ns", "sess", emitter=emitter)
+        await cb.recall().assemble()
+
+        assert len(recall_events) == 1
+        assert recall_events[0].session_id == "sess"
+        assert recall_events[0].config is not None
+        assert recall_events[0].config.tools is True
+        assert len(recall_events[0].matches) == 1
+        assert recall_events[0].duration_ms >= 0
+
+        assert len(ctx_events) == 1
+        assert len(ctx_events[0].recalled["tools"]) == 1
+
+    @respx.mock
+    async def test_no_emitter_is_safe(self):
+        respx.post(f"{TEST_URL}/api/v1/context").mock(
+            return_value=httpx.Response(200, json=CONTEXT_RESPONSE_BASE)
+        )
+        sdk = ApiClient(ApiClientConfig(server_url=TEST_URL, tools=[]))
+        cb = ContextBuilder(sdk, "ds", "ns", "sess")
+        await cb.assemble()  # must not throw
+
+
+class TestInstanceStepEvents:
+    def test_on_step_finish_emits_step_event(self):
+        emitter = ObserverEmitter()
+        events: list[StepEvent] = []
+        emitter.on("step", lambda e: events.append(e))
+
+        # Build an Instance with a fake sdk (only needs as_discover_tool)
+        class FakeSdk:
+            def as_discover_tool(self, *args, **kwargs):
+                class D:
+                    definition = type("X", (), {"name": "agentified_discover", "description": "", "parameters": {}})
+                    discovered_names = set()
+                    execute = None
+                return D()
+
+        inst = Instance("i", "ds", FakeSdk(), [], emitter=emitter)
+        inst.on_step_finish({
+            "tool_calls": [{"name": "x"}],
+            "tool_results": [{"result": 1}],
+            "usage": {"input": 10},
+            "finish_reason": "stop",
+        })
+
+        assert len(events) == 1
+        assert events[0].step_index == 0
+        assert events[0].tool_calls == [{"name": "x"}]
+        assert events[0].tool_results == [{"result": 1}]
+        assert events[0].finish_reason == "stop"
+
+    def test_step_index_increments(self):
+        emitter = ObserverEmitter()
+        events: list[StepEvent] = []
+        emitter.on("step", lambda e: events.append(e))
+
+        class FakeSdk:
+            def as_discover_tool(self, *args, **kwargs):
+                class D:
+                    definition = type("X", (), {"name": "d", "description": "", "parameters": {}})
+                    discovered_names = set()
+                    execute = None
+                return D()
+
+        inst = Instance("i", "ds", FakeSdk(), [], emitter=emitter)
+        inst.on_step_finish({})
+        inst.on_step_finish({})
+        inst.on_step_finish({})
+        assert [e.step_index for e in events] == [0, 1, 2]
+
+    def test_on_step_finish_is_safe_without_emitter(self):
+        class FakeSdk:
+            def as_discover_tool(self, *args, **kwargs):
+                class D:
+                    definition = type("X", (), {"name": "d", "description": "", "parameters": {}})
+                    discovered_names = set()
+                    execute = None
+                return D()
+
+        inst = Instance("i", "ds", FakeSdk(), [])
+        # Should not throw
+        inst.on_step_finish({})
+        off = inst.on("step", lambda e: None)
+        off()

--- a/src/ts-packages/mastra/README.md
+++ b/src/ts-packages/mastra/README.md
@@ -119,6 +119,37 @@ Converts a JSON Schema object to a Zod schema. Used internally to hydrate Mastra
 import { jsonSchemaToZod } from "@agentified/mastra";
 ```
 
+## Observability
+
+`MastraAgentified` forwards `context:assembled` / `recall` events from the underlying SDK and adds a `step` event that fires once per agent step.
+
+```typescript
+const mag = new Agentified().adaptTo(mastra());
+await mag.connect("http://localhost:9119");
+
+const instance = await mag.register({ tools: [...] });
+const session = instance.session("chat-1");
+
+mag.on("context:assembled", (evt) => metrics.emit("ctx", evt));
+session.on("step", (evt) => metrics.emit("step", evt));
+
+const ctx = await session.context.recall().messages({ strategy: "recent" }).assemble();
+const result = await agent.generate(messages, {
+  prepareStep: ctx.prepareStep,
+  onStepFinish: session.onStepFinish, // wires Mastra steps into the "step" event
+});
+```
+
+### Event names + payloads
+
+| Event | Source | Payload |
+| --- | --- | --- |
+| `context:assembled` | SDK | `sessionId`, `datasetId`, `strategyUsed`, `totalMessages`, `includedMessages`, `tokenEstimate`, `fallback`, `recalled: { tools }`, `durationMs` |
+| `recall` | SDK | `sessionId`, `datasetId`, `config`, `matches`, `durationMs` |
+| `step` | Mastra | `sessionId`, `stepIndex`, `toolCalls`, `toolResults`, `usage`, `finishReason`, `durationMs` |
+
+`mag.on(...)`, `instance.on(...)`, `session.on(...)` all return a disposer. Listeners can be sync or async; listener errors are swallowed.
+
 ## Links
 
 - [Root README](../../../README.md)

--- a/src/ts-packages/mastra/src/__tests__/events.test.ts
+++ b/src/ts-packages/mastra/src/__tests__/events.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockCreateTool = vi.fn(({ id, execute }: any) => ({ id, execute, __mastraTool: true }));
+vi.mock("@mastra/core/tools", () => ({
+  createTool: (...args: any[]) => mockCreateTool(...args),
+}));
+
+import { MastraInstance, MastraSession, MastraAgentified } from "../agentified.js";
+import { ObserverEmitter } from "agentified";
+import type { StepEvent, Agentified, Instance, Session } from "agentified";
+
+function fakeInstance(emitter?: ObserverEmitter): Instance {
+  return {
+    instanceId: "default",
+    datasetId: "default",
+    discoverTool: {
+      definition: { name: "agentified_discover", description: "", parameters: {} },
+      execute: vi.fn(),
+      discoveredNames: new Set<string>(),
+    },
+    prepareStep: vi.fn().mockResolvedValue({ activeTools: [] }),
+    session: vi.fn(),
+    namespace: vi.fn(),
+    emitter,
+  } as unknown as Instance;
+}
+
+function fakeSession(id: string, emitter?: ObserverEmitter): Session {
+  return {
+    id,
+    datasetId: "default",
+    discoverTool: {
+      definition: { name: "agentified_discover", description: "", parameters: {} },
+      execute: vi.fn(),
+      discoveredNames: new Set<string>(),
+    },
+    getMessagesTool: {
+      definition: { name: "agentified_get_messages", description: "", parameters: {} },
+      execute: vi.fn(),
+    },
+    prepareStep: vi.fn(),
+    emitter,
+    conversation: {},
+  } as unknown as Session;
+}
+
+describe("MastraAgentified.on", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("delegates on() to underlying Agentified.on", () => {
+    const ag = { on: vi.fn().mockReturnValue(() => {}) } as unknown as Agentified;
+    const m = new MastraAgentified(ag);
+    const cb = vi.fn();
+    m.on("context:assembled", cb);
+    expect(ag.on).toHaveBeenCalledWith("context:assembled", cb);
+  });
+});
+
+describe("MastraInstance step events", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("on('step', cb) + onStepFinish emits StepEvent once", () => {
+    const emitter = new ObserverEmitter();
+    const inst = fakeInstance(emitter);
+    const m = new MastraInstance(inst, []);
+
+    const events: StepEvent[] = [];
+    m.on("step", (evt) => events.push(evt));
+
+    m.onStepFinish({
+      toolCalls: [{ toolName: "x" }],
+      toolResults: [{ toolCallId: "1", result: 42 }],
+      usage: { input: 10, output: 5 },
+      finishReason: "stop",
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.stepIndex).toBe(0);
+    expect(events[0]!.toolCalls).toEqual([{ toolName: "x" }]);
+    expect(events[0]!.toolResults).toEqual([{ toolCallId: "1", result: 42 }]);
+    expect(events[0]!.usage).toEqual({ input: 10, output: 5 });
+    expect(events[0]!.finishReason).toBe("stop");
+  });
+
+  it("increments stepIndex across calls", () => {
+    const emitter = new ObserverEmitter();
+    const inst = fakeInstance(emitter);
+    const m = new MastraInstance(inst, []);
+    const events: StepEvent[] = [];
+    m.on("step", (evt) => events.push(evt));
+
+    m.onStepFinish({});
+    m.onStepFinish({});
+    m.onStepFinish({});
+
+    expect(events.map(e => e.stepIndex)).toEqual([0, 1, 2]);
+  });
+
+  it("disposer from on() removes listener", () => {
+    const emitter = new ObserverEmitter();
+    const inst = fakeInstance(emitter);
+    const m = new MastraInstance(inst, []);
+    const cb = vi.fn();
+    const off = m.on("step", cb);
+    off();
+    m.onStepFinish({});
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("no emitter means on() returns no-op disposer and onStepFinish is safe", () => {
+    const inst = fakeInstance(undefined);
+    const m = new MastraInstance(inst, []);
+    const off = m.on("step", () => {});
+    expect(typeof off).toBe("function");
+    expect(() => m.onStepFinish({})).not.toThrow();
+    expect(() => off()).not.toThrow();
+  });
+});
+
+describe("MastraSession step events", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("onStepFinish tags sessionId onto StepEvent", () => {
+    const emitter = new ObserverEmitter();
+    const sess = fakeSession("chat-42", emitter);
+    const m = new MastraSession(sess, []);
+    const events: StepEvent[] = [];
+    m.on("step", (evt) => events.push(evt));
+
+    m.onStepFinish({ toolCalls: [], toolResults: [] });
+    expect(events).toHaveLength(1);
+    expect(events[0]!.sessionId).toBe("chat-42");
+  });
+});

--- a/src/ts-packages/mastra/src/agentified.ts
+++ b/src/ts-packages/mastra/src/agentified.ts
@@ -18,6 +18,10 @@ import type {
   ContextStrategy,
   RecallConfig,
   AgentifiedTool,
+  ObserverEventName,
+  ObserverListener,
+  Unsubscribe,
+  StepEvent,
 } from "agentified";
 import { jsonSchemaToZod } from "./schema.js";
 
@@ -117,6 +121,10 @@ export class MastraAgentified {
   connect(url?: string, options?: { headers?: Record<string, string> }) { return this.ag.connect(url, options); }
   disconnect() { return this.ag.disconnect(); }
 
+  on<K extends ObserverEventName>(name: K, cb: ObserverListener<K>): Unsubscribe {
+    return this.ag.on(name, cb);
+  }
+
   dataset(name: string) { return new MastraDatasetRef(this.ag.dataset(name)); }
 
   async register(input: RegisterInput) {
@@ -143,6 +151,7 @@ export class MastraInstance {
   get datasetId() { return this.inst.datasetId; }
 
   private readonly alwaysIncludeNames: Set<string>;
+  private stepCount = 0;
 
   constructor(
     private readonly inst: Instance,
@@ -152,6 +161,19 @@ export class MastraInstance {
     this.mastraToolCache = buildMastraToolMap(backendTools);
     this.alwaysIncludeNames = extractAlwaysIncludeNames(backendTools);
   }
+
+  on<K extends ObserverEventName>(name: K, cb: ObserverListener<K>): Unsubscribe {
+    if (!this.inst.emitter) return () => { /* no-op when no emitter */ };
+    return this.inst.emitter.on(name, cb);
+  }
+
+  readonly onStepFinish = (data: Record<string, unknown>): void => {
+    const stepIndex = typeof data["stepIndex"] === "number"
+      ? (data["stepIndex"] as number)
+      : this.stepCount;
+    this.stepCount = stepIndex + 1;
+    this.inst.emitter?.emit("step", toStepEvent(data, stepIndex));
+  };
 
   readonly prepareStep = async (params: { stepNumber: number; steps: any[] }) => {
     await this.inst.prepareStep(params);
@@ -184,6 +206,7 @@ export class MastraSession {
   get conversation() { return this.sess.conversation; }
 
   private readonly alwaysIncludeNames: Set<string>;
+  private stepCount = 0;
 
   constructor(
     private readonly sess: Session,
@@ -194,6 +217,21 @@ export class MastraSession {
     this.mastraToolCache = buildMastraToolMap(backendTools);
     this.alwaysIncludeNames = extractAlwaysIncludeNames(backendTools);
   }
+
+  on<K extends ObserverEventName>(name: K, cb: ObserverListener<K>): Unsubscribe {
+    if (!this.sess.emitter) return () => { /* no-op when no emitter */ };
+    return this.sess.emitter.on(name, cb);
+  }
+
+  readonly onStepFinish = (data: Record<string, unknown>): void => {
+    const stepIndex = typeof data["stepIndex"] === "number"
+      ? (data["stepIndex"] as number)
+      : this.stepCount;
+    this.stepCount = stepIndex + 1;
+    const evt = toStepEvent(data, stepIndex);
+    evt.sessionId = this.sess.id;
+    this.sess.emitter?.emit("step", evt);
+  };
 
   get context(): MastraContextBuilder {
     return new MastraContextBuilder(
@@ -291,4 +329,15 @@ function buildMastraToolMap(backendTools: (BackendTool | McpTool)[]): Record<str
     }) as MastraTool;
   }
   return tools;
+}
+
+function toStepEvent(data: Record<string, unknown>, stepIndex: number): StepEvent {
+  return {
+    stepIndex,
+    toolCalls: Array.isArray(data["toolCalls"]) ? (data["toolCalls"] as unknown[]) : [],
+    toolResults: Array.isArray(data["toolResults"]) ? (data["toolResults"] as unknown[]) : [],
+    usage: data["usage"],
+    finishReason: typeof data["finishReason"] === "string" ? (data["finishReason"] as string) : undefined,
+    durationMs: typeof data["durationMs"] === "number" ? (data["durationMs"] as number) : undefined,
+  };
 }

--- a/src/ts-packages/sdk/README.md
+++ b/src/ts-packages/sdk/README.md
@@ -251,6 +251,36 @@ interface TokenUsage {
 }
 ```
 
+## Observability
+
+Subscribe once at startup to receive events from every `.recall()` / `.assemble()` call — no need to destructure the assembled context in every turn.
+
+```typescript
+const ag = new Agentified();
+await ag.connect("http://localhost:9119");
+
+const offCtx = ag.on("context:assembled", (evt) => {
+  metrics.emit("ctx", evt);
+});
+
+const offRecall = ag.on("recall", (evt) => {
+  console.log(`recalled ${evt.matches.length} tools in ${evt.durationMs}ms`);
+});
+
+// later: offCtx(); offRecall();
+```
+
+### Event names + payloads
+
+| Event | Payload fields |
+| --- | --- |
+| `context:assembled` | `sessionId`, `datasetId`, `strategyUsed`, `totalMessages`, `includedMessages`, `tokenEstimate`, `fallback`, `recalled: { tools }`, `durationMs` |
+| `recall` | `sessionId`, `datasetId`, `config`, `matches`, `durationMs` (only fires when `.recall(...)` was configured) |
+
+Listeners can be sync or async. Errors thrown inside listeners are swallowed; each subscriber owns its own batching / backpressure. `ag.on(...)` returns a disposer — call it to unsubscribe.
+
+For agent-step events (`step`), see the Mastra adapter — it exposes `mag.on("step", cb)` and `mag.onStepFinish` to wire into `agent.generate(...)`.
+
 ## Links
 
 - [Root README](../../../README.md)

--- a/src/ts-packages/sdk/src/__tests__/events.test.ts
+++ b/src/ts-packages/sdk/src/__tests__/events.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetContext = vi.fn();
+const mockGetMessages = vi.fn();
+const mockAppendMessages = vi.fn();
+const mockAsDiscoverTool = vi.fn();
+const mockAsGetMessagesTool = vi.fn();
+
+vi.mock("../api-client.js", () => ({
+  ApiClient: vi.fn(() => ({
+    getContext: mockGetContext,
+    getMessages: mockGetMessages,
+    appendMessages: mockAppendMessages,
+    asDiscoverTool: mockAsDiscoverTool,
+    asGetMessagesTool: mockAsGetMessagesTool,
+  })),
+}));
+
+import { ContextBuilder } from "../context-builder.js";
+import { ObserverEmitter } from "../events.js";
+import type { ContextAssembledEvent, RecallEvent } from "../events.js";
+import { ApiClient } from "../api-client.js";
+
+function baseResponse() {
+  return {
+    messages: [{ id: "m1", role: "user", content: "hi", createdAt: "", seq: 1 }],
+    strategyUsed: "recent" as const,
+    totalMessages: 1,
+    includedMessages: 1,
+    recalled: { tools: [], memories: [] },
+    tokenEstimate: 5,
+    conversationMessages: 1,
+    fallback: false,
+  };
+}
+
+describe("ObserverEmitter", () => {
+  it("calls registered listeners", () => {
+    const emitter = new ObserverEmitter();
+    const cb = vi.fn();
+    emitter.on("context:assembled", cb);
+    emitter.emit("context:assembled", { sessionId: "s" } as ContextAssembledEvent);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("disposer removes the listener", () => {
+    const emitter = new ObserverEmitter();
+    const cb = vi.fn();
+    const off = emitter.on("context:assembled", cb);
+    off();
+    emitter.emit("context:assembled", {} as ContextAssembledEvent);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("swallows listener errors and keeps other listeners", () => {
+    const emitter = new ObserverEmitter();
+    const bad = vi.fn(() => { throw new Error("boom"); });
+    const good = vi.fn();
+    emitter.on("context:assembled", bad);
+    emitter.on("context:assembled", good);
+    expect(() => emitter.emit("context:assembled", {} as ContextAssembledEvent)).not.toThrow();
+    expect(good).toHaveBeenCalled();
+  });
+
+  it("supports multiple event names independently", () => {
+    const emitter = new ObserverEmitter();
+    const ctx = vi.fn();
+    const step = vi.fn();
+    emitter.on("context:assembled", ctx);
+    emitter.on("step", step);
+    emitter.emit("context:assembled", {} as ContextAssembledEvent);
+    expect(ctx).toHaveBeenCalledTimes(1);
+    expect(step).not.toHaveBeenCalled();
+  });
+});
+
+describe("ContextBuilder events", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits context:assembled exactly once per assemble() with full payload", async () => {
+    mockGetContext.mockResolvedValue(baseResponse());
+    const emitter = new ObserverEmitter();
+    const events: ContextAssembledEvent[] = [];
+    emitter.on("context:assembled", (evt) => { events.push(evt); });
+
+    const sdk = new ApiClient({ serverUrl: "", tools: [] });
+    const cb = new ContextBuilder(sdk, "ds", "ns", "sess-1", [], new Set(), emitter);
+    await cb.assemble();
+
+    expect(events).toHaveLength(1);
+    const evt = events[0]!;
+    expect(evt.sessionId).toBe("sess-1");
+    expect(evt.datasetId).toBe("ds");
+    expect(evt.strategyUsed).toBe("recent");
+    expect(evt.totalMessages).toBe(1);
+    expect(evt.includedMessages).toBe(1);
+    expect(evt.tokenEstimate).toBe(5);
+    expect(evt.fallback).toBe(false);
+    expect(evt.recalled).toEqual({ tools: [] });
+    expect(typeof evt.durationMs).toBe("number");
+  });
+
+  it("does NOT emit recall when recall was not configured", async () => {
+    mockGetContext.mockResolvedValue(baseResponse());
+    const emitter = new ObserverEmitter();
+    const recallEvents: RecallEvent[] = [];
+    emitter.on("recall", (evt) => { recallEvents.push(evt); });
+
+    const sdk = new ApiClient({ serverUrl: "", tools: [] });
+    const cb = new ContextBuilder(sdk, "ds", "ns", "sess", [], new Set(), emitter);
+    await cb.assemble();
+
+    expect(recallEvents).toHaveLength(0);
+  });
+
+  it("emits recall once with matches when recall() was configured", async () => {
+    const ranked = { name: "get_weather", description: "", parameters: {}, score: 0.9 };
+    mockGetContext.mockResolvedValue({
+      ...baseResponse(),
+      recalled: { tools: [ranked], memories: [] },
+    });
+    const emitter = new ObserverEmitter();
+    const recallEvents: RecallEvent[] = [];
+    const ctxEvents: ContextAssembledEvent[] = [];
+    emitter.on("recall", (evt) => { recallEvents.push(evt); });
+    emitter.on("context:assembled", (evt) => { ctxEvents.push(evt); });
+
+    const sdk = new ApiClient({ serverUrl: "", tools: [] });
+    const cb = new ContextBuilder(sdk, "ds", "ns", "sess", [], new Set(), emitter);
+    await cb.recall().assemble();
+
+    expect(recallEvents).toHaveLength(1);
+    expect(recallEvents[0]!.matches).toEqual([ranked]);
+    expect(recallEvents[0]!.config).toEqual({ tools: true });
+    expect(ctxEvents).toHaveLength(1);
+    expect(ctxEvents[0]!.recalled.tools).toEqual([ranked]);
+  });
+
+  it("does not emit events when no emitter is provided", async () => {
+    mockGetContext.mockResolvedValue(baseResponse());
+    const sdk = new ApiClient({ serverUrl: "", tools: [] });
+    const cb = new ContextBuilder(sdk, "ds", "ns", "sess");
+    // Should not throw
+    await cb.assemble();
+  });
+});

--- a/src/ts-packages/sdk/src/agentified.ts
+++ b/src/ts-packages/sdk/src/agentified.ts
@@ -1,6 +1,7 @@
 import { ApiClient } from "./api-client.js";
 import { DatasetRef } from "./dataset-ref.js";
 import { Instance } from "./instance.js";
+import { ObserverEmitter, type ObserverEventName, type ObserverListener, type Unsubscribe } from "./events.js";
 import { resolveBinaryPath, findFreePort } from "./spawn-utils.js";
 import type { RegisterInput, SearchStrategy } from "./types.js";
 import { spawn, type ChildProcess } from "node:child_process";
@@ -8,6 +9,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 export class Agentified {
   /** @internal */ sdk: ApiClient | null = null;
   /** @internal */ serverUrl: string | null = null;
+  /** @internal */ readonly emitter: ObserverEmitter = new ObserverEmitter();
   private connected = false;
   private spawnedProcess: ChildProcess | null = null;
   private cleanupHandlers: Array<[string, (...args: any[]) => void]> = [];
@@ -15,6 +17,10 @@ export class Agentified {
   private spawnArgs: { binaryPath: string; port: number } | null = null;
   private headers?: Record<string, string>;
   private strategy?: SearchStrategy;
+
+  on<K extends ObserverEventName>(name: K, cb: ObserverListener<K>): Unsubscribe {
+    return this.emitter.on(name, cb);
+  }
 
   async connect(serverUrl?: string, options?: { headers?: Record<string, string>; strategy?: SearchStrategy }): Promise<void> {
     if (this.connected) throw new Error("Already connected");

--- a/src/ts-packages/sdk/src/context-builder.ts
+++ b/src/ts-packages/sdk/src/context-builder.ts
@@ -1,4 +1,5 @@
 import type { ApiClient } from "./api-client.js";
+import type { ObserverEmitter } from "./events.js";
 import type { AgentifiedTool, AssembledContext, CompactionStrategy, ContextStrategy, RecallConfig, StoredMessage } from "./types.js";
 
 export class ContextBuilder<T = AgentifiedTool> {
@@ -14,6 +15,7 @@ export class ContextBuilder<T = AgentifiedTool> {
     private readonly sessionId: string,
     private readonly registeredTools: T[] = [],
     private readonly discoveredNames: Set<string> = new Set(),
+    private readonly emitter?: ObserverEmitter,
   ) {}
 
   tools(tools: Record<string, T>): this {
@@ -39,6 +41,7 @@ export class ContextBuilder<T = AgentifiedTool> {
   async assemble(): Promise<AssembledContext<T>> {
     const { compactionStrategy } = this.messageOpts;
     const isClientCompaction = compactionStrategy && this.messageOpts.strategy === "compacted";
+    const startedAt = Date.now();
 
     const res = await this.sdk.getContext(this.datasetId, this.namespaceId, this.sessionId, {
       strategy: isClientCompaction ? "recent" : this.messageOpts.strategy,
@@ -48,6 +51,16 @@ export class ContextBuilder<T = AgentifiedTool> {
       recall: this.recallOpts,
       limitTokens: this.tokenLimit,
     });
+
+    if (this.emitter && this.recallOpts) {
+      this.emitter.emit("recall", {
+        sessionId: this.sessionId,
+        datasetId: this.datasetId,
+        config: this.recallOpts,
+        matches: res.recalled?.tools ?? [],
+        durationMs: Date.now() - startedAt,
+      });
+    }
 
     // Client-side compaction: fetch all messages, find older ones, call user's compactionStrategy
     if (isClientCompaction) {
@@ -100,7 +113,7 @@ export class ContextBuilder<T = AgentifiedTool> {
       }
     }
 
-    return {
+    const assembled: AssembledContext<T> = {
       messages: finalMessages,
       recalled: res.recalled,
       strategyUsed: res.strategyUsed,
@@ -113,5 +126,21 @@ export class ContextBuilder<T = AgentifiedTool> {
       summary: res.summary,
       summaryRange: res.summaryRange,
     };
+
+    if (this.emitter) {
+      this.emitter.emit("context:assembled", {
+        sessionId: this.sessionId,
+        datasetId: this.datasetId,
+        strategyUsed: assembled.strategyUsed,
+        totalMessages: assembled.totalMessages,
+        includedMessages: assembled.includedMessages,
+        tokenEstimate: assembled.tokenEstimate,
+        fallback: assembled.fallback,
+        recalled: { tools: assembled.recalled?.tools ?? [] },
+        durationMs: Date.now() - startedAt,
+      });
+    }
+
+    return assembled;
   }
 }

--- a/src/ts-packages/sdk/src/dataset-ref.ts
+++ b/src/ts-packages/sdk/src/dataset-ref.ts
@@ -1,4 +1,5 @@
 import { ApiClient } from "./api-client.js";
+import type { ObserverEmitter } from "./events.js";
 import { Instance } from "./instance.js";
 import type { AgentifiedTool, RegisterInput } from "./types.js";
 
@@ -15,7 +16,7 @@ function validateTools(tools: AgentifiedTool[]): void {
 
 export class DatasetRef {
   constructor(
-    /** @internal */ protected readonly _agentified: { sdk: ApiClient | null; serverUrl: string | null },
+    /** @internal */ protected readonly _agentified: { sdk: ApiClient | null; serverUrl: string | null; emitter?: ObserverEmitter },
     readonly datasetName: string,
   ) {}
 
@@ -39,6 +40,6 @@ export class DatasetRef {
     });
     await regSdk.register(this.datasetName);
 
-    return new Instance(this.datasetName, this.datasetName, sdk, input.tools);
+    return new Instance(this.datasetName, this.datasetName, sdk, input.tools, this._agentified.emitter);
   }
 }

--- a/src/ts-packages/sdk/src/events.ts
+++ b/src/ts-packages/sdk/src/events.ts
@@ -1,0 +1,73 @@
+import type { ContextStrategy, RankedTool, RecallConfig } from "./types.js";
+
+export interface ContextAssembledEvent {
+  sessionId: string;
+  datasetId: string;
+  strategyUsed: ContextStrategy;
+  totalMessages: number;
+  includedMessages: number;
+  tokenEstimate: number;
+  fallback: boolean;
+  recalled: { tools: RankedTool[] };
+  durationMs: number;
+}
+
+export interface RecallEvent {
+  sessionId: string;
+  datasetId: string;
+  config: RecallConfig | undefined;
+  matches: RankedTool[];
+  durationMs: number;
+}
+
+export interface StepEvent {
+  sessionId?: string;
+  stepIndex: number;
+  toolCalls: unknown[];
+  toolResults: unknown[];
+  usage?: unknown;
+  finishReason?: string;
+  durationMs?: number;
+}
+
+export interface ObserverEventMap {
+  "context:assembled": ContextAssembledEvent;
+  recall: RecallEvent;
+  step: StepEvent;
+}
+
+export type ObserverEventName = keyof ObserverEventMap;
+
+export type ObserverListener<K extends ObserverEventName> = (
+  evt: ObserverEventMap[K],
+) => void | Promise<void>;
+
+export type Unsubscribe = () => void;
+
+export class ObserverEmitter {
+  private listeners: Map<string, Set<(evt: unknown) => void | Promise<void>>> = new Map();
+
+  on<K extends ObserverEventName>(name: K, cb: ObserverListener<K>): Unsubscribe {
+    if (!this.listeners.has(name)) this.listeners.set(name, new Set());
+    const set = this.listeners.get(name)!;
+    set.add(cb as (evt: unknown) => void | Promise<void>);
+    return () => {
+      set.delete(cb as (evt: unknown) => void | Promise<void>);
+    };
+  }
+
+  emit<K extends ObserverEventName>(name: K, evt: ObserverEventMap[K]): void {
+    const set = this.listeners.get(name);
+    if (!set) return;
+    for (const cb of set) {
+      try {
+        const r = cb(evt);
+        if (r && typeof (r as Promise<void>).catch === "function") {
+          (r as Promise<void>).catch(() => { /* swallow async errors */ });
+        }
+      } catch {
+        /* swallow listener errors */
+      }
+    }
+  }
+}

--- a/src/ts-packages/sdk/src/index.ts
+++ b/src/ts-packages/sdk/src/index.ts
@@ -8,6 +8,16 @@ export { ContextBuilder } from "./context-builder.js";
 export { Conversation } from "./conversation.js";
 export { tool } from "./tool.js";
 export { mcpTools } from "./mcp-tools.js";
+export { ObserverEmitter } from "./events.js";
+export type {
+  ContextAssembledEvent,
+  RecallEvent,
+  StepEvent,
+  ObserverEventMap,
+  ObserverEventName,
+  ObserverListener,
+  Unsubscribe,
+} from "./events.js";
 export type { McpToolsOptions } from "./mcp-tools.js";
 export type {
   AgentifiedTool,

--- a/src/ts-packages/sdk/src/instance.ts
+++ b/src/ts-packages/sdk/src/instance.ts
@@ -1,4 +1,5 @@
 import type { ApiClient } from "./api-client.js";
+import type { ObserverEmitter } from "./events.js";
 import { Namespace } from "./namespace.js";
 import { Session } from "./session.js";
 import type { AgentifiedTool, DiscoverTool, PrepareStepFn } from "./types.js";
@@ -11,6 +12,7 @@ export class Instance {
     readonly datasetId: string,
     /** @internal */ private readonly sdk: ApiClient,
     /** @internal */ private readonly registeredTools: AgentifiedTool[],
+    /** @internal */ readonly emitter?: ObserverEmitter,
   ) {
     this.discoverTool = sdk.asDiscoverTool(datasetId);
   }
@@ -21,10 +23,10 @@ export class Instance {
   };
 
   session(id: string): Session {
-    return new Session(id, "default", this.sdk, this.datasetId, this.registeredTools);
+    return new Session(id, "default", this.sdk, this.datasetId, this.registeredTools, this.emitter);
   }
 
   namespace(id: string): Namespace {
-    return new Namespace(id, this.sdk, this.datasetId, this.registeredTools);
+    return new Namespace(id, this.sdk, this.datasetId, this.registeredTools, this.emitter);
   }
 }

--- a/src/ts-packages/sdk/src/namespace.ts
+++ b/src/ts-packages/sdk/src/namespace.ts
@@ -1,4 +1,5 @@
 import type { ApiClient } from "./api-client.js";
+import type { ObserverEmitter } from "./events.js";
 import { Session } from "./session.js";
 import type { AgentifiedTool } from "./types.js";
 
@@ -11,9 +12,10 @@ export class Namespace {
     /** @internal */ private readonly sdk: ApiClient,
     /** @internal */ private readonly datasetId: string,
     /** @internal */ private readonly registeredTools: AgentifiedTool[],
+    /** @internal */ readonly emitter?: ObserverEmitter,
   ) {}
 
   session(id: string): Session {
-    return new Session(id, this.id, this.sdk, this.datasetId, this.registeredTools);
+    return new Session(id, this.id, this.sdk, this.datasetId, this.registeredTools, this.emitter);
   }
 }

--- a/src/ts-packages/sdk/src/session.ts
+++ b/src/ts-packages/sdk/src/session.ts
@@ -1,6 +1,7 @@
 import type { ApiClient } from "./api-client.js";
 import { ContextBuilder } from "./context-builder.js";
 import { Conversation } from "./conversation.js";
+import type { ObserverEmitter } from "./events.js";
 import type { AgentifiedTool, GetMessagesTool, GetMessagesOptions, GetMessagesResult, PrepareStepFn } from "./types.js";
 
 export class Session {
@@ -15,8 +16,9 @@ export class Session {
     readonly id: string,
     readonly namespaceId: string,
     /** @internal */ private readonly sdk: ApiClient,
-    /** @internal */ private readonly datasetId: string,
+    /** @internal */ readonly datasetId: string,
     /** @internal */ private readonly registeredTools: AgentifiedTool[],
+    /** @internal */ readonly emitter?: ObserverEmitter,
   ) {
     this.conversation = new Conversation(sdk, datasetId, namespaceId, id);
     this._discoverTool = sdk.asDiscoverTool(datasetId, namespaceId, id);
@@ -27,6 +29,7 @@ export class Session {
       this.sdk, this.datasetId, this.namespaceId, this.id,
       this.registeredTools,
       this._discoverTool.discoveredNames,
+      this.emitter,
     );
   }
 


### PR DESCRIPTION
## Summary

First-class `on(...)` subscription API on both TS and Python SDKs so consumers can receive metrics fire-and-forget instead of destructuring every assembled context. Unblocks the demo/playground refactor ([AGE-137](https://linear.app/agentified/issue/AGE-137)) where the generated code becomes the idiomatic `.recall().messages().assemble()` + `agent.generate()` + `return { text }` — no boilerplate return block.

### API

- **TS SDK**: `ag.on("context:assembled" | "recall", cb)` with typed events and a disposer return value.
- **Mastra adapter**: `mag.on(...)` forwards SDK events + adds `"step"`; wire via `onStepFinish: session.onStepFinish` on `agent.generate()`.
- **Python SDK**: `ag.on("context_assembled" | "recall", cb)` — supports sync and async callbacks (coroutines are scheduled on the running loop).
- **LangChain adapter**: `lc.on(...)` + `instance.on("step", cb)` + `instance.on_step_finish(data)` for wiring per-node LangGraph post-hooks.

### Scope

- Additive only, no breaking changes.
- Events fire exactly once per underlying operation; no duplicates across adapter layers.
- Listener errors are swallowed; subscribers own their own batching/backpressure.

Closes AGE-195.

## Test plan

- [x] TS SDK events: 8 new tests (disposer, error-swallowing, multi-event, exact-once, payload)
- [x] Mastra events: 6 new tests (step index increments, session tagging, no-emitter safety)
- [x] Python SDK events: 11 new tests (sync + async, disposer, exact-once)
- [x] LangChain events: 2 new pass-through tests
- [x] Full TS test suite (ai-sdk, fe-client, mastra, react, sdk): 280 passed
- [x] Full Python test suite (sdk, langchain): 103 passed
- [x] Observability sections added to both SDK READMEs + Mastra + LangChain READMEs

## Out of scope

- OpenTelemetry exporter (can layer on top)
- Persisted metrics storage
- Demo migration PR in `agentified/platform` (separate — this PR only unblocks it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)