### PR TITLE
fix(core): deterministic ordering for tied BM25 scores in tool search

### DIFF
--- a/src/core/lib/src/registry.rs
+++ b/src/core/lib/src/registry.rs
@@ -78,14 +78,27 @@ impl ToolRegistry {
                 .k1(BM25_K1)
                 .b(BM25_B)
                 .build();
-            engine
-                .search(query, top_k)
+            // The bm25 crate sorts by score only and collects candidates through
+            // a HashSet, so equal scores fall back to hash-seed iteration order
+            // and flip between processes: tied hits at the top_k boundary make
+            // top-K membership nondeterministic. Rank the full match set, break
+            // ties by tool_id, then cut.
+            let mut ranked: Vec<SearchHit> = engine
+                .search(query, self.tools.len())
                 .into_iter()
                 .map(|r| SearchHit {
                     tool_id: r.document.id,
                     score: r.score,
                 })
-                .collect()
+                .collect();
+            ranked.sort_by(|a, b| {
+                b.score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| a.tool_id.cmp(&b.tool_id))
+            });
+            ranked.truncate(top_k);
+            ranked
         };
         let took_ms = started.elapsed().as_millis() as u64;
         let top_score = hits.first().map(|h| h.score as f64);

--- a/src/core/lib/tests/tool_search.rs
+++ b/src/core/lib/tests/tool_search.rs
@@ -365,3 +365,52 @@ fn search_matches_tool_name() {
     assert_eq!(hits[0].tool_id, "read_file");
     assert!(hits[0].score > 0.0);
 }
+
+#[test]
+fn tied_scores_are_ordered_by_tool_id() {
+    // Two tools with identical searchable text score identically for any
+    // matching query. The bm25 crate collects candidates through a HashSet,
+    // so on equal scores the order falls back to hash-seed iteration order
+    // and flips between processes. The registry must break ties stably.
+    let mut registry = ToolRegistry::new();
+    for id in ["zeta_tool", "alpha_tool"] {
+        registry.register(Tool {
+            id: id.into(),
+            name: id.into(),
+            description: "send a notification message to a channel".into(),
+            input_schema: empty_schema(),
+            output_schema: empty_schema(),
+        });
+    }
+
+    let hits = registry.search("notification message", 5);
+
+    assert_eq!(hits.len(), 2);
+    assert_eq!(hits[0].score, hits[1].score, "fixture must produce a tie");
+    assert_eq!(hits[0].tool_id, "alpha_tool");
+    assert_eq!(hits[1].tool_id, "zeta_tool");
+}
+
+#[test]
+fn tied_scores_keep_top_k_membership_stable() {
+    // Regression for the flicker observed while reproducing issue #56:
+    // with a tie at the top_k boundary, which tool made the cut depended
+    // on hash-seed iteration order, so top-K membership changed across
+    // process runs. With a stable tie-break the cut is always the same.
+    let mut registry = ToolRegistry::new();
+    for id in ["zeta_tool", "mid_tool", "alpha_tool"] {
+        registry.register(Tool {
+            id: id.into(),
+            name: id.into(),
+            description: "send a notification message to a channel".into(),
+            input_schema: empty_schema(),
+            output_schema: empty_schema(),
+        });
+    }
+
+    let hits = registry.search("notification message", 2);
+
+    assert_eq!(hits.len(), 2);
+    assert_eq!(hits[0].tool_id, "alpha_tool");
+    assert_eq!(hits[1].tool_id, "mid_tool");
+}


### PR DESCRIPTION
## Summary

Found while reproducing #56: exact BM25 score ties are ordered nondeterministically across process runs. In k33wee's 12-tool catalog, scenario "read the production environment variables file" puts `send_email` and `weather_lookup` at exactly `0.03990466520190239`, and which one makes the top-5 cut flips between runs (5/5 over 10 Bun runs, 4/4 over 8 Node runs in my samples). Top-K membership flickers on ties, and small-catalog repros become easy to mismatch.

The cause is upstream of the registry: the bm25 crate collects candidate documents through a `HashSet` and sorts by score only, so equal scores keep hash-seed iteration order. This does not touch the ranking inversion reported in #56 (those scores are not tied); diagnosis and a proposed direction for that half are in the issue thread.

## Change

- `search_with_origin` ranks the full match set, breaks ties by `tool_id`, then cuts at `top_k` (`src/core/lib/src/registry.rs`).
- Two integration tests in `tests/tool_search.rs`: tied scores ordered by `tool_id`, and stable top-K membership with a tie at the boundary. Pre-fix they fail on hash-seed order: across 12 fresh `cargo test` processes I got 8 runs with one failing and 4 with both failing.
- No API change. Scores and non-tie orderings are unchanged: the original #56 repro output against a locally built SDK is byte-identical to a pre-fix run, and hashes identically across 10 consecutive runs (pre-fix: two variants, 5/5).

Note on cost: the engine already rebuilds per query over the whole catalog, so ranking the full match set instead of `top_k` adds a sort over the matched subset, nothing asymptotically new. If you would rather keep the early cut and only re-sort the returned page, that loses cross-page determinism at the boundary; full-set ranking is the smaller invariant to reason about.

## Test

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (31 passed) all clean.
- TS SDK with the rebuilt native module: `pnpm test` 51 passed, `pnpm lint`, `pnpm typecheck` clean.
- Not run: the Python SDK test suite and ratel-bench campaigns.

#61 touches `registry.rs` too; happy to rebase this after it lands if that ordering is easier.

---
*Implemented with the help of a coding agent (Claude Code) and reviewed locally by the author.*
