### PR TITLE
chore: release observer hooks (AGE-195)

### DIFF
--- a/src/py-packages/langchain/pyproject.toml
+++ b/src/py-packages/langchain/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentified-langchain"
-version = "0.2.0"
+version = "0.3.0"
 description = "LangChain adapter for Agentified — tool injection for LangChain/LangGraph agents"
 license = "MIT"
 requires-python = ">=3.10"
 dependencies = [
-    "agentified>=0.2.0",
+    "agentified>=0.3.0",
     "langchain-core>=0.3",
 ]
 

--- a/src/py-packages/sdk/pyproject.toml
+++ b/src/py-packages/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentified"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python SDK for Agentified — Context Intelligence Layer for AI agents"
 license = "MIT"
 requires-python = ">=3.10"

--- a/src/ts-packages/.changeset/observer-hooks.md
+++ b/src/ts-packages/.changeset/observer-hooks.md
@@ -1,0 +1,9 @@
+---
+"agentified": minor
+"@agentified/mastra": minor
+"@agentified/ai-sdk": minor
+"@agentified/fe-client": minor
+"@agentified/react": minor
+---
+
+Add observer hooks for context assembly + agent steps. New `ag.on("context:assembled" | "recall", cb)` on the SDK and `mag.on("step", cb)` on the Mastra adapter let consumers subscribe once and receive typed events with a disposer return. Additive — no breaking changes.


### PR DESCRIPTION
## Summary

Release PR for [AGE-195](https://linear.app/agentified/issue/AGE-195) (observer hooks for context assembly + agent steps, merged in #42).

**Changeset** — bumps all TS SDK packages:
- `agentified`: 0.2.0 → 0.3.0 (minor)
- `@agentified/mastra`: 2.0.0 → 2.1.0 (minor)
- `@agentified/ai-sdk`: 2.0.0 → 2.1.0 (minor)
- `@agentified/fe-client`: 0.0.9 → 0.1.0 (minor)
- `@agentified/react`: 0.0.9 → 0.1.0 (minor)

**Python version bumps**:
- `agentified`: 0.2.0 → 0.3.0
- `agentified-langchain`: 0.2.0 → 0.3.0 (also bumps `agentified>=0.3.0` dep constraint)

## Publish flow

- **On merge**: Python PyPI publishes **immediately** (workflow checks pyproject.toml against PyPI).
- **After merge**: changesets/action opens a *second* "version packages" PR that bumps `package.json` files — merging **that** PR triggers the npm publish.

## Test plan

- [x] Pre-commit hooks pass (typecheck, lint, TS + Python tests)
- [ ] On merge, verify PyPI publishes `agentified==0.3.0` and `agentified-langchain==0.3.0`
- [ ] Auto-generated "version packages" PR appears — review and merge to publish npm packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)