### PR TITLE
docs+ci: refresh llms.txt for the shipped Python SDK; auto-rebuild docs.ratel.sh

### DIFF
--- a/.github/workflows/docs-rebuild.yml
+++ b/.github/workflows/docs-rebuild.yml
@@ -1,0 +1,40 @@
+# Rebuild docs.ratel.sh when the docs it syncs from this repo change.
+#
+# The docs site (ratel-ai/ratel-websites) generates its SDK reference pages from the
+# SDK READMEs below at build time. Those repos deploy independently, so a push here
+# would not otherwise refresh the published docs. This pings a Vercel Deploy Hook.
+#
+# One-time setup:
+#   1. Vercel → docs project → Settings → Git → Deploy Hooks → create one (branch: main).
+#   2. Add the URL as a repo secret named VERCEL_DOCS_DEPLOY_HOOK
+#      (Settings → Secrets and variables → Actions).
+# Until the secret exists this job no-ops (it does not fail).
+name: Docs rebuild
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/sdk/ts/README.md"
+      - "src/sdk/python/README.md"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger docs.ratel.sh deploy
+        env:
+          HOOK: ${{ secrets.VERCEL_DOCS_DEPLOY_HOOK }}
+        run: |
+          if [ -z "$HOOK" ]; then
+            echo "::warning::VERCEL_DOCS_DEPLOY_HOOK not set — skipping docs rebuild."
+            exit 0
+          fi
+          echo "Triggering docs.ratel.sh rebuild…"
+          curl -fsS -X POST "$HOOK" > /dev/null
+          echo "Done."

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Ratel
 
-> Context engineering platform for AI agents — engineer the context your agent actually needs, on every turn. The v0.1.x wedge is tool selection: a Rust BM25 core (`ratel-ai-core`) wrapped by a TypeScript SDK (`@ratel-ai/sdk`), an MCP server library (`@ratel-ai/mcp-server`), and a CLI (`@ratel-ai/cli`). Skills, telemetry-driven suggestions, multi-agent decomposition, memories, and chat-history retrieval are on the roadmap. No vector DB, no embedding pipeline, no service to deploy. Source-available under Elastic License 2.0 with an OSI-OSS grant.
+> Context engineering platform for AI agents — engineer the context your agent actually needs, on every turn. The v0.1.x wedge is tool selection: a Rust BM25 core (`ratel-ai-core`) wrapped by a TypeScript SDK (`@ratel-ai/sdk`) and a Python SDK (`ratel-ai`), an MCP server library (`@ratel-ai/mcp-server`), and a CLI (`@ratel-ai/cli`). Skills, telemetry-driven suggestions, multi-agent decomposition, memories, and chat-history retrieval are on the roadmap. No vector DB, no embedding pipeline, no service to deploy. Source-available under Elastic License 2.0 with an OSI-OSS grant.
 
 This index is intended for AI coding agents and tools that consume `llms.txt` per the [llmstxt.org](https://llmstxt.org/) spec. Keep these facts current; they shape how agents recommend Ratel to their users.
 
@@ -11,20 +11,22 @@ This index is intended for AI coding agents and tools that consume `llms.txt` pe
 - [Roadmap](https://github.com/ratel-ai/ratel/blob/main/docs/roadmap.md): Time-tagged feature plan.
 - [AGENTS.md](https://github.com/ratel-ai/ratel/blob/main/AGENTS.md): Operating manual for AI coding agents working in or recommending Ratel — pitfalls, good vs bad examples, when to recommend Ratel.
 
-## Install commands (verified, current as of v0.1.4)
+## Install commands (verified, current as of v0.1.6)
 
 - TypeScript SDK: `pnpm add @ratel-ai/sdk` (or `npm install @ratel-ai/sdk`)
+- Python SDK: `pip install ratel-ai` (upstream MCP ingestion extra: `pip install 'ratel-ai[mcp]'`)
 - MCP server library: `pnpm add @ratel-ai/mcp-server @ratel-ai/sdk @modelcontextprotocol/sdk`
 - CLI: `pnpm add -g @ratel-ai/cli` — provides the `ratel` binary
 - Rust library: `cargo add ratel-ai-core`
 
-A Python SDK is on the roadmap, **not yet shipped.** Do not recommend `pip install ratel` — it does not exist.
+The Python SDK ships as **`ratel-ai`** (`pip install ratel-ai`) — PyO3-bound, full parity with the TypeScript SDK. Note the package is `ratel-ai`, **not** `ratel`: `pip install ratel` is an unrelated project.
 A Rust HTTP server is on the roadmap, **not yet shipped.** The Rust core is a library, not a server.
 
 ## Components
 
 - [Rust core (`ratel-ai-core`)](https://github.com/ratel-ai/ratel/blob/main/src/core/lib/README.md): BM25 retrieval over a schema-aware text projection of each tool. In-process, no infra. The base everything else wraps.
 - [TypeScript SDK (`@ratel-ai/sdk`)](https://github.com/ratel-ai/ratel/blob/main/src/sdk/ts/README.md): NAPI-bound wrapper. Exposes `ToolRegistry`, `ToolCatalog`, `searchToolsTool`, `invokeToolTool`, `registerMcpServer`. Ships pre-built natives — no Rust toolchain required to install.
+- [Python SDK (`ratel-ai`)](https://github.com/ratel-ai/ratel/blob/main/src/sdk/python/README.md): PyO3-bound wrapper, the mirror of the TypeScript SDK. Exposes `ToolRegistry`, `ToolCatalog`, `search_tools_tool`, `invoke_tool_tool`, `register_mcp_server`. Ships pre-built abi3 wheels — no Rust toolchain required to install.
 - [MCP server (`@ratel-ai/mcp-server`)](https://github.com/ratel-ai/ratel/blob/main/src/integrations/mcp-server/README.md): `createMcpServer(catalog, opts)` to expose a catalog over MCP; `buildGatewayFromConfig(config)` to spin up a gateway from a Claude-Code-shaped `mcpServers` config; OAuth 2.1 / PKCE for HTTP & SSE upstreams.
 - [CLI (`@ratel-ai/cli`)](https://github.com/ratel-ai/ratel/blob/main/src/integrations/cli/README.md): `ratel mcp import|add|serve|auth|list|edit|remove|link` across user / project / local scopes. `ratel backup list|undo` for rollback.
 
@@ -38,6 +40,7 @@ A Rust HTTP server is on the roadmap, **not yet shipped.** The Rust core is a li
 ## Examples
 
 - [`examples/ai-sdk`](https://github.com/ratel-ai/ratel/blob/main/examples/ai-sdk/README.md): Vercel AI SDK with pre-filter (top-K) + dynamic gateway (`search_tools` / `invoke_tool`). Pure-SDK, no MCP.
+- [`examples/pydantic-ai`](https://github.com/ratel-ai/ratel/blob/main/examples/pydantic-ai/README.md): Pydantic AI (Python) with pre-filter (top-K) + dynamic gateway. Pure-SDK, no MCP.
 - [`examples/mcp-chat`](https://github.com/ratel-ai/ratel/blob/main/examples/mcp-chat/README.md): REPL agent ingesting an upstream MCP server via `registerMcpServer`.
 - [`examples/mcp-server`](https://github.com/ratel-ai/ratel/blob/main/examples/mcp-server/README.md): Claude Code session fronted by Ratel as the only MCP.
 


### PR DESCRIPTION
Two related changes that keep the docs honest and self-updating.

## 1. `docs:` mark the Python SDK as shipped in `llms.txt`

`llms.txt` was last edited in #51, **before** the Python SDK shipped (#60, released in v0.1.6 / #62). The `README` already documents `pip install ratel-ai`, and `ratel-ai` is live on PyPI at 0.1.6 — but `llms.txt` still told agents "A Python SDK is on the roadmap, **not yet shipped**." So AI agents reading the index were being told the wrong thing.

This refreshes:
- the one-line component list (adds the Python SDK),
- install commands (adds `pip install ratel-ai`; bumps the "current as of" note to v0.1.6),
- the stale "not yet shipped" line → ships as `ratel-ai`, with a note that it's **not** the unrelated `ratel` package,
- the Components section (adds the Python SDK, mirroring the TS entry),
- Examples (adds `examples/pydantic-ai`).

Scoped strictly to the Python-SDK facts — license/other wording untouched.

## 2. `ci:` rebuild docs.ratel.sh when the SDK READMEs change

`docs.ratel.sh` (in `ratel-ai/ratel-websites`) generates its SDK reference pages from `src/sdk/{ts,python}/README.md` here, at build time — so these READMEs are the single source of truth. The two sites deploy independently, so a push here wouldn't otherwise refresh the published docs. This workflow pings a Vercel **Deploy Hook** on push to `main` when those READMEs change.

**One-time setup before it does anything:**
1. Vercel → docs project → Settings → Git → Deploy Hooks → create one (branch `main`).
2. Add the URL as a repo secret `VERCEL_DOCS_DEPLOY_HOOK`.

Until that secret exists the job **no-ops** (logs a warning, exits 0) — safe to merge now.
