### PR TITLE
TypeScript typehint for schema input outpus

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.1)
+      '@types/json-schema':
+        specifier: ^7.0.15
+        version: 7.0.15
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.13
@@ -1077,6 +1080,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
@@ -2598,6 +2604,8 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/node@24.12.2':
     dependencies:

--- a/src/sdk/ts/native/src/lib.rs
+++ b/src/sdk/ts/native/src/lib.rs
@@ -14,7 +14,9 @@ pub struct Tool {
     pub id: String,
     pub name: String,
     pub description: String,
+    #[napi(ts_type = "import('json-schema').JSONSchema7")]
     pub input_schema: Value,
+    #[napi(ts_type = "import('json-schema').JSONSchema7")]
     pub output_schema: Value,
 }
 

--- a/src/sdk/ts/package.json
+++ b/src/sdk/ts/package.json
@@ -66,6 +66,7 @@
     "vitest": "^4.1.5"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@types/json-schema": "^7.0.15"
   }
 }


### PR DESCRIPTION
Add a barebone TS type hint for input/output schemas

~~I opted to use a minimal codebase-owned TS types definition instead of importing something like 
JSONSchema7 to avoid all the inconsistencies of different providers while improving DX~~

That became a can of worms faster than I expected, going with JSONSchema7 from @types/json-schema. 

There is a tradeoff to accept that not all providers support all features, but keeping that at the type level without specialized per-provider helpers is not worth it, overall it's a DX improvement

relates but don't resolve #53 