### PR TITLE
docs: align CLI 0.2.0 CHANGELOG date before tagging

### DIFF
--- a/src/integrations/cli/CHANGELOG.md
+++ b/src/integrations/cli/CHANGELOG.md
@@ -6,7 +6,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
-## [0.2.0] - 2026-06-10
+## [0.2.0] - 2026-06-16
 
 ### Changed
 


### PR DESCRIPTION
Tiny follow-up to #61.

The CLI `CHANGELOG.md` still read `## [0.2.0] - 2026-06-10` (pre-dated). Core, TS, and Python were corrected to the real date in #61; this brings the CLI entry in line so the coordinated **0.2.0** release is internally consistent.

**Why before the tag:** the published `v0.2.0` artifacts freeze at the tagged commit, so the immutable CLI on npm would otherwise ship with the stale date baked in. Cosmetic only — does not affect the release gate (which checks entry presence, not the date).

No code changes; one line.