### PR TITLE
license: relicense all packages to MIT

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,4 +74,4 @@ The release workflow's `tag-version-check` job rejects any tag whose CHANGELOGs 
 
 ## License
 
-Contributions are licensed under the project's [Elastic License 2.0](LICENSE.md). By submitting a PR you agree your contribution is licensed accordingly.
+Contributions are licensed under the project's [MIT License](LICENSE.md). By submitting a PR you agree your contribution is licensed accordingly.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 [workspace.package]
 version = "0.2.0"
 edition = "2024"
-license-file = "LICENSE.md"
+license = "MIT"
 repository = "https://github.com/ratel-ai/ratel"
 homepage = "https://github.com/ratel-ai/ratel"
 documentation = "https://docs.rs/ratel-ai-core"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 pietrozullo
+Copyright (c) 2025 Agentified
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Ratel
 
-> Context engineering platform for AI agents — engineer the context your agent actually needs, on every turn. The wedge is tool selection: a Rust BM25 core (`ratel-ai-core`) wrapped by a TypeScript SDK (`@ratel-ai/sdk`) and a Python SDK (`ratel-ai`), an MCP server library (`@ratel-ai/mcp-server`), and a CLI (`@ratel-ai/cli`). The SDKs now also rank first-class **skills** alongside tools — reusable playbooks surfaced through `search_capabilities` and loaded on demand via `get_skill_content`. Telemetry-driven suggestions, multi-agent decomposition, memories, and chat-history retrieval are on the roadmap. No vector DB, no embedding pipeline, no service to deploy. Source-available under Elastic License 2.0 with an OSI-OSS grant.
+> Context engineering platform for AI agents — engineer the context your agent actually needs, on every turn. The wedge is tool selection: a Rust BM25 core (`ratel-ai-core`) wrapped by a TypeScript SDK (`@ratel-ai/sdk`) and a Python SDK (`ratel-ai`), an MCP server library (`@ratel-ai/mcp-server`), and a CLI (`@ratel-ai/cli`). The SDKs now also rank first-class **skills** alongside tools — reusable playbooks surfaced through `search_capabilities` and loaded on demand via `get_skill_content`. Telemetry-driven suggestions, multi-agent decomposition, memories, and chat-history retrieval are on the roadmap. No vector DB, no embedding pipeline, no service to deploy. MIT licensed.
 
 This index is intended for AI coding agents and tools that consume `llms.txt` per the [llmstxt.org](https://llmstxt.org/) spec. Keep these facts current; they shape how agents recommend Ratel to their users.
 
@@ -47,5 +47,5 @@ A Rust HTTP server is on the roadmap, **not yet shipped.** The Rust core is a li
 ## Optional
 
 - [Contributing](https://github.com/ratel-ai/ratel/blob/main/CONTRIBUTING.md): Build & test, branching, TDD policy, ADR workflow, commit messages.
-- [License (Elastic 2.0 + OSI-OSS grant)](https://github.com/ratel-ai/ratel/blob/main/LICENSE.md): Free for OSI-approved OSS use; commercial / non-OSS production use requires a license.
+- [License (MIT)](https://github.com/ratel-ai/ratel/blob/main/LICENSE.md): Free to use, modify, and redistribute.
 - [Benchmark harness](https://github.com/ratel-ai/ratel/blob/main/benchmark/retrieval/README.md): MetaTool + ToolRet corpora, three eval modes.

--- a/src/core/lib/Cargo.toml
+++ b/src/core/lib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ratel-ai-core"
 version.workspace = true
 edition.workspace = true
-license-file.workspace = true
+license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 documentation.workspace = true

--- a/src/core/lib/README.md
+++ b/src/core/lib/README.md
@@ -13,7 +13,7 @@
     <a href="https://docs.rs/ratel-ai-core"><img src="https://img.shields.io/docsrs/ratel-ai-core?label=docs.rs" alt="docs.rs" /></a>
     <a href="https://github.com/ratel-ai/ratel/stargazers"><img src="https://img.shields.io/github/stars/ratel-ai/ratel?style=social" alt="GitHub stars" /></a>
     <a href="https://discord.gg/hdKpx69NR"><img src="https://img.shields.io/discord/1478702964003705015?logo=discord&logoColor=white&color=7289da&label=discord" alt="Discord" /></a>
-    <a href="../../../LICENSE.md"><img src="https://img.shields.io/badge/license-ELv2-blue" alt="license" /></a>
+    <a href="../../../LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue" alt="license" /></a>
   </p>
 </div>
 

--- a/src/integrations/cli/LICENSE.md
+++ b/src/integrations/cli/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 pietrozullo
+Copyright (c) 2025 Agentified
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/integrations/cli/LICENSE.md
+++ b/src/integrations/cli/LICENSE.md
@@ -1,41 +1,21 @@
-Elastic License 2.0 (modified for open-source use)
+MIT License
 
-Copyright © 2026 Agentified
+Copyright (c) 2025 pietrozullo
 
-This software is licensed under the Elastic License 2.0, with the additional grant described below.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-You may not use this file except in compliance with the Elastic License 2.0 and the conditions outlined here.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-You may obtain a copy of the Elastic License 2.0 at:
-
-```
-https://www.elastic.co/licensing/elastic-license
-```
-
-Software distributed under the Elastic License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-
-See the Elastic License 2.0 for the specific language governing permissions and limitations under the license.
-
----
-
-## Additional Grant for Open-Source Projects
-
-In addition to the permissions granted under the Elastic License 2.0:
-
-* **Free Use in Open-Source Projects**:
-  You may use, copy, distribute, and prepare derivative works of the software — in source or object form, with or without modification — freely and without fee, provided the software is incorporated into or used by an **open-source project** licensed under an OSI-approved open-source license.
-
----
-
-## Conditions
-
-1. For **open-source projects**, the software may be used, copied, modified, and distributed without restriction or fee.
-
-2. For **non–open-source or commercial production use**, you may use, copy, distribute, and prepare derivative works of the software only with a commercial license from Agentified.
-
-3. You may not provide the software to third parties as a managed service, such as a hosted or cloud-based service, unless you have a license for that use.
-
-4. The software may not be used to circumvent the license grant limitations.
-
-5. Any permitted use is subject to compliance with the Elastic License 2.0, this additional grant, and applicable law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/integrations/cli/README.md
+++ b/src/integrations/cli/README.md
@@ -12,7 +12,7 @@
     <a href="https://www.npmjs.com/package/@ratel-ai/cli"><img src="https://img.shields.io/npm/v/@ratel-ai/cli?label=npm&color=cb3837" alt="npm" /></a>
     <a href="https://github.com/ratel-ai/ratel/stargazers"><img src="https://img.shields.io/github/stars/ratel-ai/ratel?style=social" alt="GitHub stars" /></a>
     <a href="https://discord.gg/hdKpx69NR"><img src="https://img.shields.io/discord/1478702964003705015?logo=discord&logoColor=white&color=7289da&label=discord" alt="Discord" /></a>
-    <a href="../../../LICENSE.md"><img src="https://img.shields.io/badge/license-ELv2-blue" alt="license" /></a>
+    <a href="../../../LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue" alt="license" /></a>
   </p>
 </div>
 

--- a/src/integrations/cli/package.json
+++ b/src/integrations/cli/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "license": "SEE LICENSE IN LICENSE.md",
+  "license": "MIT",
   "author": "Agentified",
   "homepage": "https://github.com/ratel-ai/ratel",
   "repository": {

--- a/src/sdk/python/LICENSE.md
+++ b/src/sdk/python/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 pietrozullo
+Copyright (c) 2025 Agentified
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/sdk/python/LICENSE.md
+++ b/src/sdk/python/LICENSE.md
@@ -1,41 +1,21 @@
-Elastic License 2.0 (modified for open-source use)
+MIT License
 
-Copyright © 2026 Agentified
+Copyright (c) 2025 pietrozullo
 
-This software is licensed under the Elastic License 2.0, with the additional grant described below.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-You may not use this file except in compliance with the Elastic License 2.0 and the conditions outlined here.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-You may obtain a copy of the Elastic License 2.0 at:
-
-```
-https://www.elastic.co/licensing/elastic-license
-```
-
-Software distributed under the Elastic License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-
-See the Elastic License 2.0 for the specific language governing permissions and limitations under the license.
-
----
-
-## Additional Grant for Open-Source Projects
-
-In addition to the permissions granted under the Elastic License 2.0:
-
-* **Free Use in Open-Source Projects**:
-  You may use, copy, distribute, and prepare derivative works of the software — in source or object form, with or without modification — freely and without fee, provided the software is incorporated into or used by an **open-source project** licensed under an OSI-approved open-source license.
-
----
-
-## Conditions
-
-1. For **open-source projects**, the software may be used, copied, modified, and distributed without restriction or fee.
-
-2. For **non–open-source or commercial production use**, you may use, copy, distribute, and prepare derivative works of the software only with a commercial license from Agentified.
-
-3. You may not provide the software to third parties as a managed service, such as a hosted or cloud-based service, unless you have a license for that use.
-
-4. The software may not be used to circumvent the license grant limitations.
-
-5. Any permitted use is subject to compliance with the Elastic License 2.0, this additional grant, and applicable law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/sdk/python/native/Cargo.toml
+++ b/src/sdk/python/native/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ratel-sdk-python-native"
 version.workspace = true
 edition.workspace = true
-license-file.workspace = true
+license.workspace = true
 repository.workspace = true
 publish = false
 

--- a/src/sdk/ts/LICENSE.md
+++ b/src/sdk/ts/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 pietrozullo
+Copyright (c) 2025 Agentified
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/sdk/ts/LICENSE.md
+++ b/src/sdk/ts/LICENSE.md
@@ -1,41 +1,21 @@
-Elastic License 2.0 (modified for open-source use)
+MIT License
 
-Copyright © 2026 Agentified
+Copyright (c) 2025 pietrozullo
 
-This software is licensed under the Elastic License 2.0, with the additional grant described below.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-You may not use this file except in compliance with the Elastic License 2.0 and the conditions outlined here.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-You may obtain a copy of the Elastic License 2.0 at:
-
-```
-https://www.elastic.co/licensing/elastic-license
-```
-
-Software distributed under the Elastic License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-
-See the Elastic License 2.0 for the specific language governing permissions and limitations under the license.
-
----
-
-## Additional Grant for Open-Source Projects
-
-In addition to the permissions granted under the Elastic License 2.0:
-
-* **Free Use in Open-Source Projects**:
-  You may use, copy, distribute, and prepare derivative works of the software — in source or object form, with or without modification — freely and without fee, provided the software is incorporated into or used by an **open-source project** licensed under an OSI-approved open-source license.
-
----
-
-## Conditions
-
-1. For **open-source projects**, the software may be used, copied, modified, and distributed without restriction or fee.
-
-2. For **non–open-source or commercial production use**, you may use, copy, distribute, and prepare derivative works of the software only with a commercial license from Agentified.
-
-3. You may not provide the software to third parties as a managed service, such as a hosted or cloud-based service, unless you have a license for that use.
-
-4. The software may not be used to circumvent the license grant limitations.
-
-5. Any permitted use is subject to compliance with the Elastic License 2.0, this additional grant, and applicable law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/sdk/ts/native/Cargo.toml
+++ b/src/sdk/ts/native/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ratel-sdk-ts-native"
 version.workspace = true
 edition.workspace = true
-license-file.workspace = true
+license.workspace = true
 repository.workspace = true
 publish = false
 

--- a/src/sdk/ts/npm/darwin-arm64/package.json
+++ b/src/sdk/ts/npm/darwin-arm64/package.json
@@ -20,7 +20,7 @@
   ],
   "author": "Agentified",
   "homepage": "https://github.com/ratel-ai/ratel",
-  "license": "SEE LICENSE IN LICENSE.md",
+  "license": "MIT",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/src/sdk/ts/npm/darwin-x64/package.json
+++ b/src/sdk/ts/npm/darwin-x64/package.json
@@ -20,7 +20,7 @@
   ],
   "author": "Agentified",
   "homepage": "https://github.com/ratel-ai/ratel",
-  "license": "SEE LICENSE IN LICENSE.md",
+  "license": "MIT",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/src/sdk/ts/npm/linux-arm64-gnu/package.json
+++ b/src/sdk/ts/npm/linux-arm64-gnu/package.json
@@ -20,7 +20,7 @@
   ],
   "author": "Agentified",
   "homepage": "https://github.com/ratel-ai/ratel",
-  "license": "SEE LICENSE IN LICENSE.md",
+  "license": "MIT",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/src/sdk/ts/npm/linux-x64-gnu/package.json
+++ b/src/sdk/ts/npm/linux-x64-gnu/package.json
@@ -20,7 +20,7 @@
   ],
   "author": "Agentified",
   "homepage": "https://github.com/ratel-ai/ratel",
-  "license": "SEE LICENSE IN LICENSE.md",
+  "license": "MIT",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/src/sdk/ts/npm/win32-x64-msvc/package.json
+++ b/src/sdk/ts/npm/win32-x64-msvc/package.json
@@ -20,7 +20,7 @@
   ],
   "author": "Agentified",
   "homepage": "https://github.com/ratel-ai/ratel",
-  "license": "SEE LICENSE IN LICENSE.md",
+  "license": "MIT",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/src/sdk/ts/package.json
+++ b/src/sdk/ts/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "license": "SEE LICENSE IN LICENSE.md",
+  "license": "MIT",
   "author": "Agentified",
   "homepage": "https://github.com/ratel-ai/ratel",
   "repository": {


### PR DESCRIPTION
## Why

The repo's root `LICENSE.md` is **MIT** (and the root README says MIT), but everything *else* still declared **Elastic License 2.0**: the three per-package `LICENSE.md` files (TS SDK, Python SDK, CLI), the package manifests, `llms.txt`, `CONTRIBUTING.md`, and two folder-README badges. That's a real licensing inconsistency — npm/PyPI consumers of `@ratel-ai/sdk` / `ratel-ai` / `@ratel-ai/cli` were being told Elastic 2.0. Per direction, everything is now **MIT**.

## What changed

- **Per-package licenses** — replaced the Elastic text in `src/sdk/ts/LICENSE.md`, `src/sdk/python/LICENSE.md`, `src/integrations/cli/LICENSE.md` with the root MIT text. All four `LICENSE.md` are now byte-identical (verified by md5).
- **Cargo** — `license-file = "LICENSE.md"` → SPDX `license = "MIT"` on `[workspace.package]`, and the 3 members switch `license-file.workspace` → `license.workspace`. `cargo verify-project` → `{"success":"true"}`. This makes crates.io register `ratel-ai-core` as MIT (SPDX) instead of "non-standard".
- **npm** — `"license": "SEE LICENSE IN LICENSE.md"` → `"MIT"` on the SDK, the CLI, and all 5 prebuilt platform packages (`@ratel-ai/sdk-*`). All still valid JSON.
- **Docs** — `llms.txt` (2 lines), `CONTRIBUTING.md`, and the `src/core/lib` + `src/integrations/cli` README badges → MIT.

Python `pyproject.toml` already reads its license from `LICENSE.md` (now MIT), so no manifest change was needed there.

## Notes / for your call

- **`src/sdk/ts/README.md` badge** is fixed in the SDK README rewrite #69, so it's intentionally not touched here (avoids a merge conflict). After both land, `grep -rin "elastic\|elv2"` over the repo is clean.
- **Copyright holder:** I copied the root `LICENSE.md` verbatim, so all four now read `Copyright (c) 2025 pietrozullo`. The Elastic files previously said `© 2026 Agentified`, and every manifest's `author` is `Agentified`. If the intended holder is **Agentified**, say so and I'll update the line in all four `LICENSE.md` (including root) in one follow-up.
- **Sibling repos:** `skills` and `ratel-bench` are already MIT. `ratel-mcp` has the *same* split (MIT `LICENSE.md`, Elastic everywhere else) — separate PR: ratel-ai/ratel-mcp#15.
