### PR TITLE
ci(pr-gate): install+run darwin-x64 wheel via Rosetta x86_64

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -95,7 +95,6 @@ jobs:
           architecture: ${{ matrix.arch }}
           cache: pnpm
       - uses: actions/setup-python@v5
-        id: setup-python
         with:
           python-version: '3.11'
           architecture: ${{ matrix.arch }}
@@ -105,17 +104,22 @@ jobs:
       - name: Python SDK — build wheel, install, e2e
         run: |
           set -e
-          # Use the interpreter setup-python installed, not bare `python`. On the
-          # arm64 macos-14 runner the darwin-x64 leg needs the Rosetta x64 CPython
-          # (so the x86_64 wheel installs + loads), but the framework python on
-          # PATH shadows it — pip then runs arm64 and rejects the x86_64 wheel
-          # ("not a supported wheel on this platform"). Pinning PATH to the
-          # setup-python bin makes python/pip/maturin all the right interpreter.
-          export PATH="$(dirname '${{ steps.setup-python.outputs.python-path }}'):$PATH"
           python -m pip install --upgrade pip maturin
           ( cd src/sdk/python && maturin build --release --target ${{ matrix.target }} --out dist )
-          python -m pip install src/sdk/python/dist/*.whl
-          python e2e/python/run_e2e.py
+          # The darwin-x64 wheel is x86_64-only, but the macos-14 runner is arm64 —
+          # and even setup-python's "x64" interpreter runs as arm64 here (it's
+          # universal2), so pip computes arm64 tags and rejects the wheel ("not a
+          # supported wheel on this platform"). Install + run the e2e through
+          # Rosetta's x86_64 slice of the universal2 framework python so the real
+          # shipped x86_64 wheel is genuinely exercised. Every other leg installs
+          # natively with the runner's own python (Windows included).
+          PY=python
+          if [ "${{ matrix.target }}" = "x86_64-apple-darwin" ]; then
+            PY="arch -x86_64 /Library/Frameworks/Python.framework/Versions/3.11/bin/python3"
+          fi
+          $PY -c "import platform; print('e2e interpreter machine:', platform.machine())"
+          $PY -m pip install src/sdk/python/dist/*.whl
+          $PY e2e/python/run_e2e.py
 
       - name: Node SDK — build native, pack loader+subpackage, install, e2e
         run: |
@@ -153,7 +157,6 @@ jobs:
         if: matrix.triple == 'linux-x64-gnu'
         run: |
           set -e
-          export PATH="$(dirname '${{ steps.setup-python.outputs.python-path }}'):$PATH"
           # maturin is already installed by the Python SDK step above.
           python -m pip install --upgrade twine 'packaging>=24.2'
           ( cd src/sdk/python && maturin sdist --out dist )


### PR DESCRIPTION
## Problem

The `verify (darwin-x64)` leg of PR Gate fails on every push to `main`:

```
ERROR: ratel_ai-0.2.0-cp39-abi3-macosx_10_12_x86_64.whl is not a supported wheel on this platform.
```

maturin builds the x86_64 wheel correctly, but `pip install` rejects it. The `macos-14` runner is Apple Silicon (arm64), and **every** Python available there — the framework python *and* setup-python's nominally-"x64" interpreter — actually executes as arm64 (it's universal2), so pip computes arm64 tags and refuses the x86_64-only wheel. The `verify-pypi` job in `verify-install.yml` doesn't trip on this because it installs from PyPI, where an arm64 wheel also exists and silently satisfies the install.

This supersedes #71 (the PATH-prepend attempt), which didn't fix it for the same reason — pinning PATH still gave an arm64 interpreter.

## Fix

For the `x86_64-apple-darwin` target only, route the wheel **install + e2e** through Rosetta's x86_64 slice of the universal2 framework python (`arch -x86_64 …/python3`), so the real shipped wheel is genuinely exercised. The wheel **build** is arch-agnostic and unchanged; every other leg (Linux, Windows, darwin-arm64) keeps using the runner's native python.

## Verification

PR Gate run on this branch passed the **full 5-platform matrix**, including `darwin-x64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCFGJRGVwbFs26AFZGkzbH)_