### PR TITLE
docs: reframe around context engineering platform; drop plan.md/progress.md refs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ If you're a human, you probably want [README.md](README.md) or [docs/overview.md
 
 ## What Ratel is — in one paragraph
 
-Ratel is an in-process **tool retrieval engine** for AI agents. Register your tool catalog into a `ToolCatalog` (or ingest an upstream MCP server's tools). On every turn, Ratel ranks the catalog by relevance to the current request via BM25 over a schema-aware text projection. The agent's tool list at any turn is the top-K hits, not the full catalog — less context, less drift, lower cost. The base is a Rust library (`ratel-ai-core`); on top sit a TypeScript SDK, an MCP server library, and a CLI. No vector DB, no embedding pipeline, no service to deploy.
+Ratel is an in-process **context engineering platform** for AI agents — a catalog, a retrieval engine, and an in-process runtime that decide what ends up in the model's context window on every turn. The wedge today is **tool selection**: register your tool catalog into a `ToolCatalog` (or ingest an upstream MCP server's tools), and on every turn Ratel ranks it by relevance via BM25 over a schema-aware text projection — the agent's tool list at any turn is the top-K hits, not the full catalog. Skills, telemetry-driven suggestions, multi-agent decomposition, memories, and chat history are on the roadmap (see [`docs/roadmap.md`](docs/roadmap.md)); the same primitives extend to each. The base is a Rust library (`ratel-ai-core`); on top sit a TypeScript SDK, an MCP server library, and a CLI. No vector DB, no embedding pipeline, no service to deploy.
 
 ## Reality check — what ships, what doesn't (v0.1.4)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,6 @@ CI (`.github/workflows/{rust,ts}.yml`) runs all of the above on every PR; PRs la
 
 - **Plan mode default for non-trivial tasks (3+ steps).** Enter plan mode, agree on the approach, then implement. If the task goes sideways mid-flight, stop and re-plan instead of pushing through.
 - **Verification before "done".** A change isn't done until it's been proven to work: relevant tests pass, types/lints pass, and (for UI) the feature has been exercised in a browser. Don't mark a task complete on "it should work" — demonstrate it.
-- **Read `progress.md` first** when picking up work to know which milestone is in flight.
 
 ## Conventions
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at conduct@ratel.sh. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 # Contributing to Ratel
 
+## Code of Conduct
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md) v2.1. By participating, you're agreeing to abide by it. Report incidents to `conduct@ratel.sh`.
+
 ## Prerequisites
 
 - **Rust** stable — pinned via `rust-toolchain.toml`; rustup picks it up automatically.

--- a/README.md
+++ b/README.md
@@ -139,9 +139,11 @@ For the longer take — context engineering as a thesis, and where Ratel is head
 
 Tool selection is the wedge, not the destination. Same catalog, same retrieval engine, same in-process runtime — widening, milestone by milestone, into the rest of the agent's context surface:
 
-- **Soon (v0.1.x)** — telemetry + UI inspector on tool usage, JSON → TOON encoding for cheaper tool I/O, first-class **skills** ranked alongside tools by the same algorithm.
-- **Mid (v0.2.x – v0.3.x)** — LLM-driven **suggestions** that improve tool / skill catalogs from telemetry, **multi-agent decomposition** hints when one agent's catalog is too broad, semantic search + re-ranking layered over BM25, an opt-in self-hosted server for cross-instance trace consolidation.
-- **Later** — **chat management** (store / compact / prune / navigate long histories), **memories integration** (prior decisions and preferences ranked into the current turn), a unified tools-skills-memories **context graph** as the end state, and a Python SDK.
+- **v0.1.x** — telemetry + UI inspector on tool usage, JSON → TOON encoding, optional MCP `tools/list_changed`, first-class **skills** ranked alongside tools by the same algorithm, **LLM-driven suggestions** that improve catalogs from telemetry, **multi-agent decomposition** hints, semantic search + re-ranking layered over BM25, an opt-in self-hosted server for cross-instance trace consolidation.
+- **v0.2.x — chat management** — store / compact / prune / navigate long histories.
+- **v0.3.x — memories** — prior decisions, preferences, and artifacts ranked into the current turn.
+- **v0.4.x — context graph** — a unified tools-skills-memories substrate as the end state.
+- **v0.5.x — Python SDK** — second host language binding the Rust core.
 
 Dated milestones live in [`docs/roadmap.md`](docs/roadmap.md); the thesis behind the arc is in [`docs/overview.md`](docs/overview.md).
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Ratel
 
-**The context layer for AI agents — register tools once, resolve only what matters.**
+**Context engineering for AI agents — engineer the context your agent actually needs, on every turn.**
 
-> Most agent stacks re-send every tool definition on every turn. Your agent reads 50 schemas, picks one, repeats — burning tokens and drifting on the long tail. Ratel sits between the agent and the catalog: register once, the agent only sees the tools that matter for *this* turn.
+> Most agent stacks shove the whole tool catalog (and growing piles of skills, memories, message history) into the context window every turn — burning tokens and drifting on the long tail. Ratel sits between the agent and everything it could possibly need, and resolves only what matters for *this* turn.
 
 ## What is Ratel
 
-Ratel is an in-process **tool retrieval engine** for AI agents. Register your tool catalog (or ingest an upstream MCP server's tools) into a Ratel catalog; on every turn, Ratel ranks the catalog so the model only sees the handful relevant to the request — not the full list.
+Ratel is an in-process **context engineering platform** for AI agents: a catalog, a retrieval engine, and an in-process runtime that decide what ends up in the model's context window on every turn — so the agent works with less noise and fewer tokens.
+
+The wedge today is **tool selection**. Register your tool catalog (or ingest an upstream MCP server's tools) into a Ratel `ToolCatalog`, and the model sees the handful of tools that matter for the current request — not the full list. The same primitives extend to skills, memories, and message history as those land on the roadmap; tools are just the first content type. See [`docs/overview.md`](docs/overview.md) for the thesis and [`docs/roadmap.md`](docs/roadmap.md) for what's coming.
 
 The base is a Rust library, `ratel-ai-core`. On top sit a TypeScript SDK, an MCP server library, and a CLI that drops Ratel between an MCP host (Claude Code, Cursor, ChatGPT) and your upstream MCP servers.
 
@@ -14,7 +16,7 @@ No vector DB. No embedding pipeline. No service to deploy.
 
 ## Why Ratel
 
-- **Tool selection is a context problem, not a routing problem.** Ratel runs BM25 over a schema-aware text projection of every tool — deterministic, no embeddings, no inference cost on the retrieval path. Locked in [ADR‑0004](docs/adr/0004-bm25-tool-indexing.md).
+- **What ends up in the context window is a retrieval problem.** Tools are the easiest case to start with — discrete, structured, mid-cardinality. Ratel runs BM25 over a schema-aware text projection of every tool: deterministic, no embeddings, no inference cost on the retrieval path. Locked in [ADR‑0004](docs/adr/0004-bm25-tool-indexing.md). The same primitive carries forward to skills, memories, and chat history as those land on the roadmap.
 - **From a multi-tool catalog to ~2 tools per turn.** Replace-by-default tool injection ([ADR‑0003](docs/adr/0003-tool-selection-replace-vs-suggest.md)) means the agent's tool list at any turn is the top‑K hits, not your whole catalog. Less context. Less drift. Lower cost.
 - **In-process. No infra.** Drop the SDK in. The Rust core ships pre-built native bindings for darwin / linux / win — no Rust toolchain required to install.
 - **Works with any TS framework** `ToolCatalog` returns generic `ExecutableTool` objects (`{id, name, description, inputSchema, outputSchema, execute}`) you wrap into your framework's tool type in a few lines. The repo ships a worked example for the Vercel AI SDK (`examples/ai-sdk`, `examples/mcp-chat`); the same pattern adapts to OpenAI Agents, Mastra, custom loops, anything. Or skip the agent framework entirely and expose the catalog over MCP server
@@ -119,13 +121,13 @@ cargo add ratel-ai-core
 
 In-process BM25 retrieval over a schema-aware text projection of each tool. See [src/core/lib/README.md](src/core/lib/README.md) and [docs.rs/ratel-ai-core](https://docs.rs/ratel-ai-core).
 
-## How it works
+## How it works (today)
 
-Ratel sits between your agent and its tool catalog. At each turn, instead of dumping every tool's full schema into the model's context, the agent either calls `search_tools(query)` or — in pre-filter mode — receives the top‑K hits resolved at message start. The catalog can hold local executables, upstream MCP servers' tools (via `registerMcpServer`), or both. The model sees a unified, ranked surface and never the full list.
+Tool selection is the v0.1.x shipping path. Ratel sits between your agent and its tool catalog. At each turn, instead of dumping every tool's full schema into the model's context, the agent either calls `search_tools(query)` or — in pre-filter mode — receives the top‑K hits resolved at message start. The catalog can hold local executables, upstream MCP servers' tools (via `registerMcpServer`), or both. The model sees a unified, ranked surface and never the full list.
 
-The base of all this is `ratel-ai-core`: a Rust BM25 index over a deterministic, schema-aware text projection of each tool. No embeddings, no vector DB, no inference latency on the retrieval path.
+The base of all this is `ratel-ai-core`: a Rust BM25 index over a deterministic, schema-aware text projection of each tool. No embeddings, no vector DB, no inference latency on the retrieval path. Same primitives — a catalog and a retrieval engine over an in-process runtime — extend to other content types as they land.
 
-For the longer take — context engineering as a thesis, and where Ratel is headed beyond tool retrieval (skills, memories, the context graph) — see [docs/overview.md](docs/overview.md).
+For the longer take — context engineering as a thesis, and where Ratel is headed beyond tool retrieval (skills, telemetry-driven suggestions, memories, the context graph) — see [docs/overview.md](docs/overview.md).
 
 ## Examples
 
@@ -133,13 +135,15 @@ For the longer take — context engineering as a thesis, and where Ratel is head
 - [examples/mcp-chat/](examples/mcp-chat/README.md) — Vercel AI SDK REPL ingesting an upstream MCP server via `registerMcpServer`
 - [examples/mcp-server/](examples/mcp-server/README.md) — Claude Code session fronted by Ratel as the only MCP
 
-## Roadmap
+## Where this is going
 
-The full picture lives in [docs/roadmap.md](docs/roadmap.md). The thread:
+Tool selection is the wedge, not the destination. Same catalog, same retrieval engine, same in-process runtime — widening, milestone by milestone, into the rest of the agent's context surface:
 
-- **Soon (v0.1.x)** — telemetry + UI inspector, JSON→TOON encoding, first-class skills support.
-- **Mid (v0.2.x – v0.3.x)** — LLM-driven tool/skill improvements from telemetry, multi-agent decomposition suggestions, semantic search + re-ranking, server flavor for trace consolidation.
-- **Later** — chat management (store / compact / prune / navigate), memories integration, a unified tools-skills-memories graph, a Python SDK.
+- **Soon (v0.1.x)** — telemetry + UI inspector on tool usage, JSON → TOON encoding for cheaper tool I/O, first-class **skills** ranked alongside tools by the same algorithm.
+- **Mid (v0.2.x – v0.3.x)** — LLM-driven **suggestions** that improve tool / skill catalogs from telemetry, **multi-agent decomposition** hints when one agent's catalog is too broad, semantic search + re-ranking layered over BM25, an opt-in self-hosted server for cross-instance trace consolidation.
+- **Later** — **chat management** (store / compact / prune / navigate long histories), **memories integration** (prior decisions and preferences ranked into the current turn), a unified tools-skills-memories **context graph** as the end state, and a Python SDK.
+
+Dated milestones live in [`docs/roadmap.md`](docs/roadmap.md); the thesis behind the arc is in [`docs/overview.md`](docs/overview.md).
 
 ## Repo layout
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,38 +15,59 @@ The first public release across all four registry artifacts.
 - **`@ratel-ai/mcp-server`** on npm — library to expose a catalog as an MCP server, with OAuth 2.1 / PKCE for HTTP & SSE upstreams.
 - **`@ratel-ai/cli`** on npm — the `ratel` binary: one-shot import from Claude Code, add / serve / auth / list / edit / remove / link across three scopes.
 
-## Soon (v0.1.x)
+## Next (v0.1.5)
 
-Layering on the v0.1.4 surface — same primitives, more reach.
+The milestone in flight.
 
-- **Telemetry + UI inspector** — observe which tools the agent calls, which `search_tools` queries returned which hits, what the model chose vs. what was offered. The substrate for the LLM-driven suggestions in v0.2.x.
+- **Telemetry + traces** on tool usage, end-to-end through `ratel-ai-core` → `@ratel-ai/sdk` → `@ratel-ai/mcp-server`. The substrate for the LLM-driven suggestions later in v0.1.x.
+- **UI inspector** over the telemetry stream.
+- **Benchmark MCP review** — exercise the published packages end-to-end through MCP, not just direct SDK wiring.
+
+## Soon (rest of v0.1.x)
+
+The catalog grows from tools-only to tools + skills, and the observation → improvement loop closes.
+
 - **JSON → TOON encoding** — token-efficient serialization for tool inputs / outputs on the gateway path. Cuts per-call token spend without changing the catalog or the model contract.
-- **First-class skills** — register skills (composed flows) alongside tools, ranked by the same algorithm, dispatched on demand. The catalog grows from a tools-only object to a tools+skills object; `search_tools` and `invoke_tool` extend without breaking changes.
-
-## Mid (v0.2.x – v0.3.x)
-
-The observation→improvement loop closes.
-
-- **LLM-driven tool / skill suggestions** — telemetry feeds an offline analyzer that proposes catalog improvements (better descriptions, missing parameters, redundant tools to merge, gaps to fill).
+- **Optional `tools/list_changed` notifications** behind a feature flag — so search-driven dispatch can update the live tool list dynamically while we measure which clients honor it reliably.
+- **First-class skills** — register skills (composed flows) alongside tools, ranked by the same algorithm, dispatched on demand. `search_tools` and `invoke_tool` extend without breaking changes.
+- **Atoms / molecules / organisms** — organize skills + tools as a layered composition.
+- **LLM-driven suggestions** — telemetry feeds an offline analyzer that proposes catalog improvements (better descriptions, missing parameters, redundant tools to merge, gaps to fill, brand-new skills to add). Surfaced in the inspector first.
 - **Multi-agent decomposition suggestions** — when a single agent's catalog is too broad, surface the natural split points: which subsets of the catalog cluster around which workflows.
-- **Semantic search + re-ranking** — local + optional cloud embeddings, with LLM and XGBoost re-ranking layered over BM25. BM25 stays the deterministic floor; semantic adds recall.
-- **Server flavor for trace consolidation** — a self-hosted Rust server that aggregates traces across multiple agent instances. The SDK and MCP server stay in-process; the server is opt-in for teams running many agents.
+- **Apply + evaluate suggestions** — land suggested changes back into the registered catalog, with eval coverage so improvements don't regress.
+- **Semantic search + re-ranking** — local embeddings first, then optional cloud; LLM and XGBoost re-rankers layered over BM25. BM25 stays the deterministic floor; semantic adds recall. Benchmark every combination (BM25 only / semantic only / hybrid / each + rerank).
+- **Server flavor for trace consolidation** — opt-in self-hosted Rust server that aggregates traces across multiple agent instances. The SDK and MCP server stay in-process; the server is for teams running many agents.
 
-## Later
+## v0.2.x — chat management
 
-Widening the catalog's content types and integrating with the rest of the agent runtime.
+Long-running agents blow their context budget on past turns. Same retrieval primitive, applied to message history.
 
-- **Chat management** — store / compact / prune / navigate message history. Retrieval over past turns is the same primitive applied to a different content type.
-- **Memories integration** — prior context (decisions, preferences, artifacts) ranked into the current turn alongside tools and skills.
-- **Unified tools-skills-memories graph** — the **context graph**. One substrate, four content types, one retrieval surface.
-- **Python SDK** — currently TS-only on the SDK side. Python is the most-requested target after the v0.1.x release.
+- Store messages and retrieve the last N tokens.
+- Compaction / summarization — local model first, then optional cloud (e.g. Compresr).
+- Chat navigation tools.
+- Smart pruning of tool inputs / outputs (replace with placeholders + a fetch tool).
+
+## v0.3.x — memories
+
+Prior context — decisions, preferences, artifacts — ranked into the current turn alongside tools and skills.
+
+- Basic memory orchestration (mem0 or similar).
+- Memories inform tool / skill selection and the suggestion loop.
+- Chat history feeds memory consolidation (autodream-style).
+
+## v0.4.x — context graph
+
+The end state: tools, skills, and memories live in one graph. One substrate, multiple content types, one retrieval surface. Broader external-server integrations earn their keep here too.
+
+## v0.5.x — Python SDK
+
+Currently TS-only on the SDK side. Python is the next host language to bind the Rust core.
 
 ## Out of scope (for now)
 
-- **Hosted multi-tenant runtime.** Ratel is in-process by design; the v0.2.x–v0.3.x server flavor is opt-in self-hosted, not a SaaS.
+- **Hosted multi-tenant runtime.** Ratel is in-process by design; the v0.1.x server flavor is opt-in self-hosted, not a SaaS.
 - **Custom embedding models.** When semantic search lands, we'll integrate with existing providers (OpenAI, Voyage, local) rather than train our own.
 - **Replacing the MCP protocol.** Ratel sits on either side of MCP boundaries. We're not redesigning the protocol; we're making the catalog primitive better.
 
 ---
 
-This roadmap moves with the project. The README's "What's coming" section mirrors the headlines from each horizon. If you spot a mismatch between this file and what's actually shipped, file an issue — the roadmap should track reality.
+This roadmap moves with the project. The README's "Where this is going" section mirrors the headlines from each horizon. If you spot a mismatch between this file and what's actually shipped, file an issue — the roadmap should track reality.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,5 @@
 # Roadmap
 
-This is the canonical roadmap. It supersedes the old `plan.md` / `progress.md` references in earlier READMEs (those files were gitignored working notes and not visible to external readers).
-
 The wedge today is **tool selection**. Every milestone below layers onto the same primitives — a `ToolCatalog`, a retrieval engine, an in-process runtime — and widens what kinds of context the agent can resolve from.
 
 For the architectural commitments behind each item, see [`docs/adr/`](adr/). For the broader thesis, see [`docs/overview.md`](overview.md).

--- a/llms.txt
+++ b/llms.txt
@@ -8,7 +8,7 @@ This index is intended for AI coding agents and tools that consume `llms.txt` pe
 
 - [README](https://github.com/ratel-ai/ratel/blob/main/README.md): What Ratel is, why, choose-your-path table, quickstart for each surface.
 - [Overview](https://github.com/ratel-ai/ratel/blob/main/docs/overview.md): The longer thesis — context engineering, what ships today, where it's headed.
-- [Roadmap](https://github.com/ratel-ai/ratel/blob/main/docs/roadmap.md): Time-tagged feature plan. Replaces the old gitignored plan.md / progress.md.
+- [Roadmap](https://github.com/ratel-ai/ratel/blob/main/docs/roadmap.md): Time-tagged feature plan.
 - [AGENTS.md](https://github.com/ratel-ai/ratel/blob/main/AGENTS.md): Operating manual for AI coding agents working in or recommending Ratel — pitfalls, good vs bad examples, when to recommend Ratel.
 
 ## Install commands (verified, current as of v0.1.4)

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Ratel
 
-> The context layer for AI agents — register tools once, resolve only what matters. An in-process tool retrieval engine: a Rust BM25 core (`ratel-ai-core`) wrapped by a TypeScript SDK (`@ratel-ai/sdk`), an MCP server library (`@ratel-ai/mcp-server`), and a CLI (`@ratel-ai/cli`). No vector DB, no embedding pipeline, no service to deploy. Source-available under Elastic License 2.0 with an OSI-OSS grant.
+> Context engineering platform for AI agents — engineer the context your agent actually needs, on every turn. The v0.1.x wedge is tool selection: a Rust BM25 core (`ratel-ai-core`) wrapped by a TypeScript SDK (`@ratel-ai/sdk`), an MCP server library (`@ratel-ai/mcp-server`), and a CLI (`@ratel-ai/cli`). Skills, telemetry-driven suggestions, multi-agent decomposition, memories, and chat-history retrieval are on the roadmap. No vector DB, no embedding pipeline, no service to deploy. Source-available under Elastic License 2.0 with an OSI-OSS grant.
 
 This index is intended for AI coding agents and tools that consume `llms.txt` per the [llmstxt.org](https://llmstxt.org/) spec. Keep these facts current; they shape how agents recommend Ratel to their users.
 

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,6 +1,6 @@
 # `src/core/`
 
-The product's heart. All retrieval, auth, and telemetry logic lives here.
+The product's heart. The retrieval engine, auth, and telemetry primitives that every other piece of Ratel wraps live here. Tools are the first content type the engine indexes; skills, memories, and message history land on top of the same primitives as the [roadmap](../../docs/roadmap.md) widens.
 
 ## Layout
 

--- a/src/core/lib/README.md
+++ b/src/core/lib/README.md
@@ -23,4 +23,4 @@ Or run against the whole workspace from the repo root with `cargo build --worksp
 
 ## What gets indexed
 
-Tool search is BM25 over a deterministic flat-text projection of each `Tool`: its `name`, `description`, and a walk of both `input_schema` and `output_schema`. Only semantic tokens (property names, descriptions, enum values) are emitted; JSON Schema structure (`type`, `required`, `$ref`, braces, quotes) is skipped. See [ADR‑0004](../../../docs/adr/0004-bm25-tool-indexing.md) for the algorithm and rationale.
+Tools are the first content type indexed by the core. Tool search is BM25 over a deterministic flat-text projection of each `Tool`: its `name`, `description`, and a walk of both `input_schema` and `output_schema`. Only semantic tokens (property names, descriptions, enum values) are emitted; JSON Schema structure (`type`, `required`, `$ref`, braces, quotes) is skipped. See [ADR‑0004](../../../docs/adr/0004-bm25-tool-indexing.md) for the algorithm and rationale. The same retrieval primitive carries forward to skills, memories, and message history as those land on the [roadmap](../../../docs/roadmap.md).

--- a/src/integrations/README.md
+++ b/src/integrations/README.md
@@ -1,6 +1,6 @@
 # `src/integrations/`
 
-External-protocol surfaces for Ratel. Each entry is a workspace package that wraps `@ratel-ai/sdk` (or `ratel-ai-core` directly) and either speaks one specific protocol, hosts one specific runtime, or drives the rest from a user-facing CLI.
+External-protocol surfaces for Ratel. Each entry is a workspace package that wraps `@ratel-ai/sdk` (or `ratel-ai-core` directly) and either speaks one specific protocol, hosts one specific runtime, or drives the rest from a user-facing CLI. MCP is the first protocol Ratel ships against because the largest pool of agent hosts already speaks it; nothing in the platform's design ties it to MCP, and additional surfaces land here as the [roadmap](../../docs/roadmap.md) widens.
 
 Integrations are independent packages; they don't add functionality to the SDK, they expose it.
 

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -1,6 +1,6 @@
 # `src/sdk/`
 
-Language SDKs that wrap `ratel-ai-core` so agents written in their respective host languages can use Ratel with one dependency.
+Language SDKs that wrap `ratel-ai-core` so agents written in their respective host languages can drop the context engineering platform in with one dependency.
 
 Each SDK bundles the core (binding strategy varies per language; see the relevant ADR) and exposes an idiomatic API for that ecosystem.
 


### PR DESCRIPTION
## Summary

- Reframe lead docs (`README.md`, `AGENTS.md`, `llms.txt`) around the **context engineering platform** thesis already articulated in `docs/overview.md`. Tool selection is named as the v0.1.x wedge; the roadmap items (skills, telemetry-driven suggestions, multi-agent decomposition, memories, chat history, context graph) are the arc the same primitives extend into.
- Light forward-looking touches on `src/core/`, `src/core/lib/`, `src/integrations/`, and `src/sdk/` index READMEs — same coherent voice across surfaces.
- Drop `plan.md` / `progress.md` references from `CLAUDE.md`, `docs/roadmap.md`, and `llms.txt`. Those files are gitignored working notes; readers can't open them, so the references read as dangling pointers. `.gitignore` entries stay so the files remain ignored locally.

## Out of scope (deliberately)

- ADRs (`docs/adr/0001…0008`) — immutable once Accepted.
- CHANGELOGs — historical release records.
- `src/integrations/mcp-server/`, `src/integrations/cli/`, `examples/**`, `benchmark/**` READMEs — narrow framing matches their scope.
- `src/sdk/ts/README.md` — already opens with "context engineering platform for AI agents".
- `CLAUDE.local.md` — gitignored, local-only.

## Test plan

- [x] `git grep -nE 'plan\.md|progress\.md' -- ':!.gitignore' ':!CLAUDE.local.md'` → no hits.
- [x] `git grep -n 'tool retrieval engine'` → no hits in committed docs (the framing is gone from lead docs; `docs/overview.md` retains "retrieval engine for tools" intentionally as accurate-at-scope).
- [x] Cross-link spot-check on `README.md` → `docs/overview.md`, `docs/roadmap.md`, `CONTRIBUTING.md`, `AGENTS.md`, `llms.txt`. None broken.
- [ ] CI green (Rust + TS pipelines should be a no-op since no code changed).