### PR TITLE
docs(sdk): rewrite TS & Python SDK READMEs as docs source

### DIFF
--- a/src/sdk/python/README.md
+++ b/src/sdk/python/README.md
@@ -7,11 +7,18 @@
     <a href="../../../docs/roadmap.md">Roadmap</a> •
     <a href="https://discord.gg/hdKpx69NR">Discord</a>
   </p>
+
+  <p>
+    <a href="https://pypi.org/project/ratel-ai/"><img src="https://img.shields.io/pypi/v/ratel-ai?label=pypi&color=3775a9" alt="PyPI" /></a>
+    <a href="https://github.com/ratel-ai/ratel/stargazers"><img src="https://img.shields.io/github/stars/ratel-ai/ratel?style=social" alt="GitHub stars" /></a>
+    <a href="https://discord.gg/hdKpx69NR"><img src="https://img.shields.io/discord/1478702964003705015?logo=discord&logoColor=white&color=7289da&label=discord" alt="Discord" /></a>
+    <a href="../../../LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue" alt="license" /></a>
+  </p>
 </div>
 
-Python SDK for [Ratel](../../../README.md). Bundles `ratel-ai-core` (Rust) via [PyO3](https://pyo3.rs) so Python agents can drop Ratel in with one dependency — no Rust toolchain, no service to deploy.
+As an agent runs, its context window fills with tool definitions it will never call this turn. A model staring at 100 tools picks the wrong one, burns tokens on schemas it ignores, and drifts. **Ratel** keeps the full toolset out of the prompt and surfaces only the handful that matter for the current turn.
 
-Binding strategy is locked in [ADR 0011](../../../docs/adr/0011-python-rust-binding-strategy.md); it mirrors the TypeScript SDK's NAPI binding ([ADR 0002](../../../docs/adr/0002-ts-rust-binding-strategy.md)).
+`ratel-ai` is the Python surface of [Ratel](../../../README.md). It bundles the Rust core (`ratel-ai-core`) via [PyO3](https://pyo3.rs), so a Python agent gets ranked tool selection by adding one dependency, **in-process, no API key, no service to deploy, no Rust toolchain.** Retrieval is BM25 over a schema-aware text projection of each tool: deterministic, with no embeddings, no vector DB, and no inference cost on the retrieval path. The API mirrors the [TypeScript SDK](../ts/README.md) one-to-one; the binding strategy is locked in [ADR 0011](../../../docs/adr/0011-python-rust-binding-strategy.md).
 
 ## Install
 
@@ -21,13 +28,131 @@ pip install ratel-ai
 pip install 'ratel-ai[mcp]'
 ```
 
-Prebuilt `abi3` wheels ship for darwin-arm64, darwin-x64, linux-x64-gnu, linux-arm64-gnu, and win32-x64-msvc — no Rust toolchain required to install. The base SDK runs on CPython ≥ 3.9; the `mcp` extra requires ≥ 3.10.
+Prebuilt `abi3` wheels ship for darwin-arm64, darwin-x64, linux-x64-gnu, linux-arm64-gnu, and win32-x64-msvc, so there is nothing to compile. The base SDK runs on CPython ≥ 3.9; the `mcp` extra requires ≥ 3.10.
 
-## Usage
+## How it works
 
-The SDK exposes two layers, both framework-neutral — the Python mirror of the [TypeScript SDK](../ts/README.md).
+Everything starts with a **`ToolCatalog`**: register each of your tools once, pairing its metadata (id, description, JSON schemas) with the handler that runs it. From there you reach the model in one of two ways, and most agents use both at once:
 
-### `ToolRegistry` — metadata-only BM25 index
+- **Pre-filter (top-K).** Before each model call, ask the catalog for the few tools most relevant to the user's message and put *those* in the tool list. The full catalog never enters the prompt. This is Ratel's replace-by-default tool injection ([ADR 0003](../../../docs/adr/0003-tool-selection-replace-vs-suggest.md)).
+- **Dynamic gateway.** Give the agent two always-present tools, `search_capabilities` (find more tools by description) and `invoke_tool` (run one by id), so it can reach the rest of the catalog on its own when the pre-filtered set is not enough.
+
+The two compose: the pre-filter covers the common case in the prompt, and the gateway is the escape hatch for everything else. Tools can be local functions, an upstream MCP server's tools (via [`register_mcp_server`](#register_mcp_server-ingest-an-mcp-server)), or both. The model sees one unified, ranked surface.
+
+## Quickstart
+
+Register a catalog, then build each turn's tool list from the gateway plus the top-K hits for the user's message.
+
+```python
+from ratel_ai import (
+    ToolCatalog,
+    ExecutableTool,
+    search_capabilities_tool,
+    invoke_tool_tool,
+)
+
+catalog = ToolCatalog()
+catalog.register(
+    ExecutableTool(
+        id="read_file",
+        name="read_file",
+        description="Read a file from local disk and return its textual contents.",
+        input_schema={
+            "type": "object",
+            "properties": {"path": {"type": "string", "description": "absolute path to the file"}},
+            "required": ["path"],
+        },
+        output_schema={"type": "object", "properties": {"contents": {"type": "string"}}},
+        execute=lambda args: {"contents": open(args["path"]).read()},
+    )
+)
+# ...register the rest of your tools the same way.
+
+
+# Each turn, assemble the tools the model is allowed to see:
+def tools_for_turn(user_message: str) -> list[ExecutableTool]:
+    gateway = [search_capabilities_tool(catalog), invoke_tool_tool(catalog)]
+    top_k = [
+        executable
+        for hit in catalog.search(user_message, 3)  # BM25: the 3 most relevant tools
+        if (executable := catalog.get_executable(hit.tool_id)) is not None
+    ]
+    return [*gateway, *top_k]
+```
+
+`search_capabilities_tool` and `invoke_tool_tool` return plain `ExecutableTool` objects (`id`, `name`, `description`, `input_schema`, `output_schema`, `execute`). Wrap each one in your framework's tool type and run your normal loop. There are two dispatch paths, and getting them right matters because a registered executor may be sync or async:
+
+- **Catalog tools** (your top-K hits): dispatch through `catalog.invoke(tool_id, args)`. It awaits coroutines only when needed and records the `invoke_*` trace events. Never `await` a raw `execute` yourself, or a sync handler raises.
+- **The two gateway tools** (`search_capabilities` / `invoke_tool`): they are *not* catalog entries, and they own `async` handlers, so await `t.execute(args)` directly.
+
+With Pydantic AI, the catalog-tool wrapper is:
+
+```python
+from pydantic_ai import Tool
+
+def catalog_tool(catalog: ToolCatalog, t: ExecutableTool) -> Tool:
+    async def fn(**kwargs):
+        return await catalog.invoke(t.id, kwargs)  # handles sync/async + trace events
+    fn.__name__ = t.id
+    # Tool.from_schema builds a tool from a JSON schema directly — exactly what a dynamic catalog needs.
+    return Tool.from_schema(fn, name=t.id, description=t.description, json_schema=t.input_schema)
+```
+
+A complete runnable agent that wires both paths into a Pydantic AI `Agent` lives in [`examples/pydantic-ai/`](../../../examples/pydantic-ai/README.md).
+
+## `ToolCatalog`
+
+The catalog is the registry plus an executor per tool. The methods you will use:
+
+```python
+catalog = ToolCatalog()
+
+catalog.register(tool)                      # ExecutableTool: metadata + execute
+catalog.search(query, top_k)                # → list[SearchHit]  (.tool_id, .score), BM25-ranked
+catalog.has(tool_id)                        # → bool
+catalog.get(tool_id)                        # → Tool | None            (metadata only)
+catalog.get_executable(tool_id)             # → ExecutableTool | None  (metadata + execute)
+await catalog.invoke(tool_id, args)         # run the handler, return its result
+```
+
+`invoke` calls the handler, awaits it only if it returned a coroutine (so sync and async executors both work), and re-raises whatever it throws after recording an `invoke_error` trace event. `search` defaults to `origin="direct"`; pass `catalog.search(query, k, "agent")` to tag a search as model-initiated in telemetry.
+
+### `search_capabilities_tool` / `invoke_tool_tool`: the agent gateway
+
+These wrap a catalog into two tools an agent can call itself. Hand them to your loop and the model gets self-service access to the whole catalog without it living in the prompt.
+
+```python
+search = search_capabilities_tool(catalog)  # id == "search_capabilities"
+invoke = invoke_tool_tool(catalog)          # id == "invoke_tool"
+```
+
+**`search_capabilities({query, topKTools?, topKSkills?})`** returns two independently-ranked buckets, so a relevant skill is never crowded out by matching tools (result keys are camelCase, a wire contract shared with the TypeScript SDK and MCP):
+
+```jsonc
+{
+  "tools": {
+    "groups": [
+      {
+        "server": {"name": "fs"},                    // grouped by server (the id prefix before "__")
+        "hits": [
+          {"toolId": "fs__read_file", "score": 1.42, "description": "...", "inputSchema": {}}
+        ]
+      }
+    ]
+  },
+  "skills": [{"skillId": "deploy-vercel", "score": 0.9, "description": "..."}]
+}
+```
+
+`topKTools` defaults to 5 and `topKSkills` to 3, each clamped to `[1, 50]`. The `skills` bucket is always present and stays empty until you pass a [`SkillCatalog`](#skillcatalog-reusable-playbooks-on-demand).
+
+**`invoke_tool({toolId, args})`** runs `catalog.invoke(tool_id, args)` and returns the tool's result. Arguments go *nested* under `args`. On a bad call it returns a structured `{"error": ..., "isError": True}` instead of raising, so a model mistake (unknown id, malformed args, a handler that throws) stays recoverable inside the loop rather than crashing the host.
+
+> **Upgrading from 0.1.x?** `search_tools_tool` (id `search_tools`) is still exported as a deprecated, tools-only shim that keeps its original `{"groups": ...}` result shape. Migrate to `search_capabilities_tool`; see [`ratel_ai/gateway_compat.py`](ratel_ai/gateway_compat.py).
+
+## `ToolRegistry`: ranking without execution
+
+Need only the ranking, and you will dispatch tool calls yourself? `ToolRegistry` is the metadata-only BM25 index underneath `ToolCatalog`, with no executors and no gateway. It takes positional metadata rather than a dataclass:
 
 ```python
 from ratel_ai import ToolRegistry
@@ -41,49 +166,15 @@ registry.register(
     {"properties": {"contents": {"type": "string"}}},
 )
 
-hits = registry.search("read a text file", 5)
-# [SearchHit(tool_id="read_file", score=1.42), ...]
+registry.search("read a text file", 5)
+# → [SearchHit(tool_id="read_file", score=1.42), ...]
 ```
 
-### `ToolCatalog` + gateway tools — register once, dispatch by id
+## `SkillCatalog`: reusable playbooks, on demand
 
-`ToolCatalog` extends the registry with executable handlers (`id → execute`), and
-`search_capabilities_tool` / `invoke_tool_tool` give your agent a self-service gateway
-over the catalog. Pair them with any agent framework — see
-[`examples/pydantic-ai/`](../../../examples/pydantic-ai/README.md) for a Pydantic AI wiring.
+Skills are Markdown playbooks (a deploy runbook, a debugging checklist) ranked by a *separate* BM25 corpus from tools. Pass a `SkillCatalog` as the second argument to `search_capabilities_tool` and search returns the `skills` bucket alongside `tools`, each with its own result budget so a relevant skill is never starved by matching tools. The agent pulls a skill's full body into context on demand via `get_skill_content_tool` (id `get_skill_content`).
 
-```python
-import asyncio
-from ratel_ai import ToolCatalog, ExecutableTool, search_capabilities_tool, invoke_tool_tool
-
-catalog = ToolCatalog()
-catalog.register(
-    ExecutableTool(
-        id="read_file",
-        name="read_file",
-        description="Read a file from local disk.",
-        input_schema={"properties": {"path": {"type": "string"}}},
-        output_schema={"properties": {"contents": {"type": "string"}}},
-        execute=lambda args: {"contents": open(args["path"]).read()},
-    )
-)
-
-search = search_capabilities_tool(catalog)   # id == "search_capabilities"
-invoke = invoke_tool_tool(catalog)    # id == "invoke_tool"
-```
-
-Executors may be sync or async; `ToolCatalog.invoke` awaits coroutines automatically.
-
-### `SkillCatalog` + `get_skill_content_tool` — reusable playbooks, on demand
-
-Skills are Markdown playbooks ranked by a *separate* BM25 corpus. When a `SkillCatalog`
-is passed to `search_capabilities_tool`, the search returns a `skills` bucket alongside
-`tools` — each with its own result budget, so a relevant skill is never crowded out by
-matching tools. The agent loads a skill's full body on demand via `get_skill_content_tool`.
-
-A skill can also declare the `tools` its instructions call: when the skill matches, those
-tools are pulled into the `tools` bucket (additively, deduped), so the agent gets the
-playbook and the tools it needs in a single turn instead of a second search.
+A skill can also declare the `tools` its instructions call: when the skill matches a query, those tools are pulled into the `tools` bucket (additively, deduped) so the agent gets the playbook *and* the tools it needs in one turn instead of a second search.
 
 ```python
 from ratel_ai import Skill, SkillCatalog, get_skill_content_tool, search_capabilities_tool
@@ -94,33 +185,42 @@ skills.register(
         id="vercel-deploy",
         name="vercel-deploy",
         description="How to deploy to Vercel: env vars, preview vs production, rollbacks.",
-        tags=["deploy", "ship to production"],     # indexed for ranking
-        tools=["vercel__deploy", "fs__read_file"],  # surfaced with the skill
-        metadata={"stacks": ["next", "vercel"]},   # non-indexed context (push ranker)
+        tags=["deploy", "ship to production"],      # indexed for ranking
+        tools=["vercel__deploy", "fs__read_file"],  # surfaced alongside the skill when it matches
+        metadata={"stacks": ["next", "vercel"]},    # non-indexed context for higher-layer ranking
+        body="## Deploying to Vercel\n1. ...",       # returned by get_skill_content_tool
     )
 )
 
-search = search_capabilities_tool(catalog, skills)  # result: {"tools": {...}, "skills": [...]}
+search = search_capabilities_tool(catalog, skills)  # 2nd arg → result gains a populated `skills` bucket
 load = get_skill_content_tool(skills)               # id == "get_skill_content"
 ```
 
-### `register_mcp_server` — ingest an upstream MCP server
+Only `id`, `name`, and `description` are required; `tags`, `tools`, `metadata`, and `body` are optional. `get_skill_content({skillId})` returns `{"body": ...}`, or `{"error": ..., "isError": True}` for an unknown id.
 
-Requires the `mcp` extra. The caller owns the `ClientSession` lifecycle (set it up
-with `async with`) and passes the initialized session in:
+## `register_mcp_server`: ingest an MCP server
+
+Requires the `mcp` extra. The caller owns the `ClientSession` lifecycle (set it up with `async with`) and passes the initialized session in. `register_mcp_server` lists the upstream's tools, registers each under a namespaced id (`<name>__<tool>`), and wires its executor to the upstream `call_tool`.
 
 ```python
 from ratel_ai import register_mcp_server
 
 handle = await register_mcp_server(
-    catalog, name="github", session=session, transport_label="stdio",
+    catalog,
+    name="github",
+    session=session,            # an initialized mcp.ClientSession you own
+    transport_label="stdio",    # recorded on the upstream_register trace event
 )
-# handle.tool_ids -> ["github__create_issue", ...]
+# handle.tool_ids           → ["github__create_issue", ...]
+# handle.server_instructions → whatever you passed as `instructions`
+# catalog.search / catalog.invoke now rank and run the upstream tools alongside local ones.
 ```
 
-### Telemetry
+The caller-owns-the-session split is the one deliberate divergence from the TypeScript SDK, whose `registerMcpServer` reads the server instructions and transport label from the live handshake itself. Pass `instructions=` and `transport_label=` from your `await session.initialize()` result to make the emitted `upstream_register` event byte-identical across the two SDKs.
 
-Pass `trace` to `ToolCatalog` to capture every search / invoke / gateway / upstream / auth event into a sink owned by the Rust core ([ADR 0009](../../../docs/adr/0009-trace-events-core-owned-schema.md)). Default is no-op — nothing is captured unless you opt in.
+## Telemetry
+
+Pass `trace` to `ToolCatalog` to capture every search / invoke / gateway / upstream / auth event into a sink owned by the Rust core ([ADR 0009](../../../docs/adr/0009-trace-events-core-owned-schema.md)). The default is no-op: nothing is captured unless you opt in.
 
 ```python
 from ratel_ai import ToolCatalog, TraceSinkConfig
@@ -128,14 +228,14 @@ from ratel_ai import ToolCatalog, TraceSinkConfig
 catalog = ToolCatalog(
     trace=TraceSinkConfig(kind="jsonl", session_id="session-1", path="/tmp/ratel.jsonl"),
 )
-# every catalog.invoke, search_capabilities_tool, register_mcp_server call now writes
+# every catalog.invoke, search_capabilities_tool, and register_mcp_server call now writes
 # one JSON line per event to /tmp/ratel.jsonl.
 ```
 
 Sink kinds:
-- `kind="noop"` — drop everything (default).
-- `kind="memory"`, `session_id` — keep events in memory; drain via `catalog.drain_trace_events()`. Useful for tests.
-- `kind="jsonl"`, `session_id`, `path` — append one JSON line per event to `path` (mode `0600` on Unix). Best-effort, lossy on backpressure — see ADR-0009 for the reliability profile.
+- `kind="noop"`, drop everything (default).
+- `kind="memory"`, `session_id`, keep events in memory; drain via `catalog.drain_trace_events()`. Useful in tests.
+- `kind="jsonl"`, `session_id`, `path`, append one JSON line per event to `path` (mode `0600` on Unix). Best-effort, lossy on backpressure; see [ADR 0009](../../../docs/adr/0009-trace-events-core-owned-schema.md) for the reliability profile.
 
 `search_capabilities_tool` tags its emitted `search` event with `origin="agent"`; direct callers (`catalog.search(query, k)`) default to `"direct"`. Override per call via `catalog.search(query, k, "agent")`.
 
@@ -156,7 +256,7 @@ uv pip install --python .venv maturin pytest pytest-asyncio ruff mypy
 
 ```
 native/         PyO3 binding to ratel-ai-core (cdylib Cargo workspace member)
-ratel_ai/       pure-Python SDK: catalog, gateway tools, MCP ingestion
+ratel_ai/       pure-Python SDK: catalog, gateway tools, skills, MCP ingestion
 tests/          pytest suite
 pyproject.toml  maturin build backend + tooling config
 ```

--- a/src/sdk/ts/README.md
+++ b/src/sdk/ts/README.md
@@ -12,11 +12,13 @@
     <a href="https://www.npmjs.com/package/@ratel-ai/sdk"><img src="https://img.shields.io/npm/v/@ratel-ai/sdk?label=npm&color=cb3837" alt="npm" /></a>
     <a href="https://github.com/ratel-ai/ratel/stargazers"><img src="https://img.shields.io/github/stars/ratel-ai/ratel?style=social" alt="GitHub stars" /></a>
     <a href="https://discord.gg/hdKpx69NR"><img src="https://img.shields.io/discord/1478702964003705015?logo=discord&logoColor=white&color=7289da&label=discord" alt="Discord" /></a>
-    <a href="../../../LICENSE.md"><img src="https://img.shields.io/badge/license-ELv2-blue" alt="license" /></a>
+    <a href="../../../LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue" alt="license" /></a>
   </p>
 </div>
 
-TypeScript SDK for [Ratel](../../../README.md). Bundles `ratel-ai-core` (Rust) via NAPI-RS so JS/TS agents can drop Ratel in with one dependency — no Rust toolchain, no service to deploy.
+As an agent runs, its context window fills with tool definitions it will never call this turn. A model staring at 100 tools picks the wrong one, burns tokens on schemas it ignores, and drifts. **Ratel** keeps the full toolset out of the prompt and surfaces only the handful that matter for the current turn.
+
+`@ratel-ai/sdk` is the TypeScript surface of [Ratel](../../../README.md). It bundles the Rust core (`ratel-ai-core`) via [NAPI-RS](https://napi.rs), so a JS / TS agent gets ranked tool selection by adding one dependency, **in-process, no API key, no service to deploy, no Rust toolchain.** Retrieval is BM25 over a schema-aware text projection of each tool: deterministic, with no embeddings, no vector DB, and no inference cost on the retrieval path.
 
 ## Install
 
@@ -26,15 +28,124 @@ pnpm add @ratel-ai/sdk
 npm install @ratel-ai/sdk
 ```
 
-From `0.1.4`, prebuilt native bindings ship for darwin-arm64, darwin-x64, linux-x64-gnu, linux-arm64-gnu, and win32-x64-msvc — no Rust toolchain required to install. The right per-platform binary is selected automatically via npm `optionalDependencies`. See [ADR 0002](../../../docs/adr/0002-ts-rust-binding-strategy.md) for the rationale.
+Prebuilt native bindings ship for darwin-arm64, darwin-x64, linux-x64-gnu, linux-arm64-gnu, and win32-x64-msvc. The right per-platform binary is selected automatically through npm `optionalDependencies` ([ADR 0002](../../../docs/adr/0002-ts-rust-binding-strategy.md)), so there is nothing to compile.
 
-## Usage
+## How it works
 
-The SDK exposes two layers, both framework-neutral.
+Everything starts with a **`ToolCatalog`**: register each of your tools once, pairing its metadata (id, description, JSON schemas) with the handler that runs it. From there you reach the model in one of two ways, and most agents use both at once:
 
-### `ToolRegistry` — metadata-only BM25 index
+- **Pre-filter (top-K).** Before each model call, ask the catalog for the few tools most relevant to the user's message and put *those* in the tool list. The full catalog never enters the prompt. This is Ratel's replace-by-default tool injection ([ADR 0003](../../../docs/adr/0003-tool-selection-replace-vs-suggest.md)).
+- **Dynamic gateway.** Give the agent two always-present tools, `search_capabilities` (find more tools by description) and `invoke_tool` (run one by id), so it can reach the rest of the catalog on its own when the pre-filtered set is not enough.
 
-Use this when you just need ranking and you'll dispatch tool calls yourself.
+The two compose: the pre-filter covers the common case in the prompt, and the gateway is the escape hatch for everything else. Tools can be local functions, an upstream MCP server's tools (via [`registerMcpServer`](#registermcpserver-ingest-an-mcp-servers-tools)), or both. The model sees one unified, ranked surface.
+
+## Quickstart
+
+Register a catalog, then build each turn's tool list from the gateway plus the top-K hits for the user's message.
+
+```ts
+import {
+  ToolCatalog,
+  searchCapabilitiesTool,
+  invokeToolTool,
+  type ExecutableTool,
+} from "@ratel-ai/sdk";
+import { readFile } from "node:fs/promises";
+
+const catalog = new ToolCatalog();
+catalog.register({
+  id: "read_file",
+  name: "read_file",
+  description: "Read a file from local disk and return its textual contents.",
+  inputSchema: {
+    type: "object",
+    properties: { path: { type: "string", description: "absolute path to the file" } },
+    required: ["path"],
+  },
+  outputSchema: { type: "object", properties: { contents: { type: "string" } } },
+  execute: async ({ path }) => ({ contents: await readFile(path, "utf8") }),
+});
+// ...register the rest of your tools the same way.
+
+// Each turn, assemble the tools the model is allowed to see:
+function toolsForTurn(userMessage: string): ExecutableTool[] {
+  const gateway = [searchCapabilitiesTool(catalog), invokeToolTool(catalog)];
+  const topK = catalog
+    .search(userMessage, 3) // BM25: the 3 most relevant tools for this message
+    .map((hit) => catalog.getExecutable(hit.toolId))
+    .filter((t): t is ExecutableTool => t !== undefined);
+  return [...gateway, ...topK];
+}
+```
+
+`searchCapabilitiesTool` and `invokeToolTool` return plain `ExecutableTool` objects (`{ id, name, description, inputSchema, outputSchema, execute }`). Wrap each one in your framework's tool type, a few lines, and run your normal loop. For the Vercel AI SDK that adapter is:
+
+```ts
+import { tool, jsonSchema } from "ai";
+
+const toAISDKTool = (t: ExecutableTool) =>
+  tool({
+    description: t.description,
+    inputSchema: jsonSchema(t.inputSchema),
+    execute: t.execute,
+  });
+```
+
+A complete runnable agent that wires this into `ToolLoopAgent` lives in [`examples/ai-sdk/`](../../../examples/ai-sdk/README.md); [`examples/mcp-chat/`](../../../examples/mcp-chat/README.md) does the same over an upstream MCP server.
+
+## `ToolCatalog`
+
+The catalog is the registry plus an executor per tool. The methods you will use:
+
+```ts
+const catalog = new ToolCatalog();
+
+catalog.register(tool);              // ExecutableTool: metadata + execute()
+catalog.search(query, topK);         // → SearchHit[]  ({ toolId, score }), BM25-ranked
+catalog.has(toolId);                 // → boolean
+catalog.get(toolId);                 // → Tool | undefined            (metadata only)
+catalog.getExecutable(toolId);       // → ExecutableTool | undefined  (metadata + execute)
+await catalog.invoke(toolId, args);  // run the handler, return its result
+```
+
+`invoke` awaits async executors and rethrows whatever the handler throws (after recording an `invoke_error` trace event), so failures surface where you call it. `search` defaults to `origin: "direct"`; pass `catalog.search(query, k, "agent")` to tag a search as model-initiated in telemetry.
+
+### `searchCapabilitiesTool` / `invokeToolTool`: the agent gateway
+
+These wrap a catalog into two tools an agent can call itself. Hand them to your loop and the model gets self-service access to the whole catalog without it living in the prompt.
+
+```ts
+const search = searchCapabilitiesTool(catalog); // id: "search_capabilities"
+const invoke = invokeToolTool(catalog);         // id: "invoke_tool"
+```
+
+**`search_capabilities({ query, topKTools?, topKSkills? })`** returns two independently-ranked buckets, so a relevant skill is never crowded out by matching tools:
+
+```jsonc
+{
+  "tools": {
+    "groups": [
+      {
+        "server": { "name": "fs" },                  // grouped by server (the id prefix before "__")
+        "hits": [
+          { "toolId": "fs__read_file", "score": 1.42, "description": "...", "inputSchema": {} }
+        ]
+      }
+    ]
+  },
+  "skills": [{ "skillId": "deploy-vercel", "score": 0.9, "description": "..." }]
+}
+```
+
+`topKTools` defaults to 5 and `topKSkills` to 3, each clamped to `[1, 50]`. The `skills` bucket is always present and stays empty until you pass a [`SkillCatalog`](#skillcatalog-reusable-playbooks-on-demand).
+
+**`invoke_tool({ toolId, args })`** runs `catalog.invoke(toolId, args)` and returns the tool's result. Arguments go *nested* under `args`. On a bad call it returns a structured `{ error, isError: true }` instead of throwing, so a model mistake (unknown id, malformed args, a handler that throws) stays recoverable inside the loop rather than crashing the host.
+
+> **Upgrading from 0.1.x?** `searchToolsTool` (id `search_tools`) is still exported as a deprecated, tools-only shim that keeps its original `{ groups }` result shape. Migrate to `searchCapabilitiesTool`; see [`src/gateway-compat.ts`](src/gateway-compat.ts).
+
+## `ToolRegistry`: ranking without execution
+
+Need only the ranking, and you will dispatch tool calls yourself? `ToolRegistry` is the metadata-only BM25 index underneath `ToolCatalog`, with no executors and no gateway.
 
 ```ts
 import { ToolRegistry, type Tool } from "@ratel-ai/sdk";
@@ -48,45 +159,15 @@ registry.register({
   outputSchema: { properties: { contents: { type: "string" } } },
 });
 
-const hits = registry.search("read a text file", 5);
-// [{ toolId: "read_file", score: 1.42 }, ...]
+registry.search("read a text file", 5);
+// → [{ toolId: "read_file", score: 1.42 }, ...]
 ```
 
-### `ToolCatalog` + gateway tools — register once, dispatch by id
+## `SkillCatalog`: reusable playbooks, on demand
 
-`ToolCatalog` extends the registry with executable handlers (`id → execute`), and `searchCapabilitiesTool` / `invokeToolTool` give your agent a self-service gateway over the catalog. Pair them with any agent framework — see [`examples/ai-sdk/`](../../../examples/ai-sdk/README.md) for a Vercel AI SDK wiring.
+Skills are Markdown playbooks (a deploy runbook, a debugging checklist) ranked by a *separate* BM25 corpus from tools. Pass a `SkillCatalog` as the second argument to `searchCapabilitiesTool` and search returns the `skills` bucket alongside `tools`, each with its own result budget so a relevant skill is never starved by matching tools. The agent pulls a skill's full body into context on demand via `getSkillContentTool` (id `get_skill_content`).
 
-```ts
-import {
-  ToolCatalog,
-  searchCapabilitiesTool,
-  invokeToolTool,
-  type ExecutableTool,
-} from "@ratel-ai/sdk";
-
-const catalog = new ToolCatalog();
-catalog.register({
-  id: "read_file",
-  name: "read_file",
-  description: "Read a file from local disk.",
-  inputSchema: { properties: { path: { type: "string" } } },
-  outputSchema: { properties: { contents: { type: "string" } } },
-  execute: async ({ path }) => ({ contents: await fs.readFile(path, "utf8") }),
-});
-
-// Gateway tools — wrap them into your framework's tool type.
-// Each returns ExecutableTool ({ id, name, description, inputSchema, outputSchema, execute }).
-const search = searchCapabilitiesTool(catalog);
-const invoke = invokeToolTool(catalog);
-```
-
-Tool injection (replace vs suggest, [ADR 0003](../../../docs/adr/0003-tool-selection-replace-vs-suggest.md)) is layered on later when the SDK exposes a higher-level adapter.
-
-### `SkillCatalog` + `getSkillContentTool` — reusable playbooks, on demand
-
-Skills are Markdown playbooks ranked by a *separate* BM25 corpus. Pass a `SkillCatalog` as the second argument to `searchCapabilitiesTool` and the search returns a `skills` bucket alongside `tools` — each with its own result budget, so a relevant skill is never crowded out by matching tools. The agent loads a skill's full body on demand via `getSkillContentTool`.
-
-A skill can also declare the `tools` its instructions call: when the skill matches, those tools are pulled into the `tools` bucket (additively, deduped), so the agent gets the playbook and the tools it needs in a single turn instead of a second search.
+A skill can also declare the `tools` its instructions call: when the skill matches a query, those tools are pulled into the `tools` bucket (additively, deduped) so the agent gets the playbook *and* the tools it needs in one turn instead of a second search.
 
 ```ts
 import {
@@ -102,21 +183,20 @@ skills.register({
   name: "vercel-deploy",
   description: "How to deploy to Vercel: env vars, preview vs production, rollbacks.",
   tags: ["deploy", "ship to production"],     // indexed for ranking
-  tools: ["vercel__deploy", "fs__read_file"], // surfaced with the skill
-  metadata: { stacks: ["next", "vercel"] },   // non-indexed context (push ranker)
+  tools: ["vercel__deploy", "fs__read_file"], // surfaced alongside the skill when it matches
+  metadata: { stacks: ["next", "vercel"] },   // non-indexed context for higher-layer ranking
   body: "## Deploying to Vercel\n1. ...",      // returned by getSkillContentTool
 });
 
-// Pass the skill catalog as the 2nd arg → result: { tools: {...}, skills: [...] }
-const search = searchCapabilitiesTool(catalog, skills);
-const load = getSkillContentTool(skills); // id == "get_skill_content"
+const search = searchCapabilitiesTool(catalog, skills); // 2nd arg → result gains a populated `skills` bucket
+const load = getSkillContentTool(skills);               // id: "get_skill_content"
 ```
 
-Only `id`, `name`, and `description` are required; `tags`, `tools`, `metadata`, and `body` are optional (parity with the Python SDK).
+Only `id`, `name`, and `description` are required; `tags`, `tools`, `metadata`, and `body` are optional (parity with the Python SDK). `get_skill_content({ skillId })` returns `{ body }`, or `{ error, isError: true }` for an unknown id.
 
-### `registerMcpServer` — index an MCP server's tools into the catalog
+## `registerMcpServer`: ingest an MCP server's tools
 
-Hand the catalog a connected MCP transport and Ratel will call `tools/list`, register each upstream tool with a server-namespaced id (`<name>__<toolName>`), and wire its executor to `tools/call` over the same connection. Use any [transport from `@modelcontextprotocol/sdk`](https://modelcontextprotocol.io) — stdio, Streamable HTTP, or SSE.
+Hand the catalog a connected MCP transport and Ratel calls `tools/list`, registers each upstream tool under a server-namespaced id (`<name>__<toolName>`), and wires its executor to `tools/call` over the same connection. Use any [transport from `@modelcontextprotocol/sdk`](https://modelcontextprotocol.io): stdio, Streamable HTTP, or SSE.
 
 ```ts
 import { ToolCatalog, registerMcpServer } from "@ratel-ai/sdk";
@@ -131,37 +211,37 @@ const handle = await registerMcpServer(catalog, {
   }),
 });
 
-// handle.toolIds → ["fs__echo", "fs__add", ...]
-// catalog.search / catalog.invoke now see the upstream tools alongside any local ones.
+// handle.toolIds            → ["fs__echo", "fs__add", ...]
+// handle.serverInstructions → the upstream's instructions, if any
+// catalog.search / catalog.invoke now rank and run the upstream tools alongside local ones.
 
 await handle.close(); // disconnect on shutdown
 ```
 
-Errors from the upstream `tools/call` propagate as rejected promises from `catalog.invoke`, so they slot into the same handling as local executors.
+Errors from the upstream `tools/call` propagate as rejected promises from `catalog.invoke`, so they slot into the same handling as local executors. Mix as many servers and local tools into one catalog as you like; the model still sees a single ranked surface.
 
-### Telemetry
+## Telemetry
 
-Pass `trace` to the `ToolCatalog` constructor to capture every search / invoke / gateway / upstream / auth event into a sink owned by the Rust core ([ADR 0009](../../../docs/adr/0009-trace-events-core-owned-schema.md)). Default is no-op — nothing is captured unless you opt in.
+Pass `trace` to the `ToolCatalog` constructor to capture every search / invoke / gateway / upstream / auth event into a sink owned by the Rust core ([ADR 0009](../../../docs/adr/0009-trace-events-core-owned-schema.md)). The default is no-op: nothing is captured unless you opt in.
 
 ```ts
 const catalog = new ToolCatalog({
   trace: { kind: "jsonl", sessionId: "session-1", path: "/tmp/ratel.jsonl" },
 });
-// every catalog.invoke, searchCapabilitiesTool, registerMcpServer call now writes
+// every catalog.invoke, searchCapabilitiesTool, and registerMcpServer call now writes
 // one JSON line per event to /tmp/ratel.jsonl.
 ```
 
 Sink kinds:
-- `{ kind: "noop" }` — drop everything (default).
-- `{ kind: "memory"; sessionId }` — keep events in memory; drain via `catalog.drainTraceEvents()`. Useful for tests.
-- `{ kind: "jsonl"; sessionId; path }` — append one JSON line per event to `path` (mode `0600` on Unix). Best-effort, lossy on backpressure — see ADR-0009 for the reliability profile.
+- `{ kind: "noop" }`, drop everything (default).
+- `{ kind: "memory"; sessionId }`, keep events in memory; drain via `catalog.drainTraceEvents()`. Useful in tests.
+- `{ kind: "jsonl"; sessionId; path }`, append one JSON line per event to `path` (mode `0600` on Unix). Best-effort, lossy on backpressure; see [ADR 0009](../../../docs/adr/0009-trace-events-core-owned-schema.md) for the reliability profile.
 
 `searchCapabilitiesTool` tags its emitted `search` event with `origin: "agent"`; direct callers (`catalog.search(query, k)`) default to `"direct"`. Override per call via `catalog.search(query, k, "agent")`.
 
 ## Package shape
 
-- Package name: `@ratel-ai/sdk`
-- ESM entry (`dist/index.js`); the underlying NAPI loader is CJS, statically bridged at build time.
+- Package name: `@ratel-ai/sdk` (ESM, entry `dist/index.js`); the underlying NAPI loader is CJS, statically bridged at build time.
 - Native binding lives in [`native/`](native/README.md) (Rust + NAPI-RS).
 
 ## Build & test


### PR DESCRIPTION
## Why

`src/sdk/ts/README.md` and `src/sdk/python/README.md` are the **single source of truth** for the SDK reference pages on [docs.ratel.sh](https://docs.ratel.sh/docs/sdks) — `ratel-websites` fetches them from `main` and renders them verbatim (`apps/docs/scripts/sync-ratel-docs.mjs`). So these files are docs, not just repo READMEs. This rewrite makes them read like docs while keeping every snippet code-accurate against the shipped 0.2.0 surface.

## What changed

Both READMEs now follow the same shape, mirrored 1:1 across languages:

1. **Client-facing intro** — the problem (context bloat → wrong tool, wasted tokens, drift), what the SDK does (BM25 tool selection, in-process, no infra/API key/Rust toolchain).
2. **How it works** — the mental model: one `ToolCatalog`, two ways to reach the model (top-K **pre-filter** + the **dynamic gateway**), and that both compose.
3. **Quickstart** — the end-to-end pattern most agents actually use: build each turn's tool list from the two gateway tools **plus** the top-K hits, with `getExecutable` wiring and a real framework-adapter snippet (Vercel AI SDK / Pydantic AI), grounded in `examples/`.
4. **Per-layer reference** — `ToolCatalog`, the `search_capabilities` / `invoke_tool` gateway (with the **two-bucket result shape**, `topK` defaults + `[1,50]` clamp, and the structured-error contracts), `ToolRegistry`, `SkillCatalog` + `get_skill_content`, `registerMcpServer`, telemetry.

Also:
- Notes the deprecated 0.1.x `search_tools` shim and how to migrate.
- Python README spells out the catalog-tool (`catalog.invoke`) vs gateway-tool (await `execute`) dispatch split that the example relies on.
- Aligns the TS license badge with `LICENSE.md` (**MIT**) — see note below.

## Accuracy

Every symbol, signature, result shape, default, and error contract was checked against the SDK source (`catalog.ts`/`.py`, `gateway.ts`/`.py`, `skill-*`, `mcp.*`, native `*.d.cts`/`.pyi`) and the runnable `examples/`. Ran the docs sync transforms (header strip, em-dash → comma, link absolutization) locally: both files render cleanly, all relative links resolve, and intra-page anchors survive.

## ⚠️ License inconsistency (needs a decision)

`LICENSE.md` is **MIT**, the root README badge says MIT, but `llms.txt` still says *Elastic License 2.0 + OSI grant* and the TS badge said *ELv2*. I aligned the TS badge to MIT (matching the actual license file). **`llms.txt` is left untouched** — please confirm the intended license and I'll reconcile `llms.txt` in a follow-up.

## Notes
- Docs-only; no code/tests touched. The synced pages on docs.ratel.sh refresh from these READMEs on the next `ratel-websites` build.
- Companion PR fixes the hand-authored quickstart/overview pages: ratel-ai/ratel-websites#3.
