### PR TITLE
release: v0.1.6 — first coordinated release with Python SDK

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,8 +345,11 @@ jobs:
       - name: Validate packaging (metadata + README rendering)
         # Mirrors the npm/crate `--dry-run` publishes: exercise the PyPI path on
         # dry runs too, so a broken wheel/sdist or bad metadata fails before a real tag.
+        # `packaging>=24.2` is required to understand maturin's `Metadata-Version: 2.4`
+        # wheels (PEP 639 `License-File`); the runner's preinstalled system `packaging`
+        # is older and otherwise rejects the field as "unrecognized or malformed".
         run: |
-          python -m pip install --upgrade twine
+          python -m pip install --upgrade twine 'packaging>=24.2'
           twine check dist/*
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ratel-ai-core"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bm25",
  "serde",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "ratel-sdk-python-native"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "pyo3",
  "pythonize",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "ratel-sdk-ts-native"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "napi",
  "napi-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 license-file = "LICENSE.md"
 repository = "https://github.com/ratel-ai/ratel"

--- a/src/core/lib/CHANGELOG.md
+++ b/src/core/lib/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-06-10
+
+### Changed
+
+- Version bump for the coordinated v0.1.6 release (first release shipping the `ratel-ai` Python SDK). No crate source changes since 0.1.5; re-published in lockstep to keep all artifacts version-aligned.
+
 ## [0.1.5] - 2026-05-10
 
 ### Added

--- a/src/integrations/cli/CHANGELOG.md
+++ b/src/integrations/cli/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-06-10
+
+### Changed
+
+- Version bump for the coordinated v0.1.6 release. No user-facing CLI changes since 0.1.5; the internal `@ratel-ai/mcp-server` dependency is now consumed from npm (extracted to `ratel-ai/ratel-mcp`). Re-published in lockstep to keep all artifacts version-aligned.
+
 ## [0.1.5] - 2026-05-10
 
 ### Added

--- a/src/integrations/cli/package.json
+++ b/src/integrations/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Ratel CLI — manage MCP servers across scopes, run the Ratel MCP gateway, import Claude Code's MCP setup, drive OAuth flows.",
   "private": false,
   "type": "module",

--- a/src/integrations/cli/src/probe.ts
+++ b/src/integrations/cli/src/probe.ts
@@ -114,7 +114,14 @@ export async function authProbeEntry(
   const catalog = new ToolCatalog();
   let result: Awaited<ReturnType<AuthStep>>;
   try {
-    result = await step(name, entry, { catalog, logger: options.logger });
+    // `@ratel-ai/mcp-server` is still consumed from npm (transitional, until the CLI
+    // refactor lands) and bundles its own pinned `@ratel-ai/sdk` copy. Once the
+    // workspace SDK version moves ahead of that copy, the two `ToolCatalog`
+    // declarations differ only by nominal (private-field) identity, so `tsc` rejects
+    // the assignment. The instance is structurally identical and used here purely as a
+    // throwaway probe vessel, so bridge the version skew explicitly at this one seam.
+    const ctxCatalog = catalog as unknown as Parameters<AuthStep>[2]["catalog"];
+    result = await step(name, entry, { catalog: ctxCatalog, logger: options.logger });
   } catch (err) {
     return { status: "failed", reason: (err as Error).message };
   }

--- a/src/sdk/python/CHANGELOG.md
+++ b/src/sdk/python/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-06-10
+
 ### Added
 
 - Initial release of the Python SDK. Binds the Rust core (`ratel-ai-core`) via PyO3, distributed as prebuilt `abi3` wheels for darwin-arm64, darwin-x64, linux-x64-gnu, linux-arm64-gnu, and win32-x64-msvc — no Rust toolchain required to install. (`v0.1.5` shipped TS-only on 2026-05-10; the first release carrying Python is the next version bump.) Binding strategy locked in [ADR-0011](../../../docs/adr/0011-python-rust-binding-strategy.md).

--- a/src/sdk/python/pyproject.toml
+++ b/src/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ratel-ai"
-version = "0.1.5"
+version = "0.1.6"
 description = "Python SDK for Ratel — context engineering platform for AI agents. BM25 tool retrieval, MCP ingestion, framework-neutral gateway tools."
 readme = "README.md"
 license = { file = "LICENSE.md" }

--- a/src/sdk/ts/CHANGELOG.md
+++ b/src/sdk/ts/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-06-10
+
+### Fixed
+
+- TypeScript typehint for JSON-schema tool input/output ([#54](https://github.com/ratel-ai/ratel/pull/54)).
+
 ## [0.1.5] - 2026-05-10
 
 ### Added

--- a/src/sdk/ts/npm/darwin-arm64/package.json
+++ b/src/sdk/ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/sdk-darwin-arm64",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "cpu": [
     "arm64"
   ],

--- a/src/sdk/ts/npm/darwin-x64/package.json
+++ b/src/sdk/ts/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/sdk-darwin-x64",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "cpu": [
     "x64"
   ],

--- a/src/sdk/ts/npm/linux-arm64-gnu/package.json
+++ b/src/sdk/ts/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/sdk-linux-arm64-gnu",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "cpu": [
     "arm64"
   ],

--- a/src/sdk/ts/npm/linux-x64-gnu/package.json
+++ b/src/sdk/ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/sdk-linux-x64-gnu",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "cpu": [
     "x64"
   ],

--- a/src/sdk/ts/npm/win32-x64-msvc/package.json
+++ b/src/sdk/ts/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/sdk-win32-x64-msvc",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "cpu": [
     "x64"
   ],

--- a/src/sdk/ts/package.json
+++ b/src/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/sdk",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "TypeScript SDK for Ratel — context engineering platform for AI agents. BM25 tool retrieval, MCP ingestion, framework-neutral gateway tools.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
Cuts `v0.1.6` — the first coordinated release. One tag re-publishes npm + cli + crate **and** publishes the first `ratel-ai` Python wheel to PyPI, all at the same version (ADR-0008 version alignment, enforced by `release.yml`'s `tag-version-check`).

Closes RAT-241.

## Why 0.1.6 (not re-tag 0.1.5)
All four artifacts sit at `0.1.5`, but `@ratel-ai/sdk@0.1.5` is already on npm — re-tagging would fail on re-publish. The first release carrying Python must be the next bump.

## Version bump 0.1.5 → 0.1.6 (lockstep)
- `Cargo.toml` (+ `Cargo.lock` workspace members), `src/sdk/ts/package.json` (+ 5 `npm/*` platform packages), `src/integrations/cli/package.json`, `src/sdk/python/pyproject.toml`.
- `pnpm-lock.yaml` untouched: workspace deps are `workspace:*` links; the only `0.1.5` pin there is the external `@ratel-ai/mcp-server` dep — matches the v0.1.5 release precedent.

## CHANGELOGs (`## [0.1.6] - 2026-06-10`)
- **core** — lockstep re-publish note (no crate source changes since 0.1.5).
- **ts** — `Fixed`: TypeScript typehint for JSON-schema input/output (#54).
- **cli** — lockstep re-publish note (internal `@ratel-ai/mcp-server` now from npm).
- **python** — converted the parked `[Unreleased]` entry to `[0.1.6]` (per PR #60).

Both `tag-version-check` gates verified locally: all four versions == `0.1.6`, and all four CHANGELOGs contain `## [0.1.6]`.

## ⚠️ Handoff before tagging (not done in this PR)
1. **PyPI Trusted Publisher (OIDC)** for `ratel-ai` on pypi.org — repo `ratel-ai/ratel`, workflow `release.yml`, env `release`. Must exist before the tag or the PyPI publish has nothing to authenticate against.
2. **Dry-run** after merge: `gh workflow run release.yml -f dry_run=true -f ref=main` (npm/crate `--dry-run` + PyPI `twine check`). Confirm green.
3. **Tag & push:** `git tag v0.1.6 && git push origin v0.1.6`.

## Acceptance
- [ ] `pip install ratel-ai` works (first PyPI publish) and `from ratel_ai import ToolRegistry` imports
- [ ] npm / cli / crate re-published at 0.1.6
- [ ] `verify-install.yml` smoke tests green across all wheel targets (incl. darwin-x64)