### PR TITLE
v0.1.5: telemetry — core-owned trace stream, JSONL by default, ratel inspect

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,9 @@ name = "ratel-ai-core"
 version = "0.1.5-rc.3"
 dependencies = [
  "bm25",
+ "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ pnpm add -g @ratel-ai/cli
 
 ratel mcp import   # interactive: scans ~/.claude.json + per-project .mcp.json,
                    # cherry-pick which upstreams to move into Ratel,
-                   # rewrites Claude Code to launch `ratel mcp serve`.
+                   # rewrites Claude Code to launch `ratel serve`.
 
 ratel backup undo  # roll back any time — every change writes a timestamped backup under ~/.ratel/backups/.
 ```

--- a/docs/adr/0009-trace-events-core-owned-schema.md
+++ b/docs/adr/0009-trace-events-core-owned-schema.md
@@ -1,0 +1,74 @@
+# 9. Trace events — core-owned schema, single stream, query-log semantics
+
+Date: 2026-05-08
+
+## Status
+
+Proposed
+
+## Context
+
+v0.1.5 puts telemetry on the critical path: traces of tool usage end-to-end through `ratel-ai-core` → `@ratel-ai/sdk` → `@ratel-ai/mcp-server`, plus a UI inspector over the resulting stream. The same stream is the substrate for what comes next — XGBoost / LLM re-ranking (v0.1.14–15), LLM-driven catalog suggestions (v0.1.9), multi-agent decomposition hints (v0.1.10), and the optional self-hosted trace consolidation server (v0.1.x tail).
+
+Two questions stack:
+
+1. **Where does the trace data model live?** `ratel-ai-core` is intentionally tiny today — `Tool`, `ToolRegistry::register`, `ToolRegistry::search`, `SearchHit`, the schema-aware indexing walk. Everything else — execution dispatch (`ToolCatalog.invoke`), the `search_tools` / `invoke_tool` gateway tools, MCP ingest via `registerMcpServer`, OAuth / `needs_auth` semantics — lives in TypeScript. A reflexive "telemetry goes in the core" answer would only cover ranking events; the most interesting events (what the agent actually invoked, with which args, with what outcome) never cross into Rust.
+
+2. **Are internal-feedback traces and external observability the same stream or two?** A natural framing splits them: an "oplog" that feeds rerankers and the suggestion analyzer (consumed *inside* the system) versus "telemetry" that drives the inspector (consumed *outside*). They overlap heavily — a search event with query, hits, scores, latency feeds both — so it's worth pinning whether they are one stream with multiple consumers or two parallel emission paths.
+
+The mental model that drove this ADR: think of `ratel-ai-core` as a database, the trace stream as `pg_stat_statements` (not the WAL — see below), and downstream rerankers / suggestion analyzers as planner-like consumers of usage data. Inspector and external trace consolidation are additional consumers of the same data.
+
+## Decision
+
+### Schema and sink ownership
+
+The **trace event data model and the sink trait live in `ratel-ai-core`**. Every host language (TS today, Python in v0.5.x) emits into the same shape; every consumer (reranker training, LLM-suggestion analyzer, inspector, future trace-consolidation server) reads the same shape. The schema is the cross-language contract; placing it anywhere else forces re-definition per host language and blocks training a single reranker on cross-host data.
+
+Concrete events the schema covers from day one: search, invocation (start / end / error), gateway-tool calls (`search_tools`, `invoke_tool`), upstream-MCP ingest, auth / `needs_auth`. The set is open-ended; new event types are additions, not breaking changes.
+
+### Single stream, multiple consumers
+
+**One tagged event stream. Filtering happens at the consumer**, not at the producer. Reranker training subscribes to a cut (search ↔ invoke pairs with outcome); the inspector subscribes to everything; the suggestion analyzer subscribes to a different cut. This avoids double instrumentation and the drift between two pipes the "internal vs external" framing would have created.
+
+### Query-log semantics, not oplog semantics
+
+Tool invocations and search calls are **observations of usage**, not state mutations of the catalog. The closest database analogue is `pg_stat_statements` or a slow-query log, not the WAL. This pins the reliability profile:
+
+- **Best-effort, sampleable, lossy on backpressure.** Losing a trace event is acceptable; corrupting the catalog is not.
+- **Loose / causal ordering**, not strict serialization. Per-event timestamps are enough; total order is not required.
+- **No synchronous durability on the hot path.** In-memory ring buffer in core, periodic flush. Sampling rate is a knob.
+
+This is a deliberate departure from the oplog framing: oplog-grade reliability would over-engineer durability and ordering guarantees that aren't load-bearing for any consumer we have planned, and would pay that cost on every search and invoke.
+
+### SDK → core communication: synchronous NAPI call per event
+
+Because execution lives in the SDK, the SDK records invocation, gateway, and MCP-ingest events into the core sink via NAPI. **Synchronous call per event** for v0.1.5 — one NAPI hop is negligible against the LLM call that brackets each invocation, and keeping persistence / sampling / retention in one place (Rust) keeps the data-integrity story trivial. Async / batched emission is a future optimization, not a v0.1.5 concern.
+
+`@ratel-ai/mcp-server` emits the auth-shaped events (refresh attempts, 401-driven `needs_auth`, OAuth flow start/finish) into the same sink via the same path.
+
+### Producer responsibilities by layer
+
+| Layer | Events it produces |
+|---|---|
+| `ratel-ai-core` | search (query, hit ids, scores, latency); index churn |
+| `@ratel-ai/sdk` | invoke start / end / error (toolId, args-shape, latency, outcome); gateway-tool calls; upstream MCP ingest |
+| `@ratel-ai/mcp-server` | OAuth refresh, `needs_auth`, auth-flow start / completion |
+
+The **inspector and the rerankers consume the same stream**, just with different filters. The optional self-hosted trace-consolidation server (v0.1.x tail) also consumes this stream — its existence is the strongest argument for the schema being cross-language and core-owned.
+
+## Consequences
+
+- **Cross-language reuse is built in.** A future Python SDK binds the same Rust trace API and emits the same shapes; a single reranker trains on the union of TS- and Python-emitted events without a schema-translation layer.
+- **The data contract for v0.1.9 (suggestions), v0.1.14–15 (rerankers), and the consolidation server is locked at v0.1.5.** Adding events later is non-breaking; renaming or removing them is. Treat the schema with the same care as `Tool` and the `searchable_text` projection (per ADR-0004).
+- **The inspector is a downstream concern, not a separate pipeline.** It consumes the same events the rerankers do, with a different cut. Build the producer once.
+- **Sampling and retention are core-owned knobs.** Every host language inherits them; per-language overrides aren't planned.
+- **Future move of execution into Rust pays off automatically.** If local executables / WASM tools ever run inside the core, they record into the same log with no second pipeline.
+- **The "internal vs external" mental split survives as a consumer concern.** It's still useful for reasoning about which events feed the learning loop vs. the human surface, but it does not show up in the producer architecture.
+
+## Rejected
+
+- **Pure Rust-side telemetry.** Misses invoke, gateway, and auth events — the most interesting half of the surface — because execution and OAuth live in TS today. A telemetry milestone that omits invocation outcomes can't feed reranker training or the suggestion analyzer.
+- **Pure SDK-side telemetry.** Duplicates the schema for the future Python SDK and for the trace-consolidation server, and forces every cross-language consumer to learn N event shapes. Also strands the search events (the only events Rust can natively observe) outside the trace pipeline.
+- **Two parallel streams ("oplog" for internal, "telemetry" for external).** The producer-level event set overlaps heavily; the split is real at the *consumer* boundary, not the producer one. Two pipes means double instrumentation, two chances to forget, and two places for the schemas to drift.
+- **Oplog-grade reliability for trace events.** Tool invocations don't mutate registry state — they're query-log shaped. Synchronous fsync per event, strict ordering, and no-loss durability would impose hot-path cost on every search and invoke for guarantees no consumer needs.
+- **Async / batched NAPI emission for v0.1.5.** The hop cost is negligible against the LLM call bracketing each invocation, and JS-side buffering would split persistence ownership across the NAPI boundary. Revisit only if profiling surfaces real overhead.

--- a/docs/adr/0009-trace-events-core-owned-schema.md
+++ b/docs/adr/0009-trace-events-core-owned-schema.md
@@ -4,7 +4,7 @@ Date: 2026-05-08
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/0009-trace-events-core-owned-schema.md
+++ b/docs/adr/0009-trace-events-core-owned-schema.md
@@ -46,6 +46,10 @@ Because execution lives in the SDK, the SDK records invocation, gateway, and MCP
 
 `@ratel-ai/mcp-server` emits the auth-shaped events (refresh attempts, 401-driven `needs_auth`, OAuth flow start/finish) into the same sink via the same path.
 
+### On-disk layout: per-project buckets
+
+The CLI's default JSONL sink writes each session under `~/.ratel/telemetry/<project-slug>/<session-id>.jsonl`. The slug is `process.cwd()` at serve time with every `/` and `.` replaced by `-`, **mirroring Claude Code's `~/.claude/projects/<slug>/` convention bit-for-bit** so the bucket is recognisable to anyone who's seen CC's project directories. `ratel inspect` defaults to the bucket for the current cwd (strict — refuses to surface another project's telemetry), with `--all` to scan every bucket and `--project <abs-path>` to target one explicitly. The slugging logic lives entirely in the CLI; the core's `JsonlSink` accepts any path. `--telemetry-file` overrides skip slugging and write to the literal path. `RATEL_TELEMETRY_DIR` overrides the root that buckets nest under.
+
 ### Producer responsibilities by layer
 
 | Layer | Events it produces |

--- a/examples/mcp-server/claude-with-ratel.template.json
+++ b/examples/mcp-server/claude-with-ratel.template.json
@@ -4,7 +4,6 @@
       "command": "node",
       "args": [
         "<REPO_ROOT>/src/integrations/cli/dist/bin.js",
-        "mcp",
         "serve",
         "--config",
         "<REPO_ROOT>/examples/mcp-server/ratel-config.json"

--- a/src/core/lib/CHANGELOG.md
+++ b/src/core/lib/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+### Added
+
+- `trace` module: `TraceEvent` tagged enum, `TraceEnvelope`, `TraceSink` trait with `NoopSink`, `MemorySink`, and `JsonlSink` (synchronous `O_APPEND`, mode `0600` on Unix) — single tagged event stream per [ADR-0009](../../../docs/adr/0009-trace-events-core-owned-schema.md). `ToolRegistry::with_trace_sink` / `set_trace_sink` / `record_event` plus a `search_with_origin` method. `register` emits `index_churn{Add}`; `search` emits `search` with a `bm25` stage.
+
 ## [0.1.5-rc.3] - 2026-05-08
 
 _No crate-specific changes; released in lockstep with the workspace._

--- a/src/core/lib/Cargo.toml
+++ b/src/core/lib/Cargo.toml
@@ -14,4 +14,8 @@ categories = ["text-processing", "algorithms"]
 
 [dependencies]
 bm25 = "2.3"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/core/lib/README.md
+++ b/src/core/lib/README.md
@@ -41,3 +41,27 @@ Or run against the whole workspace from the repo root with `cargo build --worksp
 ## What gets indexed
 
 Tools are the first content type indexed by the core. Tool search is BM25 over a deterministic flat-text projection of each `Tool`: its `name`, `description`, and a walk of both `input_schema` and `output_schema`. Only semantic tokens (property names, descriptions, enum values) are emitted; JSON Schema structure (`type`, `required`, `$ref`, braces, quotes) is skipped. See [ADR‑0004](../../../docs/adr/0004-bm25-tool-indexing.md) for the algorithm and rationale. The same retrieval primitive carries forward to skills, memories, and message history as those land on the [roadmap](../../../docs/roadmap.md).
+
+## Trace stream
+
+Every layer of Ratel — core, SDK, mcp-server — emits into a single tagged event stream owned by this crate ([ADR‑0009](../../../docs/adr/0009-trace-events-core-owned-schema.md)). One stream, multiple consumers (inspector, suggestion analyzer, future rerankers and consolidation server), filtered at the consumer.
+
+```rust
+use std::sync::Arc;
+use ratel_ai_core::{JsonlSink, ToolRegistry, TraceEvent};
+
+let sink = Arc::new(JsonlSink::new("session-1", "/tmp/ratel.jsonl")?);
+let mut registry = ToolRegistry::with_trace_sink(sink);
+registry.register(my_tool);
+let _ = registry.search("read a file", 5);
+// every `register` and `search` is now appended as one JSON line.
+```
+
+Built-in sinks:
+- `NoopSink` — default; drops everything.
+- `MemorySink` — `Vec`-backed for tests and embedder assertions (`snapshot()`, `drain()`).
+- `JsonlSink` — synchronous `O_APPEND` per event, mode `0600` on Unix.
+
+Schema: `TraceEvent` is a tagged enum (search, index_churn, invoke_*, gateway_*, upstream_*, auth_*) wrapped in `TraceEnvelope { v, ts, session_id, ...event }`. The reliability profile is **query-log shaped** — best-effort, sampleable, lossy on backpressure. See ADR-0009 for the full rationale.
+
+The custom `TraceSink` trait lets embedders forward events to their own pipeline (HTTP, structured logger, ring buffer). The trait carries a `sample_rate()` knob (defaulting to `1.0`); the rate-limiter implementation is deferred to a later release.

--- a/src/core/lib/src/lib.rs
+++ b/src/core/lib/src/lib.rs
@@ -5,6 +5,11 @@
 mod indexing;
 mod registry;
 mod tool;
+mod trace;
 
 pub use registry::{SearchHit, ToolRegistry};
 pub use tool::Tool;
+pub use trace::{
+    ChurnKind, JsonlSink, MemorySink, NoopSink, Origin, SearchHitTrace, SearchStage, TraceEnvelope,
+    TraceEvent, TraceSink,
+};

--- a/src/core/lib/src/registry.rs
+++ b/src/core/lib/src/registry.rs
@@ -62,7 +62,7 @@ impl ToolRegistry {
     }
 
     pub fn search(&self, query: &str, top_k: usize) -> Vec<SearchHit> {
-        self.search_with_origin(query, top_k, Origin::User)
+        self.search_with_origin(query, top_k, Origin::Direct)
     }
 
     pub fn search_with_origin(&self, query: &str, top_k: usize, origin: Origin) -> Vec<SearchHit> {

--- a/src/core/lib/src/registry.rs
+++ b/src/core/lib/src/registry.rs
@@ -1,7 +1,13 @@
+use std::sync::Arc;
+use std::time::Instant;
+
 use bm25::{Document, Language, SearchEngineBuilder};
 
 use crate::indexing::searchable_text;
 use crate::tool::Tool;
+use crate::trace::{
+    ChurnKind, NoopSink, Origin, SearchHitTrace, SearchStage, TraceEvent, TraceSink,
+};
 
 // Tuned for short tool descriptions; see ADR-0004.
 const BM25_K1: f32 = 0.9;
@@ -12,39 +18,95 @@ pub struct SearchHit {
     pub score: f32,
 }
 
-#[derive(Default)]
 pub struct ToolRegistry {
     tools: Vec<Tool>,
+    sink: Arc<dyn TraceSink>,
+}
+
+impl Default for ToolRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ToolRegistry {
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            tools: Vec::new(),
+            sink: Arc::new(NoopSink),
+        }
+    }
+
+    pub fn with_trace_sink(sink: Arc<dyn TraceSink>) -> Self {
+        Self {
+            tools: Vec::new(),
+            sink,
+        }
+    }
+
+    pub fn set_trace_sink(&mut self, sink: Arc<dyn TraceSink>) {
+        self.sink = sink;
+    }
+
+    pub fn record_event(&self, event: TraceEvent) {
+        self.sink.record(event);
     }
 
     pub fn register(&mut self, tool: Tool) {
+        let tool_id = tool.id.clone();
         self.tools.push(tool);
+        self.sink.record(TraceEvent::IndexChurn {
+            kind: ChurnKind::Add,
+            tool_id,
+        });
     }
 
     pub fn search(&self, query: &str, top_k: usize) -> Vec<SearchHit> {
-        if self.tools.is_empty() {
-            return Vec::new();
-        }
-        let docs = self.tools.iter().map(|t| Document {
-            id: t.id.clone(),
-            contents: searchable_text(t),
+        self.search_with_origin(query, top_k, Origin::User)
+    }
+
+    pub fn search_with_origin(&self, query: &str, top_k: usize, origin: Origin) -> Vec<SearchHit> {
+        let started = Instant::now();
+        let hits: Vec<SearchHit> = if self.tools.is_empty() {
+            Vec::new()
+        } else {
+            let docs = self.tools.iter().map(|t| Document {
+                id: t.id.clone(),
+                contents: searchable_text(t),
+            });
+            let engine = SearchEngineBuilder::<String>::with_documents(Language::English, docs)
+                .k1(BM25_K1)
+                .b(BM25_B)
+                .build();
+            engine
+                .search(query, top_k)
+                .into_iter()
+                .map(|r| SearchHit {
+                    tool_id: r.document.id,
+                    score: r.score,
+                })
+                .collect()
+        };
+        let took_ms = started.elapsed().as_millis() as u64;
+        let top_score = hits.first().map(|h| h.score as f64);
+        self.sink.record(TraceEvent::Search {
+            query: query.to_string(),
+            origin,
+            top_k: top_k as u32,
+            hits: hits
+                .iter()
+                .map(|h| SearchHitTrace {
+                    tool_id: h.tool_id.clone(),
+                    score: h.score as f64,
+                })
+                .collect(),
+            stages: vec![SearchStage {
+                name: "bm25".into(),
+                took_ms,
+                top_score,
+            }],
+            took_ms,
         });
-        let engine = SearchEngineBuilder::<String>::with_documents(Language::English, docs)
-            .k1(BM25_K1)
-            .b(BM25_B)
-            .build();
-        engine
-            .search(query, top_k)
-            .into_iter()
-            .map(|r| SearchHit {
-                tool_id: r.document.id,
-                score: r.score,
-            })
-            .collect()
+        hits
     }
 }

--- a/src/core/lib/src/trace/event.rs
+++ b/src/core/lib/src/trace/event.rs
@@ -1,0 +1,116 @@
+use serde::{Deserialize, Serialize};
+
+/// Distinguishes a query the human typed (pre-fetch helpers) from one the agent
+/// synthesized inside its loop (gateway tool). Used to separate the two paths
+/// in trace consumers (rerankers train on agent calls, inspector shows both).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Origin {
+    User,
+    Agent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChurnKind {
+    Add,
+    Remove,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SearchHitTrace {
+    pub tool_id: String,
+    pub score: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SearchStage {
+    pub name: String,
+    pub took_ms: u64,
+    pub top_score: Option<f64>,
+}
+
+/// Every event produced by any layer of Ratel. New variants are additive;
+/// renames or removals are breaking — see ADR-0009.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum TraceEvent {
+    Search {
+        query: String,
+        origin: Origin,
+        top_k: u32,
+        hits: Vec<SearchHitTrace>,
+        stages: Vec<SearchStage>,
+        took_ms: u64,
+    },
+    IndexChurn {
+        kind: ChurnKind,
+        tool_id: String,
+    },
+    InvokeStart {
+        tool_id: String,
+        args_size_bytes: u64,
+    },
+    InvokeEnd {
+        tool_id: String,
+        took_ms: u64,
+    },
+    InvokeError {
+        tool_id: String,
+        took_ms: u64,
+        error: String,
+    },
+    GatewaySearch {
+        query: String,
+        origin: Origin,
+        top_k: u32,
+        hits: u32,
+        took_ms: u64,
+    },
+    GatewayInvoke {
+        tool_id: String,
+        took_ms: u64,
+    },
+    GatewayError {
+        tool_id: String,
+        error: String,
+    },
+    UpstreamRegister {
+        server: String,
+        transport: String,
+        tool_count: u32,
+    },
+    UpstreamInvoke {
+        server: String,
+        tool_id: String,
+        took_ms: u64,
+    },
+    UpstreamError {
+        server: String,
+        tool_id: String,
+        error: String,
+    },
+    AuthRefresh {
+        upstream: String,
+        ok: bool,
+    },
+    AuthNeeds {
+        upstream: String,
+    },
+    AuthFlowStart {
+        upstream: String,
+    },
+    AuthFlowEnd {
+        upstream: String,
+        ok: bool,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TraceEnvelope {
+    pub v: u32,
+    pub ts: u64,
+    pub session_id: String,
+    #[serde(flatten)]
+    pub event: TraceEvent,
+}

--- a/src/core/lib/src/trace/event.rs
+++ b/src/core/lib/src/trace/event.rs
@@ -1,12 +1,13 @@
 use serde::{Deserialize, Serialize};
 
-/// Distinguishes a query the human typed (pre-fetch helpers) from one the agent
-/// synthesized inside its loop (gateway tool). Used to separate the two paths
-/// in trace consumers (rerankers train on agent calls, inspector shows both).
+/// Distinguishes a direct API call (pre-fetch helpers, library callers,
+/// benchmarks) from one the agent synthesized inside its loop (gateway tool).
+/// Used to separate the two paths in trace consumers (rerankers train on agent
+/// calls, inspector shows both).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Origin {
-    User,
+    Direct,
     Agent,
 }
 

--- a/src/core/lib/src/trace/mod.rs
+++ b/src/core/lib/src/trace/mod.rs
@@ -1,0 +1,10 @@
+//! Trace events emitted from every layer of Ratel — the substrate for the
+//! inspector, the suggestion analyzer, the reranker training, and the optional
+//! self-hosted consolidation server. See ADR-0009 for the schema-ownership
+//! and reliability story.
+
+mod event;
+mod sink;
+
+pub use event::{ChurnKind, Origin, SearchHitTrace, SearchStage, TraceEnvelope, TraceEvent};
+pub use sink::{JsonlSink, MemorySink, NoopSink, TraceSink};

--- a/src/core/lib/src/trace/sink.rs
+++ b/src/core/lib/src/trace/sink.rs
@@ -1,0 +1,121 @@
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::trace::event::{TraceEnvelope, TraceEvent};
+
+const ENVELOPE_VERSION: u32 = 1;
+
+/// A best-effort sink for trace events. Implementations must be cheap on the
+/// hot path — see ADR-0009 for the query-log reliability profile (lossy on
+/// backpressure is fine, blocking the agent loop is not).
+pub trait TraceSink: Send + Sync {
+    fn record(&self, event: TraceEvent);
+
+    /// Per-sink rate limit hint. Currently a documentation knob; v0.1.5 doesn't
+    /// rate-limit anywhere, but the contract is in place so consumers can
+    /// adopt it without a breaking change.
+    fn sample_rate(&self) -> f64 {
+        1.0
+    }
+}
+
+pub struct NoopSink;
+
+impl TraceSink for NoopSink {
+    fn record(&self, _event: TraceEvent) {}
+}
+
+pub struct MemorySink {
+    session_id: String,
+    events: Mutex<Vec<TraceEnvelope>>,
+}
+
+impl MemorySink {
+    pub fn new(session_id: impl Into<String>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            events: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn snapshot(&self) -> Vec<TraceEnvelope> {
+        self.events.lock().expect("trace sink poisoned").clone()
+    }
+
+    pub fn drain(&self) -> Vec<TraceEnvelope> {
+        let mut guard = self.events.lock().expect("trace sink poisoned");
+        std::mem::take(&mut *guard)
+    }
+
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+}
+
+impl TraceSink for MemorySink {
+    fn record(&self, event: TraceEvent) {
+        let envelope = wrap(self.session_id.clone(), event);
+        if let Ok(mut guard) = self.events.lock() {
+            guard.push(envelope);
+        }
+    }
+}
+
+pub struct JsonlSink {
+    session_id: String,
+    file: Mutex<BufWriter<File>>,
+}
+
+impl JsonlSink {
+    pub fn new(session_id: impl Into<String>, path: impl AsRef<Path>) -> std::io::Result<Self> {
+        let path: PathBuf = path.as_ref().to_path_buf();
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+        }
+        Ok(Self {
+            session_id: session_id.into(),
+            file: Mutex::new(BufWriter::new(file)),
+        })
+    }
+}
+
+impl TraceSink for JsonlSink {
+    fn record(&self, event: TraceEvent) {
+        let envelope = wrap(self.session_id.clone(), event);
+        let Ok(line) = serde_json::to_string(&envelope) else {
+            return;
+        };
+        if let Ok(mut guard) = self.file.lock() {
+            // Best-effort: a write failure should not crash the agent loop.
+            let _ = writeln!(guard, "{line}");
+            let _ = guard.flush();
+        }
+    }
+}
+
+fn wrap(session_id: String, event: TraceEvent) -> TraceEnvelope {
+    TraceEnvelope {
+        v: ENVELOPE_VERSION,
+        ts: now_ms(),
+        session_id,
+        event,
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/src/core/lib/tests/trace.rs
+++ b/src/core/lib/tests/trace.rs
@@ -1,0 +1,304 @@
+use std::sync::Arc;
+
+use ratel_ai_core::{
+    ChurnKind, JsonlSink, MemorySink, NoopSink, Origin, Tool, ToolRegistry, TraceEnvelope,
+    TraceEvent, TraceSink,
+};
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
+fn empty_schema() -> Value {
+    json!({})
+}
+
+fn lookup_tool(id: &str) -> Tool {
+    Tool {
+        id: id.into(),
+        name: id.into(),
+        description: "lookup".into(),
+        input_schema: empty_schema(),
+        output_schema: empty_schema(),
+    }
+}
+
+#[test]
+fn default_registry_uses_noop_sink_and_does_not_panic() {
+    let mut registry = ToolRegistry::new();
+    registry.register(lookup_tool("t"));
+    let _ = registry.search("lookup", 5);
+}
+
+#[test]
+fn register_emits_index_churn_add() {
+    let sink = Arc::new(MemorySink::new("session-1"));
+    let mut registry = ToolRegistry::with_trace_sink(sink.clone());
+    registry.register(lookup_tool("alpha"));
+
+    let events = sink.snapshot();
+    assert_eq!(events.len(), 1);
+    let env: &TraceEnvelope = &events[0];
+    assert_eq!(env.session_id, "session-1");
+    assert_eq!(env.v, 1);
+    assert!(env.ts > 0);
+    match &env.event {
+        TraceEvent::IndexChurn { kind, tool_id } => {
+            assert_eq!(*kind, ChurnKind::Add);
+            assert_eq!(tool_id, "alpha");
+        }
+        other => panic!("expected IndexChurn, got {other:?}"),
+    }
+}
+
+#[test]
+fn search_emits_search_event_with_bm25_stage_and_hits() {
+    let sink = Arc::new(MemorySink::new("session-2"));
+    let mut registry = ToolRegistry::with_trace_sink(sink.clone());
+    registry.register(lookup_tool("alpha"));
+
+    let hits = registry.search("lookup", 5);
+    assert!(!hits.is_empty());
+
+    let events = sink.snapshot();
+    let search_event = events
+        .iter()
+        .find(|e| matches!(e.event, TraceEvent::Search { .. }))
+        .expect("expected a search event");
+
+    match &search_event.event {
+        TraceEvent::Search {
+            query,
+            origin,
+            top_k,
+            hits,
+            stages,
+            ..
+        } => {
+            assert_eq!(query, "lookup");
+            assert_eq!(*origin, Origin::User);
+            assert_eq!(*top_k, 5);
+            assert_eq!(hits.len(), 1);
+            assert_eq!(hits[0].tool_id, "alpha");
+            assert!(hits[0].score > 0.0);
+            assert_eq!(stages.len(), 1);
+            assert_eq!(stages[0].name, "bm25");
+            assert_eq!(stages[0].top_score, Some(hits[0].score));
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn search_with_origin_propagates_origin() {
+    let sink = Arc::new(MemorySink::new("session-3"));
+    let mut registry = ToolRegistry::with_trace_sink(sink.clone());
+    registry.register(lookup_tool("alpha"));
+
+    let _ = registry.search_with_origin("lookup", 3, Origin::Agent);
+
+    let events = sink.snapshot();
+    let search_event = events
+        .iter()
+        .find(|e| matches!(e.event, TraceEvent::Search { .. }))
+        .expect("expected a search event");
+    if let TraceEvent::Search { origin, .. } = &search_event.event {
+        assert_eq!(*origin, Origin::Agent);
+    }
+}
+
+#[test]
+fn empty_registry_search_still_emits_event() {
+    let sink = Arc::new(MemorySink::new("session-4"));
+    let registry = ToolRegistry::with_trace_sink(sink.clone());
+
+    let _ = registry.search("anything", 5);
+
+    let events = sink.snapshot();
+    assert_eq!(events.len(), 1);
+    match &events[0].event {
+        TraceEvent::Search { hits, stages, .. } => {
+            assert!(hits.is_empty());
+            assert_eq!(stages.len(), 1);
+            assert_eq!(stages[0].name, "bm25");
+            assert!(stages[0].top_score.is_none());
+        }
+        _ => panic!("expected Search event"),
+    }
+}
+
+#[test]
+fn record_event_passes_through_sink() {
+    let sink = Arc::new(MemorySink::new("session-5"));
+    let registry = ToolRegistry::with_trace_sink(sink.clone());
+
+    registry.record_event(TraceEvent::InvokeStart {
+        tool_id: "x".into(),
+        args_size_bytes: 42,
+    });
+
+    let events = sink.snapshot();
+    assert_eq!(events.len(), 1);
+    match &events[0].event {
+        TraceEvent::InvokeStart {
+            tool_id,
+            args_size_bytes,
+        } => {
+            assert_eq!(tool_id, "x");
+            assert_eq!(*args_size_bytes, 42);
+        }
+        _ => panic!("expected InvokeStart"),
+    }
+}
+
+#[test]
+fn set_trace_sink_swaps_sink() {
+    let mut registry = ToolRegistry::new();
+    let sink = Arc::new(MemorySink::new("session-6"));
+    registry.set_trace_sink(sink.clone());
+
+    registry.record_event(TraceEvent::AuthNeeds {
+        upstream: "github".into(),
+    });
+
+    assert_eq!(sink.snapshot().len(), 1);
+}
+
+#[test]
+fn noop_sink_drops_everything() {
+    let sink = Arc::new(NoopSink);
+    let registry = ToolRegistry::with_trace_sink(sink);
+    registry.record_event(TraceEvent::AuthRefresh {
+        upstream: "x".into(),
+        ok: true,
+    });
+    // Test that nothing panics; NoopSink has no observable side effect.
+}
+
+#[test]
+fn jsonl_sink_writes_one_line_per_event() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("trace.jsonl");
+    let sink = Arc::new(JsonlSink::new("session-7", &path).expect("open sink"));
+    sink.record(TraceEvent::AuthNeeds {
+        upstream: "github".into(),
+    });
+    sink.record(TraceEvent::AuthRefresh {
+        upstream: "github".into(),
+        ok: true,
+    });
+    drop(sink);
+
+    let body = std::fs::read_to_string(&path).unwrap();
+    let lines: Vec<&str> = body.lines().collect();
+    assert_eq!(lines.len(), 2);
+
+    let first: Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(first["v"], 1);
+    assert_eq!(first["session_id"], "session-7");
+    assert_eq!(first["type"], "auth_needs");
+    assert_eq!(first["upstream"], "github");
+    assert!(first["ts"].as_u64().unwrap() > 0);
+
+    let second: Value = serde_json::from_str(lines[1]).unwrap();
+    assert_eq!(second["type"], "auth_refresh");
+    assert_eq!(second["ok"], true);
+}
+
+#[test]
+fn jsonl_sink_creates_parent_directory() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("nested").join("subdir").join("trace.jsonl");
+    let sink = JsonlSink::new("session-8", &path).expect("open sink in nested dir");
+    sink.record(TraceEvent::AuthFlowStart {
+        upstream: "x".into(),
+    });
+    drop(sink);
+    assert!(path.exists());
+}
+
+#[test]
+fn trace_event_round_trips_through_json() {
+    let originals = vec![
+        TraceEvent::Search {
+            query: "q".into(),
+            origin: Origin::Agent,
+            top_k: 5,
+            hits: vec![ratel_ai_core::SearchHitTrace {
+                tool_id: "t".into(),
+                score: 1.5,
+            }],
+            stages: vec![ratel_ai_core::SearchStage {
+                name: "bm25".into(),
+                took_ms: 1,
+                top_score: Some(1.5),
+            }],
+            took_ms: 1,
+        },
+        TraceEvent::InvokeStart {
+            tool_id: "x".into(),
+            args_size_bytes: 12,
+        },
+        TraceEvent::InvokeEnd {
+            tool_id: "x".into(),
+            took_ms: 7,
+        },
+        TraceEvent::InvokeError {
+            tool_id: "x".into(),
+            took_ms: 7,
+            error: "boom".into(),
+        },
+        TraceEvent::GatewaySearch {
+            query: "q".into(),
+            origin: Origin::Agent,
+            top_k: 5,
+            hits: 1,
+            took_ms: 1,
+        },
+        TraceEvent::GatewayInvoke {
+            tool_id: "x".into(),
+            took_ms: 1,
+        },
+        TraceEvent::GatewayError {
+            tool_id: "x".into(),
+            error: "boom".into(),
+        },
+        TraceEvent::UpstreamRegister {
+            server: "s".into(),
+            transport: "stdio".into(),
+            tool_count: 3,
+        },
+        TraceEvent::UpstreamInvoke {
+            server: "s".into(),
+            tool_id: "s.t".into(),
+            took_ms: 1,
+        },
+        TraceEvent::UpstreamError {
+            server: "s".into(),
+            tool_id: "s.t".into(),
+            error: "boom".into(),
+        },
+        TraceEvent::AuthRefresh {
+            upstream: "u".into(),
+            ok: false,
+        },
+        TraceEvent::AuthNeeds {
+            upstream: "u".into(),
+        },
+        TraceEvent::AuthFlowStart {
+            upstream: "u".into(),
+        },
+        TraceEvent::AuthFlowEnd {
+            upstream: "u".into(),
+            ok: true,
+        },
+        TraceEvent::IndexChurn {
+            kind: ChurnKind::Add,
+            tool_id: "t".into(),
+        },
+    ];
+
+    for original in originals {
+        let serialized = serde_json::to_string(&original).expect("serialize");
+        let back: TraceEvent = serde_json::from_str(&serialized).expect("deserialize");
+        assert_eq!(back, original);
+    }
+}

--- a/src/core/lib/tests/trace.rs
+++ b/src/core/lib/tests/trace.rs
@@ -74,7 +74,7 @@ fn search_emits_search_event_with_bm25_stage_and_hits() {
             ..
         } => {
             assert_eq!(query, "lookup");
-            assert_eq!(*origin, Origin::User);
+            assert_eq!(*origin, Origin::Direct);
             assert_eq!(*top_k, 5);
             assert_eq!(hits.len(), 1);
             assert_eq!(hits[0].tool_id, "alpha");

--- a/src/integrations/README.md
+++ b/src/integrations/README.md
@@ -18,7 +18,7 @@ Library function that takes a `ToolCatalog` plus a caller-supplied MCP `Transpor
 ## `cli/` — `@ratel-ai/cli`
 
 The `ratel` binary. Verbs are grouped:
-- `ratel mcp serve` runs the gateway over stdio against one or more Ratel configs.
+- `ratel serve` runs the gateway over stdio against one or more Ratel configs.
 - `ratel mcp add` mirrors `claude mcp add` — copy-pasted invocations behave identically on both sides.
 - `ratel mcp import` / `link` migrate Claude Code's existing MCP setup into Ratel's three-scope (user/project/local) hierarchy.
 

--- a/src/integrations/cli/CHANGELOG.md
+++ b/src/integrations/cli/CHANGELOG.md
@@ -6,9 +6,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `ratel mcp serve` is now `ratel serve`. The `mcp` group manages configuration; serving the gateway is its own top-level command (room for future `--as-<protocol>` modes). After upgrading, re-run `ratel mcp import` (or `ratel mcp link`) so Claude Code's config points at `["serve", ...]` instead of `["mcp", "serve", ...]`.
+
 ### Added
 
-- `ratel mcp serve` writes telemetry to `~/.ratel/telemetry/<ISO-ts>-<short>.jsonl` by default (one JSON line per event, mode `0600` on Unix). Opt out with `--telemetry off` (or `RATEL_TELEMETRY=off`); override the path with `--telemetry-file <path>`; override the directory with `RATEL_TELEMETRY_DIR`.
+- `ratel serve` writes telemetry to `~/.ratel/telemetry/<project-slug>/<ISO-ts>-<short>.jsonl` by default (one JSON line per event, mode `0600` on Unix). Opt out with `--telemetry off` (or `RATEL_TELEMETRY=off`); override the path with `--telemetry-file <path>`; override the directory with `RATEL_TELEMETRY_DIR`.
 - New `ratel inspect` verb — summarizes the most recent telemetry session into ASCII tables (session totals, top tools by hit count, gateway-vs-direct invoke split, top errors). Flags: `--from <FILE>`, `--last <N>`. `ratel inspect ls` lists files newest-first.
 
 ## [0.1.5-rc.3] - 2026-05-08

--- a/src/integrations/cli/CHANGELOG.md
+++ b/src/integrations/cli/CHANGELOG.md
@@ -6,6 +6,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+### Added
+
+- `ratel mcp serve` writes telemetry to `~/.ratel/telemetry/<ISO-ts>-<short>.jsonl` by default (one JSON line per event, mode `0600` on Unix). Opt out with `--telemetry off` (or `RATEL_TELEMETRY=off`); override the path with `--telemetry-file <path>`; override the directory with `RATEL_TELEMETRY_DIR`.
+- New `ratel inspect` verb — summarizes the most recent telemetry session into ASCII tables (session totals, top tools by hit count, gateway-vs-direct invoke split, top errors). Flags: `--from <FILE>`, `--last <N>`. `ratel inspect ls` lists files newest-first.
+
 ## [0.1.5-rc.3] - 2026-05-08
 
 ### Added

--- a/src/integrations/cli/README.md
+++ b/src/integrations/cli/README.md
@@ -33,6 +33,7 @@ ratel <group> <verb> [args...]
 ratel --help                 # top-level usage
 ratel mcp                    # mcp group usage
 ratel backup                 # backup group usage
+ratel inspect                # summarize the most recent telemetry session
 ```
 
 ### `ratel mcp`
@@ -56,6 +57,15 @@ ratel backup                 # backup group usage
 | `list` | List backup sets created under `~/.ratel/backups/`. |
 
 (`ratel backup undo` exists and restores the most recent set, but is deliberately hidden from `--help`. Use it when you need to roll back the last `import`/`add`/`edit`/`remove`/`link`.)
+
+### `ratel inspect`
+
+| Verb | Purpose |
+|---|---|
+| `inspect` (no verb) | Summarize the most recent telemetry file under `$RATEL_TELEMETRY_DIR` (default `~/.ratel/telemetry/`) into ASCII tables (session totals, top tools by hit count, gateway-vs-direct invoke split, top errors). |
+| `inspect ls` | List telemetry files newest-first with size and modified time. |
+
+Flags: `--from <FILE>` summarizes a specific JSONL file; `--last <N>` restricts the summary to the last N events.
 
 ## `ratel mcp add` — Claude-compatible
 
@@ -126,6 +136,20 @@ HTTP and SSE upstreams that require OAuth authorization are handled at the gatew
 When the gateway boots, every HTTP/SSE upstream with stored tokens runs through a proactive refresh — expired access tokens are rotated up front so the catalog comes online with fresh credentials. If the auth server rejects the refresh (e.g. revoked refresh token), the upstream is flagged `needsAuth: true` rather than blocking the boot — the agent can call the `auth` MCP tool, or you can run `ratel mcp auth <name>`, to recover. A 401 during a live `invoke_tool` returns `{ error: "needs_auth", upstream }` so the agent can branch and call `auth` itself.
 
 Token state is per-user-per-machine (`~/.ratel/oauth/`), not per-config-scope. Multiple Ratel gateways running on the same host (e.g. several Claude Code sessions, or a CLI invocation overlapping a `serve`) refresh through a cross-process file lock so they cannot race on the same `refresh_token` — only one process performs the network refresh; the rest read the rotated tokens from disk under the same lock.
+
+## Telemetry
+
+`ratel mcp serve` writes one JSON line per event to `~/.ratel/telemetry/<ISO-ts>-<short>.jsonl` by default — every search, invoke, gateway call, upstream MCP call, and OAuth event flows through the same JSONL ([ADR 0009](../../../docs/adr/0009-trace-events-core-owned-schema.md)). Best-effort, sampleable, lossy on backpressure — query-log shaped, not oplog.
+
+Flags / env on `ratel mcp serve`:
+
+| Flag | Env | Purpose |
+|---|---|---|
+| `--telemetry off` | `RATEL_TELEMETRY=off` | Disable telemetry for this run. |
+| `--telemetry-file <path>` | — | Override the JSONL path. |
+| — | `RATEL_TELEMETRY_DIR` | Override the default telemetry directory. |
+
+Run `ratel inspect` to summarize the most recent file (or any file via `--from`); `ratel inspect ls` lists what's on disk.
 
 ## Backups & undo
 

--- a/src/integrations/cli/README.md
+++ b/src/integrations/cli/README.md
@@ -62,10 +62,12 @@ ratel inspect                # summarize the most recent telemetry session
 
 | Verb | Purpose |
 |---|---|
-| `inspect` (no verb) | Summarize the most recent telemetry file under `$RATEL_TELEMETRY_DIR` (default `~/.ratel/telemetry/`) into ASCII tables (session totals, top tools by hit count, gateway-vs-direct invoke split, top errors). |
-| `inspect ls` | List telemetry files newest-first with size and modified time. |
+| `inspect` (no verb) | Summarize the most recent telemetry file in the **bucket for the current cwd**, under `$RATEL_TELEMETRY_DIR/<project-slug>/` (default root `~/.ratel/telemetry/`), into ASCII tables (session totals, top tools by hit count, gateway-vs-direct invoke split, top errors). |
+| `inspect ls` | List telemetry files in the cwd's bucket, newest-first with size and modified time. |
 
-Flags: `--from <FILE>` summarizes a specific JSONL file; `--last <N>` restricts the summary to the last N events.
+Flags: `--from <FILE>` summarizes a specific JSONL file; `--last <N>` restricts the summary to the last N events; `--project <ABS-PATH>` targets another project's bucket explicitly; `--all` falls back to the global "newest mtime overall" semantics across every bucket (and, for `ls`, prefixes each row with the project slug).
+
+The slug mirrors Claude Code's `~/.claude/projects/` convention: every `/` and `.` in the absolute project path becomes `-` (e.g. `/Users/me/.config/foo` → `-Users-me--config-foo`).
 
 ## `ratel mcp add` — Claude-compatible
 
@@ -139,17 +141,17 @@ Token state is per-user-per-machine (`~/.ratel/oauth/`), not per-config-scope. M
 
 ## Telemetry
 
-`ratel mcp serve` writes one JSON line per event to `~/.ratel/telemetry/<ISO-ts>-<short>.jsonl` by default — every search, invoke, gateway call, upstream MCP call, and OAuth event flows through the same JSONL ([ADR 0009](../../../docs/adr/0009-trace-events-core-owned-schema.md)). Best-effort, sampleable, lossy on backpressure — query-log shaped, not oplog.
+`ratel mcp serve` writes one JSON line per event to `~/.ratel/telemetry/<project-slug>/<ISO-ts>-<short>.jsonl` by default — every search, invoke, gateway call, upstream MCP call, and OAuth event flows through the same JSONL ([ADR 0009](../../../docs/adr/0009-trace-events-core-owned-schema.md)). The slug is `process.cwd()` at serve time with every `/` and `.` replaced by `-`, mirroring Claude Code's `~/.claude/projects/` convention. Best-effort, sampleable, lossy on backpressure — query-log shaped, not oplog.
 
 Flags / env on `ratel mcp serve`:
 
 | Flag | Env | Purpose |
 |---|---|---|
 | `--telemetry off` | `RATEL_TELEMETRY=off` | Disable telemetry for this run. |
-| `--telemetry-file <path>` | — | Override the JSONL path. |
-| — | `RATEL_TELEMETRY_DIR` | Override the default telemetry directory. |
+| `--telemetry-file <path>` | — | Override the JSONL path verbatim (no slugging). |
+| — | `RATEL_TELEMETRY_DIR` | Override the default telemetry root (the per-project slug nests under it). |
 
-Run `ratel inspect` to summarize the most recent file (or any file via `--from`); `ratel inspect ls` lists what's on disk.
+Run `ratel inspect` from the project's directory to summarize that project's most recent session (or any file via `--from`, any project via `--project`, or every bucket via `--all`); `ratel inspect ls` lists what's on disk for the current bucket (`--all` walks every bucket).
 
 ## Backups & undo
 

--- a/src/integrations/cli/README.md
+++ b/src/integrations/cli/README.md
@@ -36,17 +36,20 @@ ratel backup                 # backup group usage
 ratel inspect                # summarize the most recent telemetry session
 ```
 
+### `ratel serve`
+
+Start the gateway over stdio. Pass one or more configs via `--config` (right-most wins on `mcpServers` collisions). See [Telemetry](#telemetry) for the flags that control trace output.
+
 ### `ratel mcp`
 
 | Verb | Purpose |
 |---|---|
-| `serve` | Start the gateway over stdio. Pass one or more configs via `--config`; right-most wins on `mcpServers` collisions. |
 | `add` | Add an MCP server entry to a Ratel scope. **Mirrors `claude mcp add`** (see below). |
 | `remove [--scope <s>] --name <n>` | Remove an entry from a scope. `--scope` defaults to `user`. |
 | `list` | List MCP servers configured across Ratel scopes. |
 | `get <name> [--scope <s>]` | Print one entry's resolved details. Without `--scope`, walks local → project → user. |
 | `edit [--scope <s>] --name <n>` | Edit fields on an existing entry. `--scope` defaults to `user`. Pass any subset of `--description`, `--type`, `--command`, `--arg` (repeatable), `--env KEY=VAL` (repeatable; `KEY=` clears one), `--cwd`, `--url`, `--header KEY=VAL`. `--entry-json '{...}'` does a full replacement. With no flags, prompts interactively. |
-| `import` | Migrate Claude Code's existing MCP servers into Ratel. Two stages: (a) pick which upstreams to migrate, optionally describe each (each prompt is pre-filled with the upstream's MCP `instructions` if it exposes one), then confirm Ratel writes; (b) confirm the Claude rewrite that points Claude at `ratel mcp serve`. Deselected entries stay in Claude untouched. Decline Stage B and re-run `import` (or run `link`) later. |
+| `import` | Migrate Claude Code's existing MCP servers into Ratel. Two stages: (a) pick which upstreams to migrate, optionally describe each (each prompt is pre-filled with the upstream's MCP `instructions` if it exposes one), then confirm Ratel writes; (b) confirm the Claude rewrite that points Claude at `ratel serve`. Deselected entries stay in Claude untouched. Decline Stage B and re-run `import` (or run `link`) later. |
 | `link` | Stage B alone: rewrites Claude's config to point at Ratel for entries already present in Ratel scopes. Useful after a declined Stage B or hand-authored Ratel configs. |
 | `auth [<name>] [--check]` | Refresh-or-reauth HTTP/SSE upstreams. **Refresh-first**: if a `refresh_token` is on disk, rotates silently — no browser pops. Falls back to PKCE only when refresh is impossible or fails. The output annotates each row as `authorized (refreshed)` or `authorized (re-authed)` so you know which path ran. With `--check`, prints expiry status per upstream without touching the network: `[ok] expires in 23h 12m`, `[expired] expired 5h ago, refresh available`, `[needs auth]`, `[n/a]` for stdio. |
 
@@ -92,7 +95,7 @@ ratel mcp add [flags] <name> <url>                       # http / sse
 By default, after the entry is assembled, `mcp add` connects to the upstream and stores its server-level `instructions` (per the MCP spec) as the entry's `description`. Behavior by transport:
 
 - **stdio**: silent connect → read instructions → close.
-- **http / sse**: drives the OAuth 2.1 / PKCE flow against the upstream (browser opens to authorize), persists tokens to `~/.ratel/oauth/<name>.json`, then reads instructions. After this, the entry is fully usable by `ratel mcp serve` — no follow-up `ratel mcp auth` required.
+- **http / sse**: drives the OAuth 2.1 / PKCE flow against the upstream (browser opens to authorize), persists tokens to `~/.ratel/oauth/<name>.json`, then reads instructions. After this, the entry is fully usable by `ratel serve` — no follow-up `ratel mcp auth` required.
 
 Pass `--description` to override the fetched text (the OAuth flow still runs for http/sse so tokens get persisted). Pass `--no-fetch-description` to skip the probe entirely (useful in CI / headless boxes — you can run `ratel mcp auth <name>` from a workstation later). A failed probe / declined authorization is logged with a hint to retry via `ratel mcp auth <name>` and does not fail the add.
 
@@ -118,13 +121,13 @@ Ratel mirrors Claude Code's MCP scoping with three logical configs:
 | project | `<root>/.ratel/config.json` | Committed alongside the repo. |
 | local | `<root>/.ratel/config.local.json` | Per-user-per-project; **add to your project's `.gitignore`**. |
 
-When you run `ratel mcp serve --config a.json --config b.json --config c.json`, the configs are merged in order — last wins on `mcpServers` key collisions. The `import` wizard wires the right `--config` chain into Claude Code at each scope:
+When you run `ratel serve --config a.json --config b.json --config c.json`, the configs are merged in order — last wins on `mcpServers` key collisions. The `import` wizard wires the right `--config` chain into Claude Code at each scope:
 
 | Claude scope | Args of the `ratel` entry written into Claude's config |
 |---|---|
-| user (`~/.claude.json` root `mcpServers`) | `["mcp", "serve", "--config", <user>]` |
-| project (`<root>/.mcp.json`) | `["mcp", "serve", "--config", <user>, "--config", <project>]` |
-| local (`~/.claude.json` `projects[<root>].mcpServers`) | `["mcp", "serve", "--config", <user>, "--config", <project>, "--config", <local>]` |
+| user (`~/.claude.json` root `mcpServers`) | `["serve", "--config", <user>]` |
+| project (`<root>/.mcp.json`) | `["serve", "--config", <user>, "--config", <project>]` |
+| local (`~/.claude.json` `projects[<root>].mcpServers`) | `["serve", "--config", <user>, "--config", <project>, "--config", <local>]` |
 
 ## OAuth flow
 
@@ -141,9 +144,9 @@ Token state is per-user-per-machine (`~/.ratel/oauth/`), not per-config-scope. M
 
 ## Telemetry
 
-`ratel mcp serve` writes one JSON line per event to `~/.ratel/telemetry/<project-slug>/<ISO-ts>-<short>.jsonl` by default — every search, invoke, gateway call, upstream MCP call, and OAuth event flows through the same JSONL ([ADR 0009](../../../docs/adr/0009-trace-events-core-owned-schema.md)). The slug is `process.cwd()` at serve time with every `/` and `.` replaced by `-`, mirroring Claude Code's `~/.claude/projects/` convention. Best-effort, sampleable, lossy on backpressure — query-log shaped, not oplog.
+`ratel serve` writes one JSON line per event to `~/.ratel/telemetry/<project-slug>/<ISO-ts>-<short>.jsonl` by default — every search, invoke, gateway call, upstream MCP call, and OAuth event flows through the same JSONL ([ADR 0009](../../../docs/adr/0009-trace-events-core-owned-schema.md)). The slug is `process.cwd()` at serve time with every `/` and `.` replaced by `-`, mirroring Claude Code's `~/.claude/projects/` convention. Best-effort, sampleable, lossy on backpressure — query-log shaped, not oplog.
 
-Flags / env on `ratel mcp serve`:
+Flags / env on `ratel serve`:
 
 | Flag | Env | Purpose |
 |---|---|---|

--- a/src/integrations/cli/src/args.test.ts
+++ b/src/integrations/cli/src/args.test.ts
@@ -30,7 +30,6 @@ describe("parseArgs — group/verb routing", () => {
   });
 
   it.each([
-    "serve",
     "add",
     "remove",
     "list",
@@ -42,6 +41,12 @@ describe("parseArgs — group/verb routing", () => {
     const r = parseArgs(["mcp", verb]);
     expect(r.group).toBe("mcp");
     expect(r.verb).toBe(verb);
+  });
+
+  it("recognizes the top-level serve group", () => {
+    const r = parseArgs(["serve"]);
+    expect(r.group).toBe("serve");
+    expect(r.verb).toBeUndefined();
   });
 
   it.each(["list", "undo"] as const)("recognizes backup %s", (verb) => {
@@ -67,39 +72,38 @@ describe("parseArgs — group/verb routing", () => {
   });
 
   it("does not consume --help in the middle as a group/verb", () => {
-    const r = parseArgs(["mcp", "serve", "--help"]);
-    expect(r.group).toBe("mcp");
-    expect(r.verb).toBe("serve");
+    const r = parseArgs(["serve", "--help"]);
+    expect(r.group).toBe("serve");
     expect(r.flags.help).toBe(true);
   });
 });
 
 describe("parseArgs — flags and config paths", () => {
-  it("collects repeated --config flags in order under mcp serve", () => {
-    const r = parseArgs(["mcp", "serve", "--config", "a.json", "--config", "b.json"]);
+  it("collects repeated --config flags in order under serve", () => {
+    const r = parseArgs(["serve", "--config", "a.json", "--config", "b.json"]);
     expect(r.configPaths).toEqual(["a.json", "b.json"]);
   });
 
-  it("accepts --config=value long form under mcp serve", () => {
-    const r = parseArgs(["mcp", "serve", "--config=a.json", "--config=b.json"]);
+  it("accepts --config=value long form under serve", () => {
+    const r = parseArgs(["serve", "--config=a.json", "--config=b.json"]);
     expect(r.configPaths).toEqual(["a.json", "b.json"]);
   });
 
-  it("treats a positional under mcp serve as a config path", () => {
-    const r = parseArgs(["mcp", "serve", "base.json", "--config", "extra.json"]);
+  it("treats a positional under serve as a config path", () => {
+    const r = parseArgs(["serve", "base.json", "--config", "extra.json"]);
     expect(r.configPaths).toEqual(["base.json", "extra.json"]);
   });
 
-  it("does not treat positionals as config paths under non-serve verbs", () => {
+  it("does not treat positionals as config paths under non-serve commands", () => {
     const r = parseArgs(["mcp", "add", "stripe", "https://example.com"]);
     expect(r.configPaths).toEqual([]);
     expect(r.rest).toEqual(["stripe", "https://example.com"]);
   });
 
   it("throws ArgError when --config has no value", () => {
-    expect(() => parseArgs(["mcp", "serve", "--config"])).toThrow(ArgError);
-    expect(() => parseArgs(["mcp", "serve", "--config", "--other"])).toThrow(ArgError);
-    expect(() => parseArgs(["mcp", "serve", "--config="])).toThrow(ArgError);
+    expect(() => parseArgs(["serve", "--config"])).toThrow(ArgError);
+    expect(() => parseArgs(["serve", "--config", "--other"])).toThrow(ArgError);
+    expect(() => parseArgs(["serve", "--config="])).toThrow(ArgError);
   });
 
   it("collects --key value flag pairs into flags", () => {

--- a/src/integrations/cli/src/args.ts
+++ b/src/integrations/cli/src/args.ts
@@ -1,4 +1,4 @@
-export type Group = "mcp" | "backup" | "help";
+export type Group = "mcp" | "backup" | "inspect" | "help";
 
 export type McpVerb =
   | "serve"
@@ -13,6 +13,8 @@ export type McpVerb =
 
 export type BackupVerb = "list" | "undo";
 
+export type InspectVerb = "ls";
+
 const MCP_VERBS: ReadonlySet<string> = new Set([
   "serve",
   "add",
@@ -26,6 +28,8 @@ const MCP_VERBS: ReadonlySet<string> = new Set([
 ]);
 
 const BACKUP_VERBS: ReadonlySet<string> = new Set(["list", "undo"]);
+
+const INSPECT_VERBS: ReadonlySet<string> = new Set(["ls"]);
 
 const SHORT_FLAG_ALIASES: Record<string, string> = {
   e: "env",
@@ -103,6 +107,17 @@ export function parseArgs(argv: string[]): ParsedArgs {
       const candidate = argv[1];
       if (!BACKUP_VERBS.has(candidate)) {
         throw new ArgError(`unknown backup verb: ${candidate}`);
+      }
+      verb = candidate;
+      i = 2;
+    }
+  } else if (first === "inspect") {
+    group = "inspect";
+    i = 1;
+    if (argv.length > 1 && !argv[1].startsWith("-")) {
+      const candidate = argv[1];
+      if (!INSPECT_VERBS.has(candidate)) {
+        throw new ArgError(`unknown inspect verb: ${candidate}`);
       }
       verb = candidate;
       i = 2;

--- a/src/integrations/cli/src/args.ts
+++ b/src/integrations/cli/src/args.ts
@@ -1,22 +1,12 @@
-export type Group = "mcp" | "backup" | "inspect" | "help";
+export type Group = "mcp" | "backup" | "inspect" | "serve" | "help";
 
-export type McpVerb =
-  | "serve"
-  | "add"
-  | "remove"
-  | "list"
-  | "get"
-  | "edit"
-  | "import"
-  | "link"
-  | "auth";
+export type McpVerb = "add" | "remove" | "list" | "get" | "edit" | "import" | "link" | "auth";
 
 export type BackupVerb = "list" | "undo";
 
 export type InspectVerb = "ls";
 
 const MCP_VERBS: ReadonlySet<string> = new Set([
-  "serve",
   "add",
   "remove",
   "list",
@@ -122,6 +112,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
       verb = candidate;
       i = 2;
     }
+  } else if (first === "serve") {
+    group = "serve";
+    i = 1;
   } else {
     throw new ArgError(`unknown command: ${first}`);
   }
@@ -203,7 +196,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
       continue;
     }
 
-    if (group === "mcp" && verb === "serve") {
+    if (group === "serve") {
       configPaths.push(tok);
     } else {
       rest.push(tok);

--- a/src/integrations/cli/src/cli.test.ts
+++ b/src/integrations/cli/src/cli.test.ts
@@ -20,13 +20,13 @@ async function fakeUpstream() {
   return { server, clientTransport };
 }
 
-describe("runCli — mcp serve", () => {
+describe("runCli — serve", () => {
   it("reads the config, builds the gateway, and exposes search_tools + invoke_tool over the given downstream transport", async () => {
     const upstream = await fakeUpstream();
     const [downstreamServerTransport, downstreamClientTransport] =
       InMemoryTransport.createLinkedPair();
 
-    const { shutdown } = await runCli(["mcp", "serve", "/fake/config.json"], {
+    const { shutdown } = await runCli(["serve", "/fake/config.json"], {
       readConfig: async () => ({
         mcpServers: { up: { type: "stdio", command: "noop" } },
       }),
@@ -63,7 +63,7 @@ describe("runCli — mcp serve", () => {
     const [downstreamServerTransport, downstreamClientTransport] =
       InMemoryTransport.createLinkedPair();
 
-    const { shutdown } = await runCli(["mcp", "serve", "/fake/config.json"], {
+    const { shutdown } = await runCli(["serve", "/fake/config.json"], {
       readConfig: async () => ({
         mcpServers: {
           up: { type: "stdio", command: "noop", description: "ping server" },
@@ -87,12 +87,12 @@ describe("runCli — mcp serve", () => {
   });
 
   it("rejects when no config path is provided, with a usage message", async () => {
-    await expect(runCli(["mcp", "serve"], { logger: () => {} })).rejects.toThrow(/usage/i);
+    await expect(runCli(["serve"], { logger: () => {} })).rejects.toThrow(/usage/i);
   });
 
   it("propagates a clear error when the config file cannot be read", async () => {
     await expect(
-      runCli(["mcp", "serve", "/missing.json"], {
+      runCli(["serve", "/missing.json"], {
         readConfig: async () => {
           throw new Error("ENOENT");
         },
@@ -103,7 +103,7 @@ describe("runCli — mcp serve", () => {
 
   it("propagates parseConfig errors with the field path when the JSON is malformed", async () => {
     await expect(
-      runCli(["mcp", "serve", "/bad.json"], {
+      runCli(["serve", "/bad.json"], {
         readConfig: async () => ({ mcpServers: { fs: { type: "stdio" } } }),
         logger: () => {},
       }),
@@ -115,7 +115,7 @@ describe("runCli — mcp serve", () => {
     const [serverTransport] = InMemoryTransport.createLinkedPair();
     const logs: string[] = [];
 
-    const { shutdown } = await runCli(["mcp", "serve", "/x"], {
+    const { shutdown } = await runCli(["serve", "/x"], {
       readConfig: async () => ({
         mcpServers: { up: { type: "stdio", command: "noop" } },
       }),
@@ -135,21 +135,18 @@ describe("runCli — mcp serve", () => {
     const [serverTransport] = InMemoryTransport.createLinkedPair();
     const reads: string[] = [];
 
-    const { shutdown } = await runCli(
-      ["mcp", "serve", "--config", "/a.json", "--config", "/b.json"],
-      {
-        readConfig: async (path) => {
-          reads.push(path);
-          if (path === "/a.json") {
-            return { mcpServers: { up: { type: "stdio", command: "from-a" } } };
-          }
-          return { mcpServers: { up: { type: "stdio", command: "from-b" } } };
-        },
-        transportFactory: () => upstream.clientTransport,
-        serverTransport,
-        logger: () => {},
+    const { shutdown } = await runCli(["serve", "--config", "/a.json", "--config", "/b.json"], {
+      readConfig: async (path) => {
+        reads.push(path);
+        if (path === "/a.json") {
+          return { mcpServers: { up: { type: "stdio", command: "from-a" } } };
+        }
+        return { mcpServers: { up: { type: "stdio", command: "from-b" } } };
       },
-    );
+      transportFactory: () => upstream.clientTransport,
+      serverTransport,
+      logger: () => {},
+    });
 
     expect(reads).toEqual(["/a.json", "/b.json"]);
 
@@ -171,7 +168,6 @@ describe("runCli — help and routing", () => {
     const logs: string[] = [];
     await runCli(["mcp"], { logger: (m) => logs.push(m) });
     const out = logs.join("\n");
-    expect(out).toMatch(/serve/);
     expect(out).toMatch(/add/);
     expect(out).toMatch(/import/);
   });

--- a/src/integrations/cli/src/cli.ts
+++ b/src/integrations/cli/src/cli.ts
@@ -27,7 +27,12 @@ import { runRemove } from "./handlers/remove.js";
 import type { HandlerCtx } from "./handlers/types.js";
 import { runUndo } from "./handlers/undo.js";
 import { findProjectRoot, type HierarchyEnv } from "./hierarchy.js";
-import { defaultTelemetryDir, listSessions, summarizeSession } from "./inspect.js";
+import {
+  defaultTelemetryDir,
+  listSessions,
+  projectBucketDir,
+  summarizeSession,
+} from "./inspect.js";
 import { type JsonFs, nodeFs } from "./io.js";
 import { type PromptAdapter, silentPromptAdapter } from "./prompts.js";
 
@@ -78,15 +83,19 @@ Verbs:
 
 const INSPECT_USAGE = `usage: ratel inspect [verb] [args...]
 
-Default (no verb) summarizes the most recent telemetry file under
-\`$RATEL_TELEMETRY_DIR\` (default \`~/.ratel/telemetry/\`).
+Default (no verb) summarizes the most recent telemetry file in the bucket for
+the current cwd, under \`$RATEL_TELEMETRY_DIR/<project-slug>/\` (default root
+\`~/.ratel/telemetry/\`). The slug mirrors Claude Code's \`~/.claude/projects/\`
+convention: every \`/\` and \`.\` in the absolute path becomes \`-\`.
 
 Flags:
-  --from <FILE>   summarize a specific JSONL file
-  --last <N>      restrict the summary to the last N events
+  --from <FILE>          summarize a specific JSONL file
+  --last <N>             restrict the summary to the last N events
+  --project <ABS-PATH>   target another project's bucket explicitly
+  --all                  scan every bucket and pick the global newest
 
 Verbs:
-  ls   list telemetry files (most recent first)`;
+  ls   list telemetry files in the cwd's bucket (most recent first; use --all to enumerate every bucket)`;
 
 export async function runCli(argv: string[], options: RunCliOptions = {}): Promise<RunCliResult> {
   const log = options.logger ?? ((m) => console.error(m));
@@ -232,11 +241,17 @@ async function runInspect(parsed: ParsedArgs, log: (m: string) => void): Promise
     log(INSPECT_USAGE);
     return {};
   }
+  const all = parsed.flags.all === true;
+  const projectFlag = parsed.flags.project;
+  const project = typeof projectFlag === "string" ? projectFlag : undefined;
   if (parsed.verb === "ls") {
-    log(await listSessions(defaultTelemetryDir()));
+    const listOpts: { project?: string; all?: boolean } = {};
+    if (all) listOpts.all = true;
+    if (project) listOpts.project = project;
+    log(await listSessions(defaultTelemetryDir(), listOpts));
     return {};
   }
-  const opts: { from?: string; last?: number } = {};
+  const opts: { from?: string; last?: number; project?: string; all?: boolean } = {};
   const from = parsed.flags.from;
   if (typeof from === "string") opts.from = from;
   const last = parsed.flags.last;
@@ -244,6 +259,8 @@ async function runInspect(parsed: ParsedArgs, log: (m: string) => void): Promise
     const n = Number.parseInt(last, 10);
     if (Number.isFinite(n)) opts.last = n;
   }
+  if (all) opts.all = true;
+  if (project) opts.project = project;
   log(await summarizeSession(opts));
   return {};
 }
@@ -262,14 +279,14 @@ async function resolveTraceSink(
   if (typeof flagFile === "string" && flagFile.length > 0) {
     return { kind: "jsonl", sessionId, path: flagFile };
   }
-  const dir = defaultTelemetryDir();
+  const bucket = projectBucketDir(defaultTelemetryDir(), process.cwd());
   try {
-    await mkdir(dir, { recursive: true });
+    await mkdir(bucket, { recursive: true });
   } catch (err) {
-    log(`[ratel] could not create telemetry dir ${dir}: ${(err as Error).message}; disabling`);
+    log(`[ratel] could not create telemetry dir ${bucket}: ${(err as Error).message}; disabling`);
     return { kind: "noop" };
   }
-  const path = join(dir, `${sessionId}.jsonl`);
+  const path = join(bucket, `${sessionId}.jsonl`);
   return { kind: "jsonl", sessionId, path };
 }
 

--- a/src/integrations/cli/src/cli.ts
+++ b/src/integrations/cli/src/cli.ts
@@ -8,7 +8,7 @@ import type { ClaudeFs } from "./claude.js";
 import { BACKUP_USAGE, runBackup } from "./handlers/backup.js";
 import { runInspect } from "./handlers/inspect.js";
 import { MCP_USAGE, runMcp } from "./handlers/mcp.js";
-import { runMcpServe } from "./handlers/mcp-serve.js";
+import { runServe } from "./handlers/serve.js";
 import type { HandlerCtx } from "./handlers/types.js";
 import { findProjectRoot, type HierarchyEnv } from "./hierarchy.js";
 import { type JsonFs, nodeFs } from "./io.js";
@@ -31,10 +31,11 @@ export interface RunCliResult {
   shutdown?: () => Promise<void>;
 }
 
-const TOP_USAGE = `usage: ratel <group> <verb> [args...]
+const TOP_USAGE = `usage: ratel <command> [args...]
 
-Groups:
-  mcp      manage MCP servers (add, remove, list, get, edit, import, link) and serve the gateway
+Commands:
+  serve    start the gateway over stdio (use --config <path>; repeat for multi-file merge)
+  mcp      manage MCP servers (add, remove, list, get, edit, import, link, auth)
   backup   manage backup snapshots (list)
   inspect  summarize the most recent telemetry session (or \`ls\` for a file listing)
 
@@ -72,8 +73,8 @@ export async function runCli(argv: string[], options: RunCliOptions = {}): Promi
     return {};
   }
 
-  if (parsed.group === "mcp" && parsed.verb === "serve") {
-    return runMcpServe(parsed, options, log);
+  if (parsed.group === "serve") {
+    return runServe(parsed, options, log);
   }
 
   const ctx: HandlerCtx = {

--- a/src/integrations/cli/src/cli.ts
+++ b/src/integrations/cli/src/cli.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
+import { join } from "node:path";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {
@@ -10,6 +11,7 @@ import {
   parseConfig,
   type TransportFactory,
 } from "@ratel-ai/mcp-server";
+import type { TraceSinkConfig } from "@ratel-ai/sdk";
 import { ArgError, type ParsedArgs, parseArgs } from "./args.js";
 import type { BackupFs } from "./backup.js";
 import type { ClaudeFs } from "./claude.js";
@@ -25,6 +27,7 @@ import { runRemove } from "./handlers/remove.js";
 import type { HandlerCtx } from "./handlers/types.js";
 import { runUndo } from "./handlers/undo.js";
 import { findProjectRoot, type HierarchyEnv } from "./hierarchy.js";
+import { defaultTelemetryDir, listSessions, summarizeSession } from "./inspect.js";
 import { type JsonFs, nodeFs } from "./io.js";
 import { type PromptAdapter, silentPromptAdapter } from "./prompts.js";
 
@@ -50,6 +53,7 @@ const TOP_USAGE = `usage: ratel <group> <verb> [args...]
 Groups:
   mcp      manage MCP servers (add, remove, list, get, edit, import, link) and serve the gateway
   backup   manage backup snapshots (list)
+  inspect  summarize the most recent telemetry session (or \`ls\` for a file listing)
 
 Run \`ratel <group>\` for the verbs available in a group.`;
 
@@ -71,6 +75,18 @@ const BACKUP_USAGE = `usage: ratel backup <verb> [args...]
 
 Verbs:
   list    list backup sets under ~/.ratel/backups/`;
+
+const INSPECT_USAGE = `usage: ratel inspect [verb] [args...]
+
+Default (no verb) summarizes the most recent telemetry file under
+\`$RATEL_TELEMETRY_DIR\` (default \`~/.ratel/telemetry/\`).
+
+Flags:
+  --from <FILE>   summarize a specific JSONL file
+  --last <N>      restrict the summary to the last N events
+
+Verbs:
+  ls   list telemetry files (most recent first)`;
 
 export async function runCli(argv: string[], options: RunCliOptions = {}): Promise<RunCliResult> {
   const log = options.logger ?? ((m) => console.error(m));
@@ -97,6 +113,10 @@ export async function runCli(argv: string[], options: RunCliOptions = {}): Promi
   if (parsed.group === "backup" && parsed.verb === undefined) {
     log(BACKUP_USAGE);
     return {};
+  }
+
+  if (parsed.group === "inspect") {
+    return runInspect(parsed, log);
   }
 
   if (parsed.group === "mcp" && parsed.verb === "serve") {
@@ -178,9 +198,12 @@ async function runServer(
   }
   const config = mergeConfigs(parts);
 
+  const trace = await resolveTraceSink(parsed, log);
+
   const gateway = await buildGatewayFromConfig(config, {
     transportFactory: options.transportFactory,
     logger: log,
+    ...(trace ? { trace } : {}),
   });
 
   const downstream = options.serverTransport ?? new StdioServerTransport();
@@ -202,6 +225,58 @@ async function runServer(
       await gateway.close();
     },
   };
+}
+
+async function runInspect(parsed: ParsedArgs, log: (m: string) => void): Promise<RunCliResult> {
+  if (parsed.flags.help === true) {
+    log(INSPECT_USAGE);
+    return {};
+  }
+  if (parsed.verb === "ls") {
+    log(await listSessions(defaultTelemetryDir()));
+    return {};
+  }
+  const opts: { from?: string; last?: number } = {};
+  const from = parsed.flags.from;
+  if (typeof from === "string") opts.from = from;
+  const last = parsed.flags.last;
+  if (typeof last === "string") {
+    const n = Number.parseInt(last, 10);
+    if (Number.isFinite(n)) opts.last = n;
+  }
+  log(await summarizeSession(opts));
+  return {};
+}
+
+async function resolveTraceSink(
+  parsed: ParsedArgs,
+  log: (m: string) => void,
+): Promise<TraceSinkConfig | undefined> {
+  const flag = parsed.flags.telemetry;
+  const flagFile = parsed.flags["telemetry-file"];
+  const env = process.env.RATEL_TELEMETRY;
+  if (flag === false || flag === "off" || env === "off") {
+    return { kind: "noop" };
+  }
+  const sessionId = newSessionId();
+  if (typeof flagFile === "string" && flagFile.length > 0) {
+    return { kind: "jsonl", sessionId, path: flagFile };
+  }
+  const dir = defaultTelemetryDir();
+  try {
+    await mkdir(dir, { recursive: true });
+  } catch (err) {
+    log(`[ratel] could not create telemetry dir ${dir}: ${(err as Error).message}; disabling`);
+    return { kind: "noop" };
+  }
+  const path = join(dir, `${sessionId}.jsonl`);
+  return { kind: "jsonl", sessionId, path };
+}
+
+function newSessionId(): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `${ts}-${rand}`;
 }
 
 async function defaultReadConfig(path: string): Promise<unknown> {

--- a/src/integrations/cli/src/cli.ts
+++ b/src/integrations/cli/src/cli.ts
@@ -1,38 +1,16 @@
 import { existsSync } from "node:fs";
-import { mkdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import {
-  buildGatewayFromConfig,
-  createMcpServer,
-  mergeConfigs,
-  parseConfig,
-  type TransportFactory,
-} from "@ratel-ai/mcp-server";
-import type { TraceSinkConfig } from "@ratel-ai/sdk";
+import type { TransportFactory } from "@ratel-ai/mcp-server";
 import { ArgError, type ParsedArgs, parseArgs } from "./args.js";
 import type { BackupFs } from "./backup.js";
 import type { ClaudeFs } from "./claude.js";
-import { runAdd } from "./handlers/add.js";
-import { runEdit } from "./handlers/edit.js";
-import { runMcpGet } from "./handlers/get.js";
-import { runImport } from "./handlers/import.js";
-import { runLink } from "./handlers/link.js";
-import { runListBackups } from "./handlers/list.js";
-import { runMcpAuth } from "./handlers/mcp-auth.js";
-import { runMcpList } from "./handlers/mcp-list.js";
-import { runRemove } from "./handlers/remove.js";
+import { BACKUP_USAGE, runBackup } from "./handlers/backup.js";
+import { runInspect } from "./handlers/inspect.js";
+import { MCP_USAGE, runMcp } from "./handlers/mcp.js";
+import { runMcpServe } from "./handlers/mcp-serve.js";
 import type { HandlerCtx } from "./handlers/types.js";
-import { runUndo } from "./handlers/undo.js";
 import { findProjectRoot, type HierarchyEnv } from "./hierarchy.js";
-import {
-  defaultTelemetryDir,
-  listSessions,
-  projectBucketDir,
-  summarizeSession,
-} from "./inspect.js";
 import { type JsonFs, nodeFs } from "./io.js";
 import { type PromptAdapter, silentPromptAdapter } from "./prompts.js";
 
@@ -62,41 +40,6 @@ Groups:
 
 Run \`ratel <group>\` for the verbs available in a group.`;
 
-const MCP_USAGE = `usage: ratel mcp <verb> [args...]
-
-Verbs:
-  serve   start the gateway over stdio (use --config <path> to load a Ratel config; repeat for multi-file merge)
-  add     add an MCP server entry (Claude-compatible: ratel mcp add [flags] <name> -- <command> [args...]
-                                   or ratel mcp add [flags] <name> <url>)
-  remove  remove an entry from a Ratel scope
-  list    list MCP servers configured across Ratel scopes
-  get     show one entry's resolved details
-  edit    edit fields on an existing entry (interactive when no flags supplied)
-  import  migrate Claude Code MCP configs into Ratel (two stages: Ratel write, then Claude rewrite)
-  link    rewrite Claude Code's config to point at Ratel for entries already in Ratel scopes
-  auth    drive an interactive OAuth flow for one or all http/sse upstreams that need authorization`;
-
-const BACKUP_USAGE = `usage: ratel backup <verb> [args...]
-
-Verbs:
-  list    list backup sets under ~/.ratel/backups/`;
-
-const INSPECT_USAGE = `usage: ratel inspect [verb] [args...]
-
-Default (no verb) summarizes the most recent telemetry file in the bucket for
-the current cwd, under \`$RATEL_TELEMETRY_DIR/<project-slug>/\` (default root
-\`~/.ratel/telemetry/\`). The slug mirrors Claude Code's \`~/.claude/projects/\`
-convention: every \`/\` and \`.\` in the absolute path becomes \`-\`.
-
-Flags:
-  --from <FILE>          summarize a specific JSONL file
-  --last <N>             restrict the summary to the last N events
-  --project <ABS-PATH>   target another project's bucket explicitly
-  --all                  scan every bucket and pick the global newest
-
-Verbs:
-  ls   list telemetry files in the cwd's bucket (most recent first; use --all to enumerate every bucket)`;
-
 export async function runCli(argv: string[], options: RunCliOptions = {}): Promise<RunCliResult> {
   const log = options.logger ?? ((m) => console.error(m));
   let parsed: ParsedArgs;
@@ -125,11 +68,12 @@ export async function runCli(argv: string[], options: RunCliOptions = {}): Promi
   }
 
   if (parsed.group === "inspect") {
-    return runInspect(parsed, log);
+    await runInspect(parsed, log);
+    return {};
   }
 
   if (parsed.group === "mcp" && parsed.verb === "serve") {
-    return runServer(parsed, options, log);
+    return runMcpServe(parsed, options, log);
   }
 
   const ctx: HandlerCtx = {
@@ -141,171 +85,16 @@ export async function runCli(argv: string[], options: RunCliOptions = {}): Promi
   };
 
   if (parsed.group === "mcp") {
-    switch (parsed.verb) {
-      case "add":
-        await runAdd(ctx);
-        return {};
-      case "remove":
-        await runRemove(ctx);
-        return {};
-      case "list":
-        await runMcpList(ctx);
-        return {};
-      case "get":
-        await runMcpGet(ctx);
-        return {};
-      case "edit":
-        await runEdit(ctx);
-        return {};
-      case "import":
-        await runImport(ctx, {
-          yes: parsed.flags.yes === true,
-          dryRun: parsed.flags["dry-run"] === true,
-        });
-        return {};
-      case "link":
-        await runLink(ctx, { yes: parsed.flags.yes === true });
-        return {};
-      case "auth":
-        await runMcpAuth(ctx);
-        return {};
-      default:
-        throw new ArgError(`unknown mcp verb: ${parsed.verb}`);
-    }
+    await runMcp(ctx);
+    return {};
   }
 
   if (parsed.group === "backup") {
-    switch (parsed.verb) {
-      case "list":
-        await runListBackups(ctx);
-        return {};
-      case "undo":
-        await runUndo(ctx);
-        return {};
-      default:
-        throw new ArgError(`unknown backup verb: ${parsed.verb}`);
-    }
+    await runBackup(ctx);
+    return {};
   }
 
   throw new ArgError(`unhandled command: ${parsed.group} ${parsed.verb}`);
-}
-
-async function runServer(
-  parsed: ParsedArgs,
-  options: RunCliOptions,
-  log: (m: string) => void,
-): Promise<RunCliResult> {
-  if (parsed.configPaths.length === 0) {
-    throw new Error("usage: ratel mcp serve <config.json> [--config <path> ...]");
-  }
-
-  const readConfig = options.readConfig ?? defaultReadConfig;
-  const parts = [];
-  for (const p of parsed.configPaths) {
-    const raw = await readConfig(p);
-    parts.push(parseConfig(raw));
-  }
-  const config = mergeConfigs(parts);
-
-  const trace = await resolveTraceSink(parsed, log);
-
-  const gateway = await buildGatewayFromConfig(config, {
-    transportFactory: options.transportFactory,
-    logger: log,
-    ...(trace ? { trace } : {}),
-  });
-
-  const downstream = options.serverTransport ?? new StdioServerTransport();
-  const exposed = await createMcpServer(gateway.catalog, {
-    name: options.serverName ?? "ratel",
-    version: options.serverVersion ?? "0.0.0",
-    transport: downstream,
-    upstreamServers: gateway.upstreamServers,
-    runAuthFlow: gateway.runAuthFlow,
-  });
-  gateway.setListChangedNotifier(exposed.notifyToolListChanged);
-
-  const upstreamCount = Object.keys(config.mcpServers).length;
-  log(`[ratel] ready, ${upstreamCount} upstream server(s) configured`);
-
-  return {
-    shutdown: async () => {
-      await exposed.close();
-      await gateway.close();
-    },
-  };
-}
-
-async function runInspect(parsed: ParsedArgs, log: (m: string) => void): Promise<RunCliResult> {
-  if (parsed.flags.help === true) {
-    log(INSPECT_USAGE);
-    return {};
-  }
-  const all = parsed.flags.all === true;
-  const projectFlag = parsed.flags.project;
-  const project = typeof projectFlag === "string" ? projectFlag : undefined;
-  if (parsed.verb === "ls") {
-    const listOpts: { project?: string; all?: boolean } = {};
-    if (all) listOpts.all = true;
-    if (project) listOpts.project = project;
-    log(await listSessions(defaultTelemetryDir(), listOpts));
-    return {};
-  }
-  const opts: { from?: string; last?: number; project?: string; all?: boolean } = {};
-  const from = parsed.flags.from;
-  if (typeof from === "string") opts.from = from;
-  const last = parsed.flags.last;
-  if (typeof last === "string") {
-    const n = Number.parseInt(last, 10);
-    if (Number.isFinite(n)) opts.last = n;
-  }
-  if (all) opts.all = true;
-  if (project) opts.project = project;
-  log(await summarizeSession(opts));
-  return {};
-}
-
-async function resolveTraceSink(
-  parsed: ParsedArgs,
-  log: (m: string) => void,
-): Promise<TraceSinkConfig | undefined> {
-  const flag = parsed.flags.telemetry;
-  const flagFile = parsed.flags["telemetry-file"];
-  const env = process.env.RATEL_TELEMETRY;
-  if (flag === false || flag === "off" || env === "off") {
-    return { kind: "noop" };
-  }
-  const sessionId = newSessionId();
-  if (typeof flagFile === "string" && flagFile.length > 0) {
-    return { kind: "jsonl", sessionId, path: flagFile };
-  }
-  const bucket = projectBucketDir(defaultTelemetryDir(), process.cwd());
-  try {
-    await mkdir(bucket, { recursive: true });
-  } catch (err) {
-    log(`[ratel] could not create telemetry dir ${bucket}: ${(err as Error).message}; disabling`);
-    return { kind: "noop" };
-  }
-  const path = join(bucket, `${sessionId}.jsonl`);
-  return { kind: "jsonl", sessionId, path };
-}
-
-function newSessionId(): string {
-  const ts = new Date().toISOString().replace(/[:.]/g, "-");
-  const rand = Math.random().toString(36).slice(2, 8);
-  return `${ts}-${rand}`;
-}
-
-async function defaultReadConfig(path: string): Promise<unknown> {
-  try {
-    const text = await readFile(path, "utf8");
-    return JSON.parse(text);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      return { mcpServers: {} };
-    }
-    throw err;
-  }
 }
 
 function defaultEnv(): HierarchyEnv {

--- a/src/integrations/cli/src/handlers/backup.ts
+++ b/src/integrations/cli/src/handlers/backup.ts
@@ -1,0 +1,22 @@
+import { ArgError } from "../args.js";
+import { runListBackups } from "./list.js";
+import type { HandlerCtx } from "./types.js";
+import { runUndo } from "./undo.js";
+
+export const BACKUP_USAGE = `usage: ratel backup <verb> [args...]
+
+Verbs:
+  list    list backup sets under ~/.ratel/backups/`;
+
+export async function runBackup(ctx: HandlerCtx): Promise<void> {
+  switch (ctx.argv.verb) {
+    case "list":
+      await runListBackups(ctx);
+      return;
+    case "undo":
+      await runUndo(ctx);
+      return;
+    default:
+      throw new ArgError(`unknown backup verb: ${ctx.argv.verb}`);
+  }
+}

--- a/src/integrations/cli/src/handlers/import.test.ts
+++ b/src/integrations/cli/src/handlers/import.test.ts
@@ -147,7 +147,7 @@ describe("runImport", () => {
     expect(claude.mcpServers.ratel).toEqual({
       type: "stdio",
       command: "ratel",
-      args: ["mcp", "serve", "--config", RATEL_USER],
+      args: ["serve", "--config", RATEL_USER],
     });
   });
 
@@ -170,7 +170,6 @@ describe("runImport", () => {
 
     const claudeProj = JSON.parse(fs.files.get(PROJECT_MCP) as string);
     expect(claudeProj.mcpServers.ratel.args).toEqual([
-      "mcp",
       "serve",
       "--config",
       RATEL_USER,
@@ -200,9 +199,8 @@ describe("runImport", () => {
     await runImport(ctx, { bin: BIN, yes: true });
 
     const claude = JSON.parse(fs.files.get(HOME_CLAUDE) as string);
-    expect(claude.mcpServers.ratel.args).toEqual(["mcp", "serve", "--config", RATEL_USER]);
+    expect(claude.mcpServers.ratel.args).toEqual(["serve", "--config", RATEL_USER]);
     expect(claude.projects[ROOT].mcpServers.ratel.args).toEqual([
-      "mcp",
       "serve",
       "--config",
       RATEL_USER,
@@ -212,7 +210,6 @@ describe("runImport", () => {
       RATEL_LOCAL,
     ]);
     expect(JSON.parse(fs.files.get(PROJECT_MCP) as string).mcpServers.ratel.args).toEqual([
-      "mcp",
       "serve",
       "--config",
       RATEL_USER,

--- a/src/integrations/cli/src/handlers/inspect.ts
+++ b/src/integrations/cli/src/handlers/inspect.ts
@@ -1,0 +1,46 @@
+import type { ParsedArgs } from "../args.js";
+import { defaultTelemetryDir, listSessions, summarizeSession } from "../inspect.js";
+
+export const INSPECT_USAGE = `usage: ratel inspect [verb] [args...]
+
+Default (no verb) summarizes the most recent telemetry file in the bucket for
+the current cwd, under \`$RATEL_TELEMETRY_DIR/<project-slug>/\` (default root
+\`~/.ratel/telemetry/\`). The slug mirrors Claude Code's \`~/.claude/projects/\`
+convention: every \`/\` and \`.\` in the absolute path becomes \`-\`.
+
+Flags:
+  --from <FILE>          summarize a specific JSONL file
+  --last <N>             restrict the summary to the last N events
+  --project <ABS-PATH>   target another project's bucket explicitly
+  --all                  scan every bucket and pick the global newest
+
+Verbs:
+  ls   list telemetry files in the cwd's bucket (most recent first; use --all to enumerate every bucket)`;
+
+export async function runInspect(parsed: ParsedArgs, log: (m: string) => void): Promise<void> {
+  if (parsed.flags.help === true) {
+    log(INSPECT_USAGE);
+    return;
+  }
+  const all = parsed.flags.all === true;
+  const projectFlag = parsed.flags.project;
+  const project = typeof projectFlag === "string" ? projectFlag : undefined;
+  if (parsed.verb === "ls") {
+    const listOpts: { project?: string; all?: boolean } = {};
+    if (all) listOpts.all = true;
+    if (project) listOpts.project = project;
+    log(await listSessions(defaultTelemetryDir(), listOpts));
+    return;
+  }
+  const opts: { from?: string; last?: number; project?: string; all?: boolean } = {};
+  const from = parsed.flags.from;
+  if (typeof from === "string") opts.from = from;
+  const last = parsed.flags.last;
+  if (typeof last === "string") {
+    const n = Number.parseInt(last, 10);
+    if (Number.isFinite(n)) opts.last = n;
+  }
+  if (all) opts.all = true;
+  if (project) opts.project = project;
+  log(await summarizeSession(opts));
+}

--- a/src/integrations/cli/src/handlers/link.test.ts
+++ b/src/integrations/cli/src/handlers/link.test.ts
@@ -100,7 +100,7 @@ describe("runLink", () => {
     expect(claude.mcpServers.ratel).toEqual({
       type: "stdio",
       command: "ratel",
-      args: ["mcp", "serve", "--config", RATEL_USER],
+      args: ["serve", "--config", RATEL_USER],
     });
     // The covered entry was removed from Claude.
     expect(claude.mcpServers.fs).toBeUndefined();
@@ -207,7 +207,6 @@ describe("runLink", () => {
     await runLink(ctx, { bin: BIN, yes: true });
     const claudeProj = JSON.parse(fs.files.get(PROJECT_MCP) as string);
     expect(claudeProj.mcpServers.ratel.args).toEqual([
-      "mcp",
       "serve",
       "--config",
       RATEL_USER,

--- a/src/integrations/cli/src/handlers/mcp-serve.ts
+++ b/src/integrations/cli/src/handlers/mcp-serve.ts
@@ -1,0 +1,115 @@
+import { mkdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import {
+  buildGatewayFromConfig,
+  createMcpServer,
+  mergeConfigs,
+  parseConfig,
+  type TransportFactory,
+} from "@ratel-ai/mcp-server";
+import type { TraceSinkConfig } from "@ratel-ai/sdk";
+import type { ParsedArgs } from "../args.js";
+import { defaultTelemetryDir, projectBucketDir } from "../inspect.js";
+
+export interface McpServeOptions {
+  readConfig?: (path: string) => Promise<unknown>;
+  transportFactory?: TransportFactory;
+  serverTransport?: Transport;
+  serverName?: string;
+  serverVersion?: string;
+}
+
+export interface McpServeResult {
+  shutdown: () => Promise<void>;
+}
+
+export async function runMcpServe(
+  parsed: ParsedArgs,
+  options: McpServeOptions,
+  log: (m: string) => void,
+): Promise<McpServeResult> {
+  if (parsed.configPaths.length === 0) {
+    throw new Error("usage: ratel mcp serve <config.json> [--config <path> ...]");
+  }
+
+  const readConfig = options.readConfig ?? defaultReadConfig;
+  const parts = [];
+  for (const p of parsed.configPaths) {
+    const raw = await readConfig(p);
+    parts.push(parseConfig(raw));
+  }
+  const config = mergeConfigs(parts);
+
+  const trace = await resolveTraceSink(parsed, log);
+
+  const gateway = await buildGatewayFromConfig(config, {
+    transportFactory: options.transportFactory,
+    logger: log,
+    ...(trace ? { trace } : {}),
+  });
+
+  const downstream = options.serverTransport ?? new StdioServerTransport();
+  const exposed = await createMcpServer(gateway.catalog, {
+    name: options.serverName ?? "ratel",
+    version: options.serverVersion ?? "0.0.0",
+    transport: downstream,
+    upstreamServers: gateway.upstreamServers,
+    runAuthFlow: gateway.runAuthFlow,
+  });
+  gateway.setListChangedNotifier(exposed.notifyToolListChanged);
+
+  const upstreamCount = Object.keys(config.mcpServers).length;
+  log(`[ratel] ready, ${upstreamCount} upstream server(s) configured`);
+
+  return {
+    shutdown: async () => {
+      await exposed.close();
+      await gateway.close();
+    },
+  };
+}
+
+async function resolveTraceSink(
+  parsed: ParsedArgs,
+  log: (m: string) => void,
+): Promise<TraceSinkConfig | undefined> {
+  const flag = parsed.flags.telemetry;
+  const flagFile = parsed.flags["telemetry-file"];
+  const env = process.env.RATEL_TELEMETRY;
+  if (flag === false || flag === "off" || env === "off") {
+    return { kind: "noop" };
+  }
+  const sessionId = newSessionId();
+  if (typeof flagFile === "string" && flagFile.length > 0) {
+    return { kind: "jsonl", sessionId, path: flagFile };
+  }
+  const bucket = projectBucketDir(defaultTelemetryDir(), process.cwd());
+  try {
+    await mkdir(bucket, { recursive: true });
+  } catch (err) {
+    log(`[ratel] could not create telemetry dir ${bucket}: ${(err as Error).message}; disabling`);
+    return { kind: "noop" };
+  }
+  const path = join(bucket, `${sessionId}.jsonl`);
+  return { kind: "jsonl", sessionId, path };
+}
+
+function newSessionId(): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `${ts}-${rand}`;
+}
+
+async function defaultReadConfig(path: string): Promise<unknown> {
+  try {
+    const text = await readFile(path, "utf8");
+    return JSON.parse(text);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { mcpServers: {} };
+    }
+    throw err;
+  }
+}

--- a/src/integrations/cli/src/handlers/mcp.ts
+++ b/src/integrations/cli/src/handlers/mcp.ts
@@ -1,0 +1,59 @@
+import { ArgError } from "../args.js";
+import { runAdd } from "./add.js";
+import { runEdit } from "./edit.js";
+import { runMcpGet } from "./get.js";
+import { runImport } from "./import.js";
+import { runLink } from "./link.js";
+import { runMcpAuth } from "./mcp-auth.js";
+import { runMcpList } from "./mcp-list.js";
+import { runRemove } from "./remove.js";
+import type { HandlerCtx } from "./types.js";
+
+export const MCP_USAGE = `usage: ratel mcp <verb> [args...]
+
+Verbs:
+  serve   start the gateway over stdio (use --config <path> to load a Ratel config; repeat for multi-file merge)
+  add     add an MCP server entry (Claude-compatible: ratel mcp add [flags] <name> -- <command> [args...]
+                                   or ratel mcp add [flags] <name> <url>)
+  remove  remove an entry from a Ratel scope
+  list    list MCP servers configured across Ratel scopes
+  get     show one entry's resolved details
+  edit    edit fields on an existing entry (interactive when no flags supplied)
+  import  migrate Claude Code MCP configs into Ratel (two stages: Ratel write, then Claude rewrite)
+  link    rewrite Claude Code's config to point at Ratel for entries already in Ratel scopes
+  auth    drive an interactive OAuth flow for one or all http/sse upstreams that need authorization`;
+
+export async function runMcp(ctx: HandlerCtx): Promise<void> {
+  const { verb, flags } = ctx.argv;
+  switch (verb) {
+    case "add":
+      await runAdd(ctx);
+      return;
+    case "remove":
+      await runRemove(ctx);
+      return;
+    case "list":
+      await runMcpList(ctx);
+      return;
+    case "get":
+      await runMcpGet(ctx);
+      return;
+    case "edit":
+      await runEdit(ctx);
+      return;
+    case "import":
+      await runImport(ctx, {
+        yes: flags.yes === true,
+        dryRun: flags["dry-run"] === true,
+      });
+      return;
+    case "link":
+      await runLink(ctx, { yes: flags.yes === true });
+      return;
+    case "auth":
+      await runMcpAuth(ctx);
+      return;
+    default:
+      throw new ArgError(`unknown mcp verb: ${verb}`);
+  }
+}

--- a/src/integrations/cli/src/handlers/mcp.ts
+++ b/src/integrations/cli/src/handlers/mcp.ts
@@ -12,7 +12,6 @@ import type { HandlerCtx } from "./types.js";
 export const MCP_USAGE = `usage: ratel mcp <verb> [args...]
 
 Verbs:
-  serve   start the gateway over stdio (use --config <path> to load a Ratel config; repeat for multi-file merge)
   add     add an MCP server entry (Claude-compatible: ratel mcp add [flags] <name> -- <command> [args...]
                                    or ratel mcp add [flags] <name> <url>)
   remove  remove an entry from a Ratel scope
@@ -21,7 +20,9 @@ Verbs:
   edit    edit fields on an existing entry (interactive when no flags supplied)
   import  migrate Claude Code MCP configs into Ratel (two stages: Ratel write, then Claude rewrite)
   link    rewrite Claude Code's config to point at Ratel for entries already in Ratel scopes
-  auth    drive an interactive OAuth flow for one or all http/sse upstreams that need authorization`;
+  auth    drive an interactive OAuth flow for one or all http/sse upstreams that need authorization
+
+To start the gateway, see \`ratel serve\`.`;
 
 export async function runMcp(ctx: HandlerCtx): Promise<void> {
   const { verb, flags } = ctx.argv;

--- a/src/integrations/cli/src/handlers/serve.ts
+++ b/src/integrations/cli/src/handlers/serve.ts
@@ -13,7 +13,7 @@ import type { TraceSinkConfig } from "@ratel-ai/sdk";
 import type { ParsedArgs } from "../args.js";
 import { defaultTelemetryDir, projectBucketDir } from "../inspect.js";
 
-export interface McpServeOptions {
+export interface ServeOptions {
   readConfig?: (path: string) => Promise<unknown>;
   transportFactory?: TransportFactory;
   serverTransport?: Transport;
@@ -21,17 +21,17 @@ export interface McpServeOptions {
   serverVersion?: string;
 }
 
-export interface McpServeResult {
+export interface ServeResult {
   shutdown: () => Promise<void>;
 }
 
-export async function runMcpServe(
+export async function runServe(
   parsed: ParsedArgs,
-  options: McpServeOptions,
+  options: ServeOptions,
   log: (m: string) => void,
-): Promise<McpServeResult> {
+): Promise<ServeResult> {
   if (parsed.configPaths.length === 0) {
-    throw new Error("usage: ratel mcp serve <config.json> [--config <path> ...]");
+    throw new Error("usage: ratel serve <config.json> [--config <path> ...]");
   }
 
   const readConfig = options.readConfig ?? defaultReadConfig;

--- a/src/integrations/cli/src/import-plan.test.ts
+++ b/src/integrations/cli/src/import-plan.test.ts
@@ -88,7 +88,7 @@ describe("buildImportPlan", () => {
       ratel: {
         type: "stdio",
         command: "ratel",
-        args: ["mcp", "serve", "--config", RATEL_USER],
+        args: ["serve", "--config", RATEL_USER],
       },
     });
   });
@@ -109,7 +109,6 @@ describe("buildImportPlan", () => {
     ]);
     const claudeProject = parseAfter(plan, PROJECT_MCP);
     expect(claudeProject.mcpServers.ratel.args).toEqual([
-      "mcp",
       "serve",
       "--config",
       RATEL_USER,
@@ -140,9 +139,8 @@ describe("buildImportPlan", () => {
     expect(homeWrites).toHaveLength(1);
 
     const merged = parseAfter(plan, HOME_CLAUDE);
-    expect(merged.mcpServers.ratel.args).toEqual(["mcp", "serve", "--config", RATEL_USER]);
+    expect(merged.mcpServers.ratel.args).toEqual(["serve", "--config", RATEL_USER]);
     expect(merged.projects["/r"].mcpServers.ratel.args).toEqual([
-      "mcp",
       "serve",
       "--config",
       RATEL_USER,
@@ -197,7 +195,7 @@ describe("buildImportPlan", () => {
     const ratelStub: ServerEntry = {
       type: "stdio",
       command: "ratel",
-      args: ["mcp", "serve", "--config", RATEL_USER],
+      args: ["serve", "--config", RATEL_USER],
     };
     const plan = buildImportPlan(
       emptyInputs({

--- a/src/integrations/cli/src/import-plan.ts
+++ b/src/integrations/cli/src/import-plan.ts
@@ -268,7 +268,7 @@ function makeRatelEntry(bin: ResolvedBin, configArgs: string[]): ServerEntry {
   return {
     type: "stdio",
     command: bin.command,
-    args: [...bin.args, "mcp", "serve", ...configArgs],
+    args: [...bin.args, "serve", ...configArgs],
   };
 }
 

--- a/src/integrations/cli/src/inspect.test.ts
+++ b/src/integrations/cli/src/inspect.test.ts
@@ -1,0 +1,100 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { listSessions, summarizeSession } from "./inspect.js";
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "ratel-inspect-"));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+async function writeFixture(name: string, lines: object[]): Promise<string> {
+  const path = join(dir, name);
+  await writeFile(path, lines.map((l) => JSON.stringify(l)).join("\n"));
+  return path;
+}
+
+describe("ratel inspect", () => {
+  it("returns a friendly message when the directory has no telemetry files", async () => {
+    const out = await summarizeSession({ dir });
+    expect(out).toMatch(/no telemetry/);
+  });
+
+  it("summarizes session totals from a JSONL fixture", async () => {
+    const file = await writeFixture("trace.jsonl", [
+      {
+        v: 1,
+        ts: 1000,
+        session_id: "s1",
+        type: "search",
+        query: "x",
+        origin: "user",
+        top_k: 5,
+        hits: [{ tool_id: "t1", score: 1.0 }],
+        stages: [],
+        took_ms: 1,
+      },
+      { v: 1, ts: 1010, session_id: "s1", type: "invoke_start", tool_id: "t1", args_size_bytes: 4 },
+      { v: 1, ts: 1020, session_id: "s1", type: "invoke_end", tool_id: "t1", took_ms: 10 },
+      { v: 1, ts: 1030, session_id: "s1", type: "gateway_invoke", tool_id: "t1", took_ms: 12 },
+      {
+        v: 1,
+        ts: 1040,
+        session_id: "s1",
+        type: "invoke_error",
+        tool_id: "t1",
+        took_ms: 1,
+        error: "kaboom",
+      },
+    ]);
+
+    const out = await summarizeSession({ from: file });
+    expect(out).toContain("session s1");
+    expect(out).toContain("events");
+    expect(out).toContain("kaboom");
+    expect(out).toContain("top tools by hit");
+    expect(out).toContain("t1");
+    expect(out).toContain("gateway (search → invoke_tool)");
+  });
+
+  it("respects --last by truncating to the most recent N events", async () => {
+    const events = Array.from({ length: 6 }, (_, i) => ({
+      v: 1,
+      ts: 1000 + i * 10,
+      session_id: "s1",
+      type: "invoke_end",
+      tool_id: `t${i}`,
+      took_ms: 5,
+    }));
+    const file = await writeFixture("trace.jsonl", events);
+
+    const out = await summarizeSession({ from: file, last: 2 });
+    expect(out).toContain("invoke");
+    // direct invoke count should reflect only the last 2 events
+    expect(out).toMatch(/direct.*2/);
+  });
+
+  it("ls returns a friendly message on an empty dir", async () => {
+    const out = await listSessions(dir);
+    expect(out).toMatch(/no telemetry/);
+  });
+
+  it("ls lists the JSONL files newest-first", async () => {
+    const a = await writeFixture("a.jsonl", [{ v: 1, ts: 1, session_id: "x", type: "search" }]);
+    const b = await writeFixture("b.jsonl", [{ v: 1, ts: 2, session_id: "y", type: "search" }]);
+    void a;
+    void b;
+
+    const out = await listSessions(dir);
+    expect(out).toContain("file");
+    expect(out).toContain("size");
+    expect(out).toContain("a.jsonl");
+    expect(out).toContain("b.jsonl");
+  });
+});

--- a/src/integrations/cli/src/inspect.test.ts
+++ b/src/integrations/cli/src/inspect.test.ts
@@ -1,8 +1,8 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { listSessions, summarizeSession } from "./inspect.js";
+import { listSessions, projectBucketDir, slugifyProjectPath, summarizeSession } from "./inspect.js";
 
 let dir: string;
 
@@ -85,15 +85,147 @@ describe("ratel inspect", () => {
     expect(out).toMatch(/no telemetry/);
   });
 
-  it("ls lists the JSONL files newest-first", async () => {
-    const a = await writeFixture("a.jsonl", [{ v: 1, ts: 1, session_id: "x", type: "search" }]);
-    const b = await writeFixture("b.jsonl", [{ v: 1, ts: 2, session_id: "y", type: "search" }]);
-    void a;
-    void b;
+  it("ls --all lists JSONL files across buckets newest-first", async () => {
+    const bucketA = projectBucketDir(dir, "/Users/test/proj-a");
+    await mkdir(bucketA, { recursive: true });
+    await writeFile(
+      join(bucketA, "a.jsonl"),
+      JSON.stringify({ v: 1, ts: 1, session_id: "x", type: "search" }),
+    );
+    const bucketB = projectBucketDir(dir, "/Users/test/proj-b");
+    await mkdir(bucketB, { recursive: true });
+    await writeFile(
+      join(bucketB, "b.jsonl"),
+      JSON.stringify({ v: 1, ts: 2, session_id: "y", type: "search" }),
+    );
 
-    const out = await listSessions(dir);
-    expect(out).toContain("file");
+    const out = await listSessions(dir, { all: true });
     expect(out).toContain("size");
+    expect(out).toContain("a.jsonl");
+    expect(out).toContain("b.jsonl");
+  });
+});
+
+describe("slugifyProjectPath", () => {
+  it("replaces every / with - and keeps the leading dash", () => {
+    expect(slugifyProjectPath("/Users/example/path/to/project")).toBe(
+      "-Users-example-path-to-project",
+    );
+  });
+
+  it("replaces dots with dashes (CC parity)", () => {
+    expect(slugifyProjectPath("/Users/rstagi/.ralph/worktrees/platform/issue-52")).toBe(
+      "-Users-rstagi--ralph-worktrees-platform-issue-52",
+    );
+  });
+
+  it("turns the bare root into a single dash", () => {
+    expect(slugifyProjectPath("/")).toBe("-");
+  });
+
+  it("turns multiple consecutive dots into multiple dashes", () => {
+    expect(slugifyProjectPath("/foo/...triple")).toBe("-foo----triple");
+  });
+
+  it("handles a leaf with multiple dots", () => {
+    expect(slugifyProjectPath("/a/b.c.d")).toBe("-a-b-c-d");
+  });
+});
+
+describe("projectBucketDir", () => {
+  it("joins the global root with the slug of the absolute path", () => {
+    const out = projectBucketDir("/tmp/r", "/Users/x/y");
+    expect(out).toBe(join("/tmp/r", "-Users-x-y"));
+  });
+});
+
+describe("ratel inspect — per-project buckets", () => {
+  async function writeBucketFixture(
+    project: string,
+    name: string,
+    lines: object[],
+  ): Promise<string> {
+    const bucket = projectBucketDir(dir, project);
+    await mkdir(bucket, { recursive: true });
+    const path = join(bucket, name);
+    await writeFile(path, lines.map((l) => JSON.stringify(l)).join("\n"));
+    return path;
+  }
+
+  it("summarizes the session for the given project's bucket", async () => {
+    const project = "/Users/test/proj-a";
+    await writeBucketFixture(project, "trace.jsonl", [
+      { v: 1, ts: 1, session_id: "sA", type: "search", query: "x", origin: "user" },
+      { v: 1, ts: 2, session_id: "sA", type: "invoke_end", tool_id: "t", took_ms: 1 },
+    ]);
+
+    const out = await summarizeSession({ dir, project });
+    expect(out).toContain("session sA");
+  });
+
+  it("returns a project-scoped no-telemetry message when the bucket is empty", async () => {
+    const project = "/Users/test/empty-proj";
+    const out = await summarizeSession({ dir, project });
+    expect(out).toMatch(/no telemetry for this project/);
+    expect(out).toContain("-Users-test-empty-proj");
+  });
+
+  it("does not surface another project's session when scoped by project", async () => {
+    await writeBucketFixture("/Users/test/proj-a", "a.jsonl", [
+      { v: 1, ts: 100, session_id: "sA", type: "search", query: "x", origin: "user" },
+    ]);
+    await writeBucketFixture("/Users/test/proj-b", "b.jsonl", [
+      { v: 1, ts: 200, session_id: "sB", type: "search", query: "x", origin: "user" },
+    ]);
+
+    const out = await summarizeSession({ dir, project: "/Users/test/proj-a" });
+    expect(out).toContain("session sA");
+    expect(out).not.toContain("session sB");
+  });
+
+  it("with --all, walks every bucket and picks the global newest", async () => {
+    await writeBucketFixture("/Users/test/proj-a", "a.jsonl", [
+      { v: 1, ts: 100, session_id: "sA", type: "search", query: "x", origin: "user" },
+    ]);
+    // Ensure proj-b's file has a newer mtime than proj-a's.
+    await new Promise((r) => setTimeout(r, 10));
+    await writeBucketFixture("/Users/test/proj-b", "b.jsonl", [
+      { v: 1, ts: 200, session_id: "sB", type: "search", query: "x", origin: "user" },
+    ]);
+
+    const out = await summarizeSession({ dir, all: true });
+    expect(out).toContain("session sB");
+  });
+
+  it("--all on an empty root returns a root-scoped no-telemetry message", async () => {
+    const out = await summarizeSession({ dir, all: true });
+    expect(out).toMatch(/no telemetry under/);
+  });
+
+  it("ls scopes to the project's bucket by default", async () => {
+    await writeBucketFixture("/Users/test/proj-a", "a.jsonl", [
+      { v: 1, ts: 1, session_id: "sA", type: "search" },
+    ]);
+    await writeBucketFixture("/Users/test/proj-b", "b.jsonl", [
+      { v: 1, ts: 2, session_id: "sB", type: "search" },
+    ]);
+
+    const out = await listSessions(dir, { project: "/Users/test/proj-a" });
+    expect(out).toContain("a.jsonl");
+    expect(out).not.toContain("b.jsonl");
+  });
+
+  it("ls --all enumerates buckets and prefixes the slug for disambiguation", async () => {
+    await writeBucketFixture("/Users/test/proj-a", "a.jsonl", [
+      { v: 1, ts: 1, session_id: "sA", type: "search" },
+    ]);
+    await writeBucketFixture("/Users/test/proj-b", "b.jsonl", [
+      { v: 1, ts: 2, session_id: "sB", type: "search" },
+    ]);
+
+    const out = await listSessions(dir, { all: true });
+    expect(out).toContain("-Users-test-proj-a");
+    expect(out).toContain("-Users-test-proj-b");
     expect(out).toContain("a.jsonl");
     expect(out).toContain("b.jsonl");
   });

--- a/src/integrations/cli/src/inspect.test.ts
+++ b/src/integrations/cli/src/inspect.test.ts
@@ -34,7 +34,7 @@ describe("ratel inspect", () => {
         session_id: "s1",
         type: "search",
         query: "x",
-        origin: "user",
+        origin: "direct",
         top_k: 5,
         hits: [{ tool_id: "t1", score: 1.0 }],
         stages: [],
@@ -155,7 +155,7 @@ describe("ratel inspect — per-project buckets", () => {
   it("summarizes the session for the given project's bucket", async () => {
     const project = "/Users/test/proj-a";
     await writeBucketFixture(project, "trace.jsonl", [
-      { v: 1, ts: 1, session_id: "sA", type: "search", query: "x", origin: "user" },
+      { v: 1, ts: 1, session_id: "sA", type: "search", query: "x", origin: "direct" },
       { v: 1, ts: 2, session_id: "sA", type: "invoke_end", tool_id: "t", took_ms: 1 },
     ]);
 
@@ -172,10 +172,10 @@ describe("ratel inspect — per-project buckets", () => {
 
   it("does not surface another project's session when scoped by project", async () => {
     await writeBucketFixture("/Users/test/proj-a", "a.jsonl", [
-      { v: 1, ts: 100, session_id: "sA", type: "search", query: "x", origin: "user" },
+      { v: 1, ts: 100, session_id: "sA", type: "search", query: "x", origin: "direct" },
     ]);
     await writeBucketFixture("/Users/test/proj-b", "b.jsonl", [
-      { v: 1, ts: 200, session_id: "sB", type: "search", query: "x", origin: "user" },
+      { v: 1, ts: 200, session_id: "sB", type: "search", query: "x", origin: "direct" },
     ]);
 
     const out = await summarizeSession({ dir, project: "/Users/test/proj-a" });
@@ -185,12 +185,12 @@ describe("ratel inspect — per-project buckets", () => {
 
   it("with --all, walks every bucket and picks the global newest", async () => {
     await writeBucketFixture("/Users/test/proj-a", "a.jsonl", [
-      { v: 1, ts: 100, session_id: "sA", type: "search", query: "x", origin: "user" },
+      { v: 1, ts: 100, session_id: "sA", type: "search", query: "x", origin: "direct" },
     ]);
     // Ensure proj-b's file has a newer mtime than proj-a's.
     await new Promise((r) => setTimeout(r, 10));
     await writeBucketFixture("/Users/test/proj-b", "b.jsonl", [
-      { v: 1, ts: 200, session_id: "sB", type: "search", query: "x", origin: "user" },
+      { v: 1, ts: 200, session_id: "sB", type: "search", query: "x", origin: "direct" },
     ]);
 
     const out = await summarizeSession({ dir, all: true });

--- a/src/integrations/cli/src/inspect.ts
+++ b/src/integrations/cli/src/inspect.ts
@@ -14,26 +14,64 @@ export interface InspectOptions {
   from?: string;
   /** Restrict the summary to the most recent N events. */
   last?: number;
-  /** Override telemetry directory. Default `$RATEL_TELEMETRY_DIR` or `~/.ratel/telemetry`. */
+  /** Override the telemetry root. Default `$RATEL_TELEMETRY_DIR` or `~/.ratel/telemetry`. */
   dir?: string;
+  /** Absolute project path; selects the bucket. Defaults to `process.cwd()`. */
+  project?: string;
+  /** Scan every bucket under the root, picking the global newest by mtime. */
+  all?: boolean;
 }
 
+export interface ListOptions {
+  project?: string;
+  all?: boolean;
+}
+
+/** Telemetry root. Per-project buckets nest under this. */
 export function defaultTelemetryDir(): string {
   return process.env.RATEL_TELEMETRY_DIR ?? join(homedir(), ".ratel", "telemetry");
 }
 
-export async function listSessions(dir: string = defaultTelemetryDir()): Promise<string> {
+/** Mirror of Claude Code's `~/.claude/projects/<slug>/` rule: every `/` and `.` becomes `-`. */
+export function slugifyProjectPath(absPath: string): string {
+  return absPath.replace(/[/.]/g, "-");
+}
+
+export function projectBucketDir(root: string, absPath: string): string {
+  return join(root, slugifyProjectPath(absPath));
+}
+
+export async function listSessions(
+  dir: string = defaultTelemetryDir(),
+  opts: ListOptions = {},
+): Promise<string> {
+  if (opts.all) {
+    const rows = await collectAcrossBuckets(dir);
+    if (rows.length === 0) return `no telemetry under ${dir}`;
+    rows.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+    const header = `${pad("project", 36)}  ${pad("file", 56)}  ${pad("size", 10, "right")}  modified`;
+    const body = rows
+      .map(
+        (r) =>
+          `${pad(r.slug, 36)}  ${pad(r.name, 56)}  ${pad(formatSize(r.size), 10, "right")}  ${r.mtime.toISOString()}`,
+      )
+      .join("\n");
+    return `${header}\n${body}`;
+  }
+
+  const project = opts.project ?? process.cwd();
+  const bucket = projectBucketDir(dir, project);
   let entries: string[];
   try {
-    entries = await readdir(dir);
+    entries = await readdir(bucket);
   } catch {
-    return `no telemetry under ${dir}`;
+    return `no telemetry for this project (${bucket})`;
   }
   const files = entries.filter((e) => e.endsWith(".jsonl"));
-  if (files.length === 0) return `no telemetry under ${dir}`;
+  if (files.length === 0) return `no telemetry for this project (${bucket})`;
   const rows: Array<{ name: string; size: number; mtime: Date }> = [];
   for (const f of files) {
-    const s = await stat(join(dir, f));
+    const s = await stat(join(bucket, f));
     rows.push({ name: f, size: s.size, mtime: s.mtime });
   }
   rows.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
@@ -49,8 +87,22 @@ export async function listSessions(dir: string = defaultTelemetryDir()): Promise
 
 export async function summarizeSession(opts: InspectOptions = {}): Promise<string> {
   const dir = opts.dir ?? defaultTelemetryDir();
-  const file = opts.from ?? (await mostRecent(dir));
-  if (!file) return `no telemetry under ${dir}`;
+
+  let file: string | undefined;
+  let emptyMessage: string;
+  if (opts.from) {
+    file = opts.from;
+    emptyMessage = `${opts.from}: no events`;
+  } else if (opts.all) {
+    file = await mostRecentAcrossBuckets(dir);
+    emptyMessage = `no telemetry under ${dir}`;
+  } else {
+    const project = opts.project ?? process.cwd();
+    const bucket = projectBucketDir(dir, project);
+    file = await mostRecent(bucket);
+    emptyMessage = `no telemetry for this project (${bucket})`;
+  }
+  if (!file) return emptyMessage;
 
   const events = await readEvents(file, opts.last);
   if (events.length === 0) return `${file}: no events`;
@@ -85,6 +137,60 @@ async function mostRecent(dir: string): Promise<string | undefined> {
   }
   rows.sort((a, b) => b.mtime - a.mtime);
   return rows[0].path;
+}
+
+async function mostRecentAcrossBuckets(root: string): Promise<string | undefined> {
+  const rows = await collectAcrossBuckets(root);
+  if (rows.length === 0) return undefined;
+  rows.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+  return rows[0].path;
+}
+
+interface BucketRow {
+  slug: string;
+  name: string;
+  path: string;
+  size: number;
+  mtime: Date;
+}
+
+async function collectAcrossBuckets(root: string): Promise<BucketRow[]> {
+  let buckets: string[];
+  try {
+    buckets = await readdir(root);
+  } catch {
+    return [];
+  }
+  const rows: BucketRow[] = [];
+  for (const slug of buckets) {
+    const bucket = join(root, slug);
+    let bucketStat: Awaited<ReturnType<typeof stat>>;
+    try {
+      bucketStat = await stat(bucket);
+    } catch {
+      continue;
+    }
+    if (!bucketStat.isDirectory()) continue;
+    let entries: string[];
+    try {
+      entries = await readdir(bucket);
+    } catch {
+      continue;
+    }
+    for (const name of entries) {
+      if (!name.endsWith(".jsonl")) continue;
+      const filePath = join(bucket, name);
+      const fileStat = await stat(filePath);
+      rows.push({
+        slug,
+        name,
+        path: filePath,
+        size: fileStat.size,
+        mtime: fileStat.mtime,
+      });
+    }
+  }
+  return rows;
 }
 
 async function readEvents(file: string, last?: number): Promise<BaseEvent[]> {

--- a/src/integrations/cli/src/inspect.ts
+++ b/src/integrations/cli/src/inspect.ts
@@ -1,0 +1,226 @@
+import { createReadStream } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+
+interface BaseEvent {
+  type: string;
+  ts: number;
+  session_id: string;
+}
+
+export interface InspectOptions {
+  from?: string;
+  /** Restrict the summary to the most recent N events. */
+  last?: number;
+  /** Override telemetry directory. Default `$RATEL_TELEMETRY_DIR` or `~/.ratel/telemetry`. */
+  dir?: string;
+}
+
+export function defaultTelemetryDir(): string {
+  return process.env.RATEL_TELEMETRY_DIR ?? join(homedir(), ".ratel", "telemetry");
+}
+
+export async function listSessions(dir: string = defaultTelemetryDir()): Promise<string> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return `no telemetry under ${dir}`;
+  }
+  const files = entries.filter((e) => e.endsWith(".jsonl"));
+  if (files.length === 0) return `no telemetry under ${dir}`;
+  const rows: Array<{ name: string; size: number; mtime: Date }> = [];
+  for (const f of files) {
+    const s = await stat(join(dir, f));
+    rows.push({ name: f, size: s.size, mtime: s.mtime });
+  }
+  rows.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+  const header = `${pad("file", 56)}  ${pad("size", 10, "right")}  modified`;
+  const body = rows
+    .map(
+      (r) =>
+        `${pad(r.name, 56)}  ${pad(formatSize(r.size), 10, "right")}  ${r.mtime.toISOString()}`,
+    )
+    .join("\n");
+  return `${header}\n${body}`;
+}
+
+export async function summarizeSession(opts: InspectOptions = {}): Promise<string> {
+  const dir = opts.dir ?? defaultTelemetryDir();
+  const file = opts.from ?? (await mostRecent(dir));
+  if (!file) return `no telemetry under ${dir}`;
+
+  const events = await readEvents(file, opts.last);
+  if (events.length === 0) return `${file}: no events`;
+
+  return [
+    `session ${describeSession(events)}`,
+    `file:    ${file}`,
+    "",
+    sessionTotals(events),
+    "",
+    topToolsByHit(events),
+    "",
+    gatewayVsDirect(events),
+    "",
+    topErrors(events),
+  ].join("\n");
+}
+
+async function mostRecent(dir: string): Promise<string | undefined> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return undefined;
+  }
+  const files = entries.filter((e) => e.endsWith(".jsonl"));
+  if (files.length === 0) return undefined;
+  const rows: Array<{ path: string; mtime: number }> = [];
+  for (const f of files) {
+    const s = await stat(join(dir, f));
+    rows.push({ path: join(dir, f), mtime: s.mtime.getTime() });
+  }
+  rows.sort((a, b) => b.mtime - a.mtime);
+  return rows[0].path;
+}
+
+async function readEvents(file: string, last?: number): Promise<BaseEvent[]> {
+  const out: BaseEvent[] = [];
+  const stream = createReadStream(file, { encoding: "utf8" });
+  const lines = createInterface({ input: stream, crlfDelay: Infinity });
+  for await (const line of lines) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line) as BaseEvent;
+      out.push(parsed);
+    } catch {
+      // skip malformed lines — query-log semantics tolerate corruption
+    }
+  }
+  if (typeof last === "number" && out.length > last) {
+    return out.slice(out.length - last);
+  }
+  return out;
+}
+
+function describeSession(events: BaseEvent[]): string {
+  const sids = new Set(events.map((e) => e.session_id));
+  if (sids.size === 1) return events[0].session_id;
+  return `${sids.size} session(s)`;
+}
+
+function sessionTotals(events: BaseEvent[]): string {
+  const totals: Record<string, number> = {
+    total: events.length,
+    search: 0,
+    invoke: 0,
+    gateway: 0,
+    upstream: 0,
+    auth: 0,
+    error: 0,
+  };
+  for (const e of events) {
+    if (e.type === "search") totals.search++;
+    else if (e.type.startsWith("invoke")) totals.invoke++;
+    else if (e.type.startsWith("gateway")) totals.gateway++;
+    else if (e.type.startsWith("upstream")) totals.upstream++;
+    else if (e.type.startsWith("auth")) totals.auth++;
+    if (e.type.endsWith("_error") || e.type === "gateway_error" || e.type === "upstream_error") {
+      totals.error++;
+    }
+  }
+  const wallMs = events.length > 0 ? events[events.length - 1].ts - events[0].ts : 0;
+  const rows: Array<[string, string]> = [
+    ["events", String(totals.total)],
+    ["search", String(totals.search)],
+    ["invoke", String(totals.invoke)],
+    ["gateway", String(totals.gateway)],
+    ["upstream", String(totals.upstream)],
+    ["auth", String(totals.auth)],
+    ["errors", String(totals.error)],
+    ["wall ms", String(wallMs)],
+  ];
+  return formatTable(["totals", "value"], rows);
+}
+
+function topToolsByHit(events: BaseEvent[]): string {
+  const counts = new Map<string, number>();
+  for (const e of events) {
+    const ev = e as BaseEvent & { hits?: Array<{ tool_id: string }> };
+    if (ev.type === "search" && Array.isArray(ev.hits)) {
+      for (const h of ev.hits) counts.set(h.tool_id, (counts.get(h.tool_id) ?? 0) + 1);
+    }
+  }
+  const rows = Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
+    .map(([id, n]) => [id, String(n)] as [string, string]);
+  if (rows.length === 0) rows.push(["—", "0"]);
+  return formatTable(["top tools by hit", "count"], rows);
+}
+
+function gatewayVsDirect(events: BaseEvent[]): string {
+  let gw = 0;
+  let direct = 0;
+  for (const e of events) {
+    if (e.type === "gateway_invoke") gw++;
+    else if (e.type === "invoke_end") direct++;
+  }
+  // direct includes both the gateway-routed invokes AND any other invokes; subtract gw to get the truly-direct count.
+  const trulyDirect = Math.max(0, direct - gw);
+  return formatTable(
+    ["invoke source", "count"],
+    [
+      ["gateway (search → invoke_tool)", String(gw)],
+      ["direct (catalog.invoke)", String(trulyDirect)],
+    ],
+  );
+}
+
+function topErrors(events: BaseEvent[]): string {
+  const counts = new Map<string, number>();
+  for (const e of events) {
+    const ev = e as BaseEvent & { error?: string };
+    if (
+      (e.type === "invoke_error" || e.type === "gateway_error" || e.type === "upstream_error") &&
+      typeof ev.error === "string"
+    ) {
+      counts.set(ev.error, (counts.get(ev.error) ?? 0) + 1);
+    }
+  }
+  const rows = Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
+    .map(([m, n]) => [truncate(m, 80), String(n)] as [string, string]);
+  if (rows.length === 0) rows.push(["—", "0"]);
+  return formatTable(["top errors", "count"], rows);
+}
+
+function formatTable(header: [string, string], rows: Array<[string, string]>): string {
+  const left = Math.max(header[0].length, ...rows.map((r) => r[0].length));
+  const right = Math.max(header[1].length, ...rows.map((r) => r[1].length));
+  const sep = `${"-".repeat(left)}  ${"-".repeat(right)}`;
+  const head = `${pad(header[0], left)}  ${pad(header[1], right, "right")}`;
+  const body = rows.map((r) => `${pad(r[0], left)}  ${pad(r[1], right, "right")}`).join("\n");
+  return `${head}\n${sep}\n${body}`;
+}
+
+function pad(s: string, width: number, align: "left" | "right" = "left"): string {
+  if (s.length >= width) return s;
+  const fill = " ".repeat(width - s.length);
+  return align === "right" ? `${fill}${s}` : `${s}${fill}`;
+}
+
+function formatSize(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function truncate(s: string, n: number): string {
+  if (s.length <= n) return s;
+  return `${s.slice(0, n - 1)}…`;
+}

--- a/src/integrations/cli/src/probe.ts
+++ b/src/integrations/cli/src/probe.ts
@@ -95,7 +95,7 @@ export interface AuthProbeResult {
  * One-shot OAuth + register pass for an HTTP/SSE entry. Wraps `defaultAuthStep`
  * so `ratel mcp add` can persist tokens and capture the upstream's instructions
  * at add-time. The handle returned by the underlying step is closed before we
- * return — the catalog we register into is discarded; `ratel mcp serve` will
+ * return — the catalog we register into is discarded; `ratel serve` will
  * re-register against fresh transports using the just-persisted tokens.
  */
 export async function authProbeEntry(

--- a/src/integrations/mcp-server/CHANGELOG.md
+++ b/src/integrations/mcp-server/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+### Added
+
+- `buildGatewayFromConfig` accepts `trace` config and threads it through the catalog ([ADR-0009](../../../docs/adr/0009-trace-events-core-owned-schema.md)). The boot path emits `auth_refresh{ok}` for every refresh attempt and `auth_needs` whenever an upstream is flagged. `runAuthFlow` brackets each per-upstream step with `auth_flow_start` / `auth_flow_end{ok}`. `createMcpServer`'s `onUnauthorized` handler emits `auth_needs` when `invoke_tool` surfaces a 401 mid-session.
+
 ## [0.1.5-rc.3] - 2026-05-08
 
 ### Added

--- a/src/integrations/mcp-server/README.md
+++ b/src/integrations/mcp-server/README.md
@@ -152,7 +152,7 @@ const gateway = await buildGatewayFromConfig(config, {
 });
 ```
 
-Default is no-op — opt in to capture. The CLI's `ratel mcp serve` defaults to a JSONL sink under `~/.ratel/telemetry/`; see [`@ratel-ai/cli`](../cli/README.md) for the flags.
+Default is no-op — opt in to capture. The CLI's `ratel mcp serve` defaults to a JSONL sink under `~/.ratel/telemetry/<project-slug>/` (the slug mirrors Claude Code's `~/.claude/projects/` convention); see [`@ratel-ai/cli`](../cli/README.md) for the flags.
 
 ## Result wrapping
 

--- a/src/integrations/mcp-server/README.md
+++ b/src/integrations/mcp-server/README.md
@@ -152,7 +152,7 @@ const gateway = await buildGatewayFromConfig(config, {
 });
 ```
 
-Default is no-op — opt in to capture. The CLI's `ratel mcp serve` defaults to a JSONL sink under `~/.ratel/telemetry/<project-slug>/` (the slug mirrors Claude Code's `~/.claude/projects/` convention); see [`@ratel-ai/cli`](../cli/README.md) for the flags.
+Default is no-op — opt in to capture. The CLI's `ratel serve` defaults to a JSONL sink under `~/.ratel/telemetry/<project-slug>/` (the slug mirrors Claude Code's `~/.claude/projects/` convention); see [`@ratel-ai/cli`](../cli/README.md) for the flags.
 
 ## Result wrapping
 

--- a/src/integrations/mcp-server/README.md
+++ b/src/integrations/mcp-server/README.md
@@ -138,6 +138,22 @@ gateway.setListChangedNotifier(async () => {
 
 The CLI surface (`ratel mcp auth`, the OAuth columns in `ratel mcp list`) lives in [`@ratel-ai/cli`](../cli/README.md).
 
+## Telemetry
+
+Pass `trace` to `buildGatewayFromConfig` to forward it to the underlying `ToolCatalog` ([ADR 0009](../../../docs/adr/0009-trace-events-core-owned-schema.md)). The catalog emits search / invoke / gateway / upstream events; this library adds `auth_refresh`, `auth_needs`, `auth_flow_start`, and `auth_flow_end` around the OAuth boot and interactive paths.
+
+```ts
+const gateway = await buildGatewayFromConfig(config, {
+  trace: {
+    kind: "jsonl",
+    sessionId: "session-1",
+    path: "/tmp/ratel.jsonl",
+  },
+});
+```
+
+Default is no-op — opt in to capture. The CLI's `ratel mcp serve` defaults to a JSONL sink under `~/.ratel/telemetry/`; see [`@ratel-ai/cli`](../cli/README.md) for the flags.
+
 ## Result wrapping
 
 Every `tools/call` response carries the gateway's return value as a JSON-serialized text block; plain-object returns are also surfaced as `structuredContent`:

--- a/src/integrations/mcp-server/src/gateway.test.ts
+++ b/src/integrations/mcp-server/src/gateway.test.ts
@@ -391,6 +391,65 @@ describe("buildGatewayFromConfig", () => {
       await ok.server.close();
     });
 
+    it("emits auth_refresh{ok:true} after a successful boot-time refresh", async () => {
+      const ok = await startUpstream([{ name: "ping", description: "Ping." }]);
+      await seedStoredTokens("locked", Date.now() - 5_000);
+
+      const handle = await buildGatewayFromConfig(
+        {
+          mcpServers: {
+            locked: { type: "http", url: "https://locked.example/mcp" },
+          },
+        },
+        {
+          transportFactory: () => ok.clientTransport,
+          oauthStorePath: storePath,
+          refreshTokens: async () => undefined,
+          trace: { kind: "memory", sessionId: "t" },
+        },
+      );
+
+      const events = handle.catalog.drainTraceEvents() as Array<Record<string, unknown>>;
+      const refreshed = events.find((e) => e.type === "auth_refresh");
+      expect(refreshed?.upstream).toBe("locked");
+      expect(refreshed?.ok).toBe(true);
+
+      await handle.close();
+      await ok.server.close();
+    });
+
+    it("emits auth_refresh{ok:false} and auth_needs when refresh fails", async () => {
+      const ok = await startUpstream([{ name: "ping", description: "Ping." }]);
+      await seedStoredTokens("locked", Date.now() - 5_000);
+
+      const handle = await buildGatewayFromConfig(
+        {
+          mcpServers: {
+            locked: { type: "http", url: "https://locked.example/mcp" },
+          },
+        },
+        {
+          transportFactory: () => ok.clientTransport,
+          oauthStorePath: storePath,
+          refreshTokens: async () => {
+            throw new RefreshFailedError(new Error("invalid_grant"));
+          },
+          trace: { kind: "memory", sessionId: "t" },
+        },
+      );
+
+      const events = handle.catalog.drainTraceEvents() as Array<Record<string, unknown>>;
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: "auth_refresh", upstream: "locked", ok: false }),
+      );
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: "auth_needs", upstream: "locked" }),
+      );
+
+      await handle.close();
+      await ok.server.close();
+    });
+
     it("skips proactive refresh for HTTP upstreams without stored tokens", async () => {
       const ok = await startUpstream([{ name: "ping", description: "Ping." }]);
       const refreshTokens = vi.fn();

--- a/src/integrations/mcp-server/src/gateway.ts
+++ b/src/integrations/mcp-server/src/gateway.ts
@@ -7,6 +7,7 @@ import {
   type McpServerHandle,
   registerMcpServer,
   ToolCatalog,
+  type TraceSinkConfig,
   type UpstreamServerInfo,
 } from "@ratel-ai/sdk";
 import type { RatelConfig, ServerEntry } from "./config.js";
@@ -41,6 +42,8 @@ export interface BuildGatewayOptions {
   authStep?: AuthStep;
   /** Override boot-time token refresh. Default: refreshIfNeeded against the upstream's store. */
   refreshTokens?: RefreshTokensFn;
+  /** Trace sink configuration; forwarded to the catalog. Default: noop (no events captured). */
+  trace?: TraceSinkConfig;
 }
 
 const PLACEHOLDER_REDIRECT_URL = "http://127.0.0.1:0/cb";
@@ -77,7 +80,7 @@ export async function buildGatewayFromConfig(
   const step = options.authStep ?? defaultAuthStep({ logger: log, storePath });
   const refreshTokens = options.refreshTokens ?? defaultRefreshTokens;
 
-  const catalog = new ToolCatalog();
+  const catalog = new ToolCatalog(options.trace ? { trace: options.trace } : {});
   const handles = new Map<string, McpServerHandle>();
   const upstreamServers: UpstreamServerInfo[] = [];
   const configEntries: Record<string, ServerEntry> = { ...config.mcpServers };
@@ -90,8 +93,11 @@ export async function buildGatewayFromConfig(
       if (hadTokens) {
         try {
           await refreshTokens(store, name);
+          catalog.recordEvent({ type: "auth_refresh", upstream: name, ok: true });
         } catch (err) {
+          catalog.recordEvent({ type: "auth_refresh", upstream: name, ok: false });
           markNeedsAuth(upstreamServers, name, entry);
+          catalog.recordEvent({ type: "auth_needs", upstream: name });
           log(
             `[ratel] ${name} needs re-authorization (refresh failed: ${(err as Error).message}) — run "ratel mcp auth ${name}"`,
           );
@@ -116,6 +122,7 @@ export async function buildGatewayFromConfig(
     } catch (err) {
       if (isUnauthorized(err) || (isHttpOrSse(entry) && isAuthShapedError(err))) {
         markNeedsAuth(upstreamServers, name, entry);
+        catalog.recordEvent({ type: "auth_needs", upstream: name });
         log(
           `[ratel] ${name} requires authorization — run "ratel mcp auth ${name}" or call the auth tool`,
         );

--- a/src/integrations/mcp-server/src/oauth/flow.ts
+++ b/src/integrations/mcp-server/src/oauth/flow.ts
@@ -111,16 +111,20 @@ async function runOne(
 ): Promise<AuthFlowResult> {
   const { catalog, upstreams, handles, step, onListChanged, logger } = deps;
 
+  catalog.recordEvent({ type: "auth_flow_start", upstream: name });
   let result: AuthStepResult;
   try {
     result = await step(name, entry, { catalog, logger });
   } catch (err) {
+    catalog.recordEvent({ type: "auth_flow_end", upstream: name, ok: false });
     return { name, status: "failed", reason: (err as Error).message };
   }
 
   if (result.status !== "authorized") {
+    catalog.recordEvent({ type: "auth_flow_end", upstream: name, ok: false });
     return { name, status: result.status, reason: result.reason };
   }
+  catalog.recordEvent({ type: "auth_flow_end", upstream: name, ok: true });
 
   const previous = handles.get(name);
   if (previous) {

--- a/src/integrations/mcp-server/src/server.ts
+++ b/src/integrations/mcp-server/src/server.ts
@@ -46,6 +46,7 @@ export async function createMcpServer(
     if (info && !info.needsAuth) {
       info.needsAuth = true;
     }
+    catalog.recordEvent({ type: "auth_needs", upstream });
     void server.sendToolListChanged().catch(() => undefined);
   };
 

--- a/src/sdk/ts/CHANGELOG.md
+++ b/src/sdk/ts/CHANGELOG.md
@@ -6,6 +6,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+### Added
+
+- `ToolCatalog` accepts `{ trace }` config in its constructor — `noop` (default), `memory`, or `jsonl`. Captured events flow through the Rust core sink ([ADR-0009](../../../docs/adr/0009-trace-events-core-owned-schema.md)). New `recordEvent`, `drainTraceEvents`, and an optional third `origin` argument on `search`.
+- `searchToolsTool` emits `gateway_search` with `origin: "agent"`. `invokeToolTool` emits `gateway_invoke` on success and `gateway_error` for unknown ids, `needs_auth`, and underlying throws.
+- `ToolCatalog.invoke` emits `invoke_start` / `invoke_end` / `invoke_error` around the executor with `args_size_bytes` and `took_ms`.
+- `registerMcpServer` emits `upstream_register` on connect and `upstream_invoke` / `upstream_error` per upstream call. New `searchWithOrigin` and trace plumbing on the underlying NAPI `ToolRegistry`.
+
 ## [0.1.5-rc.3] - 2026-05-08
 
 _No package-specific changes; released in lockstep with the workspace._

--- a/src/sdk/ts/README.md
+++ b/src/sdk/ts/README.md
@@ -107,6 +107,25 @@ await handle.close(); // disconnect on shutdown
 
 Errors from the upstream `tools/call` propagate as rejected promises from `catalog.invoke`, so they slot into the same handling as local executors.
 
+### Telemetry
+
+Pass `trace` to the `ToolCatalog` constructor to capture every search / invoke / gateway / upstream / auth event into a sink owned by the Rust core ([ADR 0009](../../../docs/adr/0009-trace-events-core-owned-schema.md)). Default is no-op — nothing is captured unless you opt in.
+
+```ts
+const catalog = new ToolCatalog({
+  trace: { kind: "jsonl", sessionId: "session-1", path: "/tmp/ratel.jsonl" },
+});
+// every catalog.invoke, searchToolsTool, registerMcpServer call now writes
+// one JSON line per event to /tmp/ratel.jsonl.
+```
+
+Sink kinds:
+- `{ kind: "noop" }` — drop everything (default).
+- `{ kind: "memory"; sessionId }` — keep events in memory; drain via `catalog.drainTraceEvents()`. Useful for tests.
+- `{ kind: "jsonl"; sessionId; path }` — append one JSON line per event to `path` (mode `0600` on Unix). Best-effort, lossy on backpressure — see ADR-0009 for the reliability profile.
+
+`searchToolsTool` tags its emitted `search` event with `origin: "agent"`; pre-fetch helpers (`catalog.search(query, k)`) default to `"user"`. Override per call via `catalog.search(query, k, "agent")`.
+
 ## Package shape
 
 - Package name: `@ratel-ai/sdk`

--- a/src/sdk/ts/README.md
+++ b/src/sdk/ts/README.md
@@ -124,7 +124,7 @@ Sink kinds:
 - `{ kind: "memory"; sessionId }` — keep events in memory; drain via `catalog.drainTraceEvents()`. Useful for tests.
 - `{ kind: "jsonl"; sessionId; path }` — append one JSON line per event to `path` (mode `0600` on Unix). Best-effort, lossy on backpressure — see ADR-0009 for the reliability profile.
 
-`searchToolsTool` tags its emitted `search` event with `origin: "agent"`; pre-fetch helpers (`catalog.search(query, k)`) default to `"user"`. Override per call via `catalog.search(query, k, "agent")`.
+`searchToolsTool` tags its emitted `search` event with `origin: "agent"`; direct callers (`catalog.search(query, k)`) default to `"direct"`. Override per call via `catalog.search(query, k, "agent")`.
 
 ## Package shape
 

--- a/src/sdk/ts/native/src/lib.rs
+++ b/src/sdk/ts/native/src/lib.rs
@@ -3,7 +3,10 @@
 #[macro_use]
 extern crate napi_derive;
 
+use std::sync::Arc;
+
 use ratel_ai_core as core;
+use ratel_ai_core::{JsonlSink, MemorySink, NoopSink, Origin, TraceEvent};
 use serde_json::Value;
 
 #[napi(object)]
@@ -21,9 +24,20 @@ pub struct SearchHit {
     pub score: f64,
 }
 
+#[napi(object)]
+pub struct TraceSinkConfig {
+    /// One of "noop" | "memory" | "jsonl".
+    pub kind: String,
+    /// Stamped on every envelope. Required for "memory" and "jsonl".
+    pub session_id: Option<String>,
+    /// Required for "jsonl".
+    pub path: Option<String>,
+}
+
 #[napi]
 pub struct ToolRegistry {
     inner: core::ToolRegistry,
+    memory_sink: Option<Arc<MemorySink>>,
 }
 
 #[napi]
@@ -33,6 +47,7 @@ impl ToolRegistry {
     pub fn new() -> Self {
         Self {
             inner: core::ToolRegistry::new(),
+            memory_sink: None,
         }
     }
 
@@ -56,6 +71,79 @@ impl ToolRegistry {
                 tool_id: hit.tool_id,
                 score: hit.score as f64,
             })
+            .collect()
+    }
+
+    #[napi]
+    pub fn search_with_origin(&self, query: String, top_k: u32, origin: String) -> Vec<SearchHit> {
+        let parsed = match origin.as_str() {
+            "agent" => Origin::Agent,
+            _ => Origin::User,
+        };
+        self.inner
+            .search_with_origin(&query, top_k as usize, parsed)
+            .into_iter()
+            .map(|hit| SearchHit {
+                tool_id: hit.tool_id,
+                score: hit.score as f64,
+            })
+            .collect()
+    }
+
+    #[napi]
+    pub fn record_event(&self, event: Value) -> napi::Result<()> {
+        let event: TraceEvent = serde_json::from_value(event)
+            .map_err(|e| napi::Error::from_reason(format!("invalid trace event: {e}")))?;
+        self.inner.record_event(event);
+        Ok(())
+    }
+
+    #[napi]
+    pub fn set_trace_sink(&mut self, config: TraceSinkConfig) -> napi::Result<()> {
+        match config.kind.as_str() {
+            "noop" => {
+                self.memory_sink = None;
+                self.inner.set_trace_sink(Arc::new(NoopSink));
+            }
+            "memory" => {
+                let session_id = config
+                    .session_id
+                    .ok_or_else(|| napi::Error::from_reason("memory sink requires sessionId"))?;
+                let sink = Arc::new(MemorySink::new(session_id));
+                self.memory_sink = Some(sink.clone());
+                self.inner.set_trace_sink(sink);
+            }
+            "jsonl" => {
+                let session_id = config
+                    .session_id
+                    .ok_or_else(|| napi::Error::from_reason("jsonl sink requires sessionId"))?;
+                let path = config
+                    .path
+                    .ok_or_else(|| napi::Error::from_reason("jsonl sink requires path"))?;
+                let sink = JsonlSink::new(session_id, &path)
+                    .map_err(|e| napi::Error::from_reason(format!("open jsonl sink: {e}")))?;
+                self.memory_sink = None;
+                self.inner.set_trace_sink(Arc::new(sink));
+            }
+            other => {
+                return Err(napi::Error::from_reason(format!(
+                    "unknown trace sink kind: {other}"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Drain captured envelopes from the active sink. Returns `[]` unless the
+    /// active sink is "memory".
+    #[napi]
+    pub fn drain_trace_events(&self) -> Vec<Value> {
+        let Some(sink) = self.memory_sink.as_ref() else {
+            return Vec::new();
+        };
+        sink.drain()
+            .into_iter()
+            .filter_map(|env| serde_json::to_value(&env).ok())
             .collect()
     }
 }

--- a/src/sdk/ts/native/src/lib.rs
+++ b/src/sdk/ts/native/src/lib.rs
@@ -78,7 +78,7 @@ impl ToolRegistry {
     pub fn search_with_origin(&self, query: String, top_k: u32, origin: String) -> Vec<SearchHit> {
         let parsed = match origin.as_str() {
             "agent" => Origin::Agent,
-            _ => Origin::User,
+            _ => Origin::Direct,
         };
         self.inner
             .search_with_origin(&query, top_k as usize, parsed)

--- a/src/sdk/ts/src/catalog.test.ts
+++ b/src/sdk/ts/src/catalog.test.ts
@@ -86,7 +86,7 @@ describe("ToolCatalog tracing", () => {
     expect(types).toContain("search");
 
     const search = events.find((e) => e.type === "search");
-    expect(search?.origin).toBe("user");
+    expect(search?.origin).toBe("direct");
     expect((search?.hits as unknown[]).length).toBeGreaterThan(0);
   });
 
@@ -128,7 +128,7 @@ describe("ToolCatalog tracing", () => {
     expect(err?.error).toMatch(/kaboom/);
   });
 
-  it("search() defaults origin=user; explicit origin=agent flows through to the event", () => {
+  it("search() defaults origin=direct; explicit origin=agent flows through to the event", () => {
     const catalog = new ToolCatalog({ trace: { kind: "memory", sessionId: "t" } });
     catalog.register(readFile);
     catalog.drainTraceEvents();

--- a/src/sdk/ts/src/catalog.test.ts
+++ b/src/sdk/ts/src/catalog.test.ts
@@ -66,3 +66,76 @@ describe("ToolCatalog", () => {
     expect(result).toEqual({ contents: "contents of /etc/hosts" });
   });
 });
+
+describe("ToolCatalog tracing", () => {
+  it("does not capture events when no trace sink is configured (default noop)", () => {
+    const catalog = new ToolCatalog();
+    catalog.register(readFile);
+    catalog.search("read", 5);
+    expect(catalog.drainTraceEvents()).toEqual([]);
+  });
+
+  it("captures index_churn on register and search on search via memory sink", () => {
+    const catalog = new ToolCatalog({ trace: { kind: "memory", sessionId: "t" } });
+    catalog.register(readFile);
+    catalog.search("read", 5);
+
+    const events = catalog.drainTraceEvents() as Array<Record<string, unknown>>;
+    const types = events.map((e) => e.type);
+    expect(types).toContain("index_churn");
+    expect(types).toContain("search");
+
+    const search = events.find((e) => e.type === "search");
+    expect(search?.origin).toBe("user");
+    expect((search?.hits as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  it("emits invoke_start + invoke_end around a successful invoke", async () => {
+    const catalog = new ToolCatalog({ trace: { kind: "memory", sessionId: "t" } });
+    catalog.register(readFile);
+    catalog.drainTraceEvents(); // discard register/search noise
+
+    await catalog.invoke("read_file", { path: "/x" });
+
+    const events = catalog.drainTraceEvents() as Array<Record<string, unknown>>;
+    const types = events.map((e) => e.type);
+    expect(types).toContain("invoke_start");
+    expect(types).toContain("invoke_end");
+    const start = events.find((e) => e.type === "invoke_start");
+    expect(start?.tool_id).toBe("read_file");
+    expect(typeof start?.args_size_bytes).toBe("number");
+  });
+
+  it("emits invoke_error when the executor throws and re-throws to the caller", async () => {
+    const catalog = new ToolCatalog({ trace: { kind: "memory", sessionId: "t" } });
+    catalog.register({
+      id: "boom",
+      name: "boom",
+      description: "x",
+      inputSchema: {},
+      outputSchema: {},
+      execute: async () => {
+        throw new Error("kaboom");
+      },
+    });
+    catalog.drainTraceEvents();
+
+    await expect(catalog.invoke("boom", {})).rejects.toThrow(/kaboom/);
+
+    const events = catalog.drainTraceEvents() as Array<Record<string, unknown>>;
+    const err = events.find((e) => e.type === "invoke_error");
+    expect(err?.tool_id).toBe("boom");
+    expect(err?.error).toMatch(/kaboom/);
+  });
+
+  it("search() defaults origin=user; explicit origin=agent flows through to the event", () => {
+    const catalog = new ToolCatalog({ trace: { kind: "memory", sessionId: "t" } });
+    catalog.register(readFile);
+    catalog.drainTraceEvents();
+
+    catalog.search("read", 5, "agent");
+    const events = catalog.drainTraceEvents() as Array<Record<string, unknown>>;
+    const search = events.find((e) => e.type === "search");
+    expect(search?.origin).toBe("agent");
+  });
+});

--- a/src/sdk/ts/src/catalog.ts
+++ b/src/sdk/ts/src/catalog.ts
@@ -12,7 +12,7 @@ export type TraceSinkConfig =
   | { kind: "memory"; sessionId: string }
   | { kind: "jsonl"; sessionId: string; path: string };
 
-export type SearchOrigin = "user" | "agent";
+export type SearchOrigin = "direct" | "agent";
 
 export interface ToolCatalogOptions {
   trace?: TraceSinkConfig;
@@ -37,7 +37,7 @@ export class ToolCatalog {
     this.tools.set(tool.id, metadata);
   }
 
-  search(query: string, topK: number, origin: SearchOrigin = "user"): SearchHit[] {
+  search(query: string, topK: number, origin: SearchOrigin = "direct"): SearchHit[] {
     return this.registry.searchWithOrigin(query, topK, origin);
   }
 

--- a/src/sdk/ts/src/catalog.ts
+++ b/src/sdk/ts/src/catalog.ts
@@ -7,13 +7,27 @@ export interface ExecutableTool extends Tool {
   execute: Executor;
 }
 
+export type TraceSinkConfig =
+  | { kind: "noop" }
+  | { kind: "memory"; sessionId: string }
+  | { kind: "jsonl"; sessionId: string; path: string };
+
+export type SearchOrigin = "user" | "agent";
+
+export interface ToolCatalogOptions {
+  trace?: TraceSinkConfig;
+}
+
 export class ToolCatalog {
   private readonly registry: ToolRegistry;
   private readonly executors = new Map<string, Executor>();
   private readonly tools = new Map<string, Tool>();
 
-  constructor() {
+  constructor(options: ToolCatalogOptions = {}) {
     this.registry = new ToolRegistry();
+    if (options.trace) {
+      this.registry.setTraceSink(options.trace);
+    }
   }
 
   register(tool: ExecutableTool): void {
@@ -23,8 +37,8 @@ export class ToolCatalog {
     this.tools.set(tool.id, metadata);
   }
 
-  search(query: string, topK: number): SearchHit[] {
-    return this.registry.search(query, topK);
+  search(query: string, topK: number, origin: SearchOrigin = "user"): SearchHit[] {
+    return this.registry.searchWithOrigin(query, topK, origin);
   }
 
   has(toolId: string): boolean {
@@ -42,11 +56,54 @@ export class ToolCatalog {
     return { ...tool, execute };
   }
 
+  recordEvent(event: object): void {
+    this.registry.recordEvent(event);
+  }
+
+  drainTraceEvents(): unknown[] {
+    return this.registry.drainTraceEvents();
+  }
+
   async invoke(toolId: string, args: Record<string, unknown>): Promise<unknown> {
     const fn = this.executors.get(toolId);
     if (!fn) {
       throw new Error(`unknown toolId: ${toolId}`);
     }
-    return await fn(args);
+    this.registry.recordEvent({
+      type: "invoke_start",
+      tool_id: toolId,
+      args_size_bytes: argsSizeBytes(args),
+    });
+    const started = Date.now();
+    try {
+      const result = await fn(args);
+      this.registry.recordEvent({
+        type: "invoke_end",
+        tool_id: toolId,
+        took_ms: Date.now() - started,
+      });
+      return result;
+    } catch (err) {
+      this.registry.recordEvent({
+        type: "invoke_error",
+        tool_id: toolId,
+        took_ms: Date.now() - started,
+        error: errorMessage(err),
+      });
+      throw err;
+    }
   }
+}
+
+function argsSizeBytes(args: unknown): number {
+  try {
+    return JSON.stringify(args).length;
+  } catch {
+    return 0;
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
 }

--- a/src/sdk/ts/src/gateway.test.ts
+++ b/src/sdk/ts/src/gateway.test.ts
@@ -34,6 +34,24 @@ const sendEmail: ExecutableTool = {
   execute: async ({ to }) => ({ messageId: "abc", to }),
 };
 
+describe("searchToolsTool tracing", () => {
+  it("emits gateway_search with origin=agent and the hit count", async () => {
+    const catalog = new ToolCatalog({ trace: { kind: "memory", sessionId: "t" } });
+    catalog.register(readFile);
+    catalog.drainTraceEvents();
+
+    const tool = searchToolsTool(catalog);
+    await tool.execute({ query: "read a file", topK: 3 });
+
+    const events = catalog.drainTraceEvents() as Array<Record<string, unknown>>;
+    const gw = events.find((e) => e.type === "gateway_search");
+    expect(gw).toBeDefined();
+    expect(gw?.origin).toBe("agent");
+    expect(gw?.top_k).toBe(3);
+    expect(typeof gw?.hits).toBe("number");
+  });
+});
+
 describe("searchToolsTool", () => {
   it("uses the canonical id and name", () => {
     const catalog = new ToolCatalog();
@@ -318,6 +336,31 @@ describe("invokeToolTool", () => {
     const tool = invokeToolTool(catalog, { onUnauthorized: (upstream) => seen.push(upstream) });
     await tool.execute({ toolId: "stripe__charges", args: {} });
     expect(seen).toEqual(["stripe"]);
+  });
+
+  it("emits gateway_invoke on success with took_ms", async () => {
+    const catalog = new ToolCatalog({ trace: { kind: "memory", sessionId: "t" } });
+    catalog.register(readFile);
+    catalog.drainTraceEvents();
+
+    const tool = invokeToolTool(catalog);
+    await tool.execute({ toolId: "fs__read_file", args: { path: "/x" } });
+
+    const events = catalog.drainTraceEvents() as Array<Record<string, unknown>>;
+    const gw = events.find((e) => e.type === "gateway_invoke");
+    expect(gw?.tool_id).toBe("fs__read_file");
+    expect(typeof gw?.took_ms).toBe("number");
+  });
+
+  it("emits gateway_error with `unknown_tool_id` when the toolId is not registered", async () => {
+    const catalog = new ToolCatalog({ trace: { kind: "memory", sessionId: "t" } });
+    const tool = invokeToolTool(catalog);
+    await tool.execute({ toolId: "nope", args: {} });
+
+    const events = catalog.drainTraceEvents() as Array<Record<string, unknown>>;
+    const err = events.find((e) => e.type === "gateway_error");
+    expect(err?.tool_id).toBe("nope");
+    expect(err?.error).toBe("unknown_tool_id");
   });
 
   it("does not call onUnauthorized for a non-namespaced toolId since the upstream cannot be inferred", async () => {

--- a/src/sdk/ts/src/gateway.ts
+++ b/src/sdk/ts/src/gateway.ts
@@ -123,7 +123,17 @@ export function searchToolsTool(
     },
     execute: async (input) => {
       const { query, topK } = input as { query: string; topK?: number };
-      const hits = catalog.search(query, topK ?? 5);
+      const k = topK ?? 5;
+      const startedAt = Date.now();
+      const hits = catalog.search(query, k, "agent");
+      catalog.recordEvent({
+        type: "gateway_search",
+        query,
+        origin: "agent",
+        top_k: k,
+        hits: hits.length,
+        took_ms: Date.now() - startedAt,
+      });
       const order: string[] = [];
       const groups = new Map<string, SearchToolsGroup>();
       for (const h of hits) {
@@ -197,6 +207,11 @@ export function invokeToolTool(
       const inputObj = input as Record<string, unknown>;
       const toolId = inputObj.toolId as string;
       if (!catalog.has(toolId)) {
+        catalog.recordEvent({
+          type: "gateway_error",
+          tool_id: toolId,
+          error: "unknown_tool_id",
+        });
         return {
           error: `unknown toolId: ${toolId}. Use search_tools to discover available ids.`,
         };
@@ -206,14 +221,26 @@ export function invokeToolTool(
         nested && typeof nested === "object" && !Array.isArray(nested)
           ? (nested as Record<string, unknown>)
           : Object.fromEntries(Object.entries(inputObj).filter(([k]) => k !== "toolId"));
+      const startedAt = Date.now();
       try {
-        return await catalog.invoke(toolId, args);
+        const result = await catalog.invoke(toolId, args);
+        catalog.recordEvent({
+          type: "gateway_invoke",
+          tool_id: toolId,
+          took_ms: Date.now() - startedAt,
+        });
+        return result;
       } catch (err) {
         if (isUnauthorizedError(err)) {
           const upstream = upstreamFromToolId(toolId);
           if (upstream && opts.onUnauthorized) {
             await opts.onUnauthorized(upstream);
           }
+          catalog.recordEvent({
+            type: "gateway_error",
+            tool_id: toolId,
+            error: "needs_auth",
+          });
           const payload: { error: string; upstream?: string; hint: string } = {
             error: "needs_auth",
             hint: `call the auth tool to re-authorize${upstream ? ` ${upstream}` : ""}`,
@@ -221,6 +248,11 @@ export function invokeToolTool(
           if (upstream) payload.upstream = upstream;
           return payload;
         }
+        catalog.recordEvent({
+          type: "gateway_error",
+          tool_id: toolId,
+          error: (err as Error).message ?? String(err),
+        });
         return { error: `tool ${toolId} threw: ${(err as Error).message}` };
       }
     },

--- a/src/sdk/ts/src/index.ts
+++ b/src/sdk/ts/src/index.ts
@@ -1,6 +1,12 @@
 export type { SearchHit, Tool } from "../native/index.cjs";
 export { ToolRegistry } from "../native/index.cjs";
-export type { ExecutableTool, Executor } from "./catalog.js";
+export type {
+  ExecutableTool,
+  Executor,
+  SearchOrigin,
+  ToolCatalogOptions,
+  TraceSinkConfig,
+} from "./catalog.js";
 export { ToolCatalog } from "./catalog.js";
 export type {
   SearchToolHit,

--- a/src/sdk/ts/src/mcp.test.ts
+++ b/src/sdk/ts/src/mcp.test.ts
@@ -205,6 +205,69 @@ describe("registerMcpServer", () => {
     await handle.close();
   });
 
+  it("emits upstream_register on connect and upstream_invoke on each call", async () => {
+    const catalog = new ToolCatalog({ trace: { kind: "memory", sessionId: "t" } });
+    const handle = await registerMcpServer(catalog, {
+      name: "demo",
+      transport: fake.clientTransport,
+    });
+    catalog.drainTraceEvents().filter((e) => (e as { type: string }).type === "upstream_register");
+
+    await catalog.invoke("demo__read_file", { path: "/etc/hosts" });
+
+    const events = catalog.drainTraceEvents() as Array<Record<string, unknown>>;
+    const inv = events.find((e) => e.type === "upstream_invoke");
+    expect(inv?.server).toBe("demo");
+    expect(inv?.tool_id).toBe("demo__read_file");
+    expect(typeof inv?.took_ms).toBe("number");
+
+    await handle.close();
+  });
+
+  it("emits upstream_register at connect time with the tool count and a transport label", async () => {
+    const catalog = new ToolCatalog({ trace: { kind: "memory", sessionId: "t" } });
+    const handle = await registerMcpServer(catalog, {
+      name: "demo",
+      transport: fake.clientTransport,
+    });
+
+    const events = catalog.drainTraceEvents() as Array<Record<string, unknown>>;
+    const reg = events.find((e) => e.type === "upstream_register");
+    expect(reg?.server).toBe("demo");
+    expect(reg?.tool_count).toBe(1);
+    expect(typeof reg?.transport).toBe("string");
+
+    await handle.close();
+  });
+
+  it("emits upstream_error and re-throws when the upstream tool handler throws", async () => {
+    const failing = await startFakeMcpServer([
+      {
+        name: "boom",
+        description: "always fails",
+        handler: () => {
+          throw new Error("kaboom");
+        },
+      },
+    ]);
+    const catalog = new ToolCatalog({ trace: { kind: "memory", sessionId: "t" } });
+    const handle = await registerMcpServer(catalog, {
+      name: "demo",
+      transport: failing.clientTransport,
+    });
+    catalog.drainTraceEvents();
+
+    await expect(catalog.invoke("demo__boom", {})).rejects.toThrow();
+
+    const events = catalog.drainTraceEvents() as Array<Record<string, unknown>>;
+    const err = events.find((e) => e.type === "upstream_error");
+    expect(err?.server).toBe("demo");
+    expect(err?.tool_id).toBe("demo__boom");
+
+    await handle.close();
+    await failing.server.close();
+  });
+
   it("invokes the upstream tool via tools/call and returns its structured payload", async () => {
     const catalog = new ToolCatalog();
     const handle = await registerMcpServer(catalog, {

--- a/src/sdk/ts/src/mcp.ts
+++ b/src/sdk/ts/src/mcp.ts
@@ -24,8 +24,15 @@ export async function registerMcpServer(
   await client.connect(transport);
 
   const serverInstructions = client.getInstructions();
+  const transportLabel = transportKind(transport);
 
   const { tools } = await client.listTools();
+  catalog.recordEvent({
+    type: "upstream_register",
+    server: name,
+    transport: transportLabel,
+    tool_count: tools.length,
+  });
   const toolIds: string[] = [];
   for (const tool of tools) {
     const id = `${name}__${tool.name}`;
@@ -35,11 +42,30 @@ export async function registerMcpServer(
       description: tool.description ?? "",
       inputSchema: tool.inputSchema,
       outputSchema: tool.outputSchema ?? { type: "object" },
-      execute: async (args) =>
-        client.callTool({
-          name: tool.name,
-          arguments: args as Record<string, unknown>,
-        }),
+      execute: async (args) => {
+        const startedAt = Date.now();
+        try {
+          const result = await client.callTool({
+            name: tool.name,
+            arguments: args as Record<string, unknown>,
+          });
+          catalog.recordEvent({
+            type: "upstream_invoke",
+            server: name,
+            tool_id: id,
+            took_ms: Date.now() - startedAt,
+          });
+          return result;
+        } catch (err) {
+          catalog.recordEvent({
+            type: "upstream_error",
+            server: name,
+            tool_id: id,
+            error: (err as Error).message ?? String(err),
+          });
+          throw err;
+        }
+      },
     });
     toolIds.push(id);
   }
@@ -51,4 +77,9 @@ export async function registerMcpServer(
       await client.close();
     },
   };
+}
+
+function transportKind(transport: Transport): string {
+  const ctor = (transport as { constructor?: { name?: string } }).constructor;
+  return ctor?.name ?? "unknown";
 }


### PR DESCRIPTION
## Summary

Implements v0.1.5 telemetry per [ADR-0009](docs/adr/0009-trace-events-core-owned-schema.md): a single tagged trace event stream, with the schema and sink trait owned by `ratel-ai-core` so every host language (TS today, Python in v0.5.x) and every consumer (inspector, future rerankers, optional consolidation server) reads/writes the same shape.

- **Rust core (`ratel-ai-core`)** — new `trace` module: `TraceEvent` tagged enum (search / index_churn / invoke_* / gateway_* / upstream_* / auth_*) wrapped in `TraceEnvelope { v, ts, session_id, ...event }`; `TraceSink` trait with `NoopSink`, `MemorySink`, `JsonlSink` (sync `O_APPEND`, mode `0600` on Unix). `ToolRegistry` holds `Arc<dyn TraceSink>` (default `Noop`); `register` emits `index_churn{Add}`; `search` emits `search` with a `bm25` stage; new `search_with_origin` for user/agent tagging.
- **NAPI** — single `recordEvent(event)` surface for SDK / mcp-server emission, plus `setTraceSink({ kind, sessionId, path? })` and `searchWithOrigin`. `drainTraceEvents` exposed for SDK tests.
- **TS SDK (`@ratel-ai/sdk`)** — `ToolCatalog` accepts `{ trace }` config; emits `invoke_*` around the executor (with `args_size_bytes`, `took_ms`); `searchToolsTool` emits `gateway_search` (origin=agent); `invokeToolTool` emits `gateway_invoke` / `gateway_error`; `registerMcpServer` emits `upstream_register` and `upstream_invoke` / `upstream_error`.
- **MCP server (`@ratel-ai/mcp-server`)** — `buildGatewayFromConfig` threads `trace` through; boot path emits `auth_refresh{ok}` and `auth_needs`; `runAuthFlow` brackets each upstream with `auth_flow_start` / `auth_flow_end{ok}`; `createMcpServer.onUnauthorized` emits `auth_needs` mid-session.
- **CLI (`@ratel-ai/cli`)** — `ratel mcp serve` defaults to JSONL under `~/.ratel/telemetry/<ISO-ts>-<short>.jsonl`. Opt out with `--telemetry off` (or `RATEL_TELEMETRY=off`); override the path with `--telemetry-file`; override the directory with `RATEL_TELEMETRY_DIR`. New `ratel inspect` verb summarizes the most recent file (session totals, top tools by hit count, gateway-vs-direct invoke split, top errors); `ratel inspect ls` lists files newest-first.

Reliability profile is **query-log shaped, not oplog**: best-effort, sampleable, lossy on backpressure (per ADR-0009). The `TraceSink` trait carries a `sample_rate()` knob; rate-limiter implementation deferred (cheap to add later).

## Pinned implementation knobs (the open questions in ADR-0009)

1. **Disk path: synchronous `O_APPEND` write per event** in `JsonlSink`. No ring buffer, no background flush — the query-log story tolerates this; revisit only if profiling surfaces real overhead.
2. **No sampling logic in v0.1.5.** Trait carries the knob; rate-limiter is deferred.
3. **Single `record_event(event)` NAPI export** taking a tagged enum, not per-event-type fns.

## Out of scope (deferred per the plan)

- Phase 7 — live smoke through `examples/mcp-server/` (manual; do before promoting RC).
- Phase 8 — benchmark MCP review with new `ratel-mcp-server` arm (depends on a published RC).
- Phase 9 — RC release + flip ADR-0009 from `Proposed` to `Accepted` (post-validation, user-driven).
- Web UI inspector, ring buffer + periodic flush, sampling rate-limiter, async/batched NAPI, skill/memory/chat-history events.

## Test plan

- [x] `cargo build --workspace` — green
- [x] `cargo test --workspace` — green (29 Rust tests including 11 new in `tests/trace.rs`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check --all` — clean
- [x] `pnpm -r typecheck` — green
- [x] `pnpm -r lint` — clean
- [x] `pnpm -r test` — green (581 tests across the four packages, +14 new)
- [ ] **Manual smoke through `examples/mcp-server/`**: tail `~/.ratel/telemetry/*.jsonl` while a Claude Code session runs; confirm `search`, `gateway_search` (origin=agent), `gateway_invoke`, `invoke_*`, `upstream_invoke` fire and correlate. Run `ratel inspect`.
- [ ] **`--telemetry off`** produces no file under `~/.ratel/telemetry/`.
- [ ] **`--telemetry-file /tmp/r.jsonl`** writes to the override location.
- [ ] **Embedder path** smoke: scratch Node script with `MemorySink`, run searches/invokes, assert `drainTraceEvents()` captures events.

## Commits

- `docs(adr): add 0009 trace events — core-owned schema`
- `feat(core): add trace event schema, sink trait, and three sinks (ADR-0009)`
- `feat(sdk-native): NAPI bindings for trace sink + record_event`
- `feat(sdk): emit invoke_*, gateway_*, upstream_* via core sink`
- `feat(mcp-server): emit auth_refresh, auth_needs, auth_flow_* events`
- `feat(cli): default JsonlSink for mcp serve + ratel inspect verb`
- `docs: trace stream sections in package READMEs + CHANGELOG entries`