### PR TITLE
feat(core): usage-estimation maths in ratel-ai-core

### DIFF
--- a/docs/adr/0015-usage-estimation-in-core.md
+++ b/docs/adr/0015-usage-estimation-in-core.md
@@ -1,0 +1,55 @@
+# 15. Usage-estimation maths in the core; no separate rollup stream
+
+Date: 2026-07-03
+
+## Status
+
+Proposed
+
+## Context
+
+`ratel-ai-core` can cheaply estimate the token footprint of the context it assembles — per-tool
+and per-skill definitions, the full registered catalog vs. the selected top-K, and a coarse USD
+cost from model + token counts. These are pure, network-free maths, useful to any SDK caller that
+wants to show "what did selection save" or "what did this call cost".
+
+An earlier design — the observability / usage-analytics spike (PRs #79–#81) — went further. It
+defined a distinct **rollup** wire format: token spend broken down by five context sources
+(`skills`/`tools`/`history`/`memory`/`user_input`), realized and potential savings, model, latency,
+cost — shipped to `POST /api/v1/events` from a per-SDK background client. It also added a parallel
+observability trace-tree to the core (`TraceRoot` / `ObservationStart` / `ObservationEnd` /
+`Generation` / `TokensSaved`).
+
+Since then, [ADR-0013](0013-cloud-telemetry-unified-schema.md) landed a **unified cloud-telemetry
+Event** — the full request/response of an LLM call (provider, model, messages, tools, usage,
+finish_reason) — as the one shape `POST /api/v1/events` accepts, shipped by the pure-language
+`@ratel-ai/cloud` client. The rollup format and the Event format are two different schemas
+contending for the same endpoint, and the Event has no home for a per-source / savings breakdown.
+Carrying both would mean two wire contracts, two clients, and a second trace model in the core with
+no consumer.
+
+## Decision
+
+Keep the **maths**; drop the **separate stream**.
+
+- `ratel-ai-core` exposes the estimation primitives — `estimate_tokens`, `tool_footprint` /
+  `skill_footprint`, `tool_tokens` / `skill_tokens`, `tokens_saved`, `estimate_cost_usd`, and the
+  registry helpers `catalog_tokens()` / `tokens_for()` — bound directly into the TS and Python SDKs.
+  `ToolCatalog({ observe })` records the full-catalog-vs-top-K saving in memory (`lastSavings`) as a
+  convenience; it emits nothing to the wire and nothing to the trace stream.
+- The standalone **rollup** wire format (`Rollup` / `SourceTokens` / `buildRollup` / the `Transport`
+  seam) and the per-SDK rollup client are **not adopted**. Usage/cost telemetry rides ADR-0013's
+  Event (`usage.{input,output,cached,reasoning}_tokens`) via `@ratel-ai/cloud`.
+- The observability **trace-tree** variants proposed for the core (`TraceRoot`, `ObservationStart` /
+  `ObservationEnd`, `Generation`, `TokensSaved`) are **not added**; the core trace stream
+  ([ADR-0009](0009-trace-events-core-owned-schema.md)) is unchanged.
+
+## Consequences
+
+- One wire contract for cloud telemetry (ADR-0013), one client (`@ratel-ai/cloud`), one endpoint.
+- The per-source spend / savings *breakdown* has no wire home today. Callers can still compute
+  savings locally (`catalog_tokens` − `tokens_for`) and surface or attach it as they see fit. If a
+  dashboard needs the breakdown on the wire later, that is an additive extension to the Event (or a
+  new ADR), decided when there is a consumer for it — not carried speculatively.
+- Withdraws the never-merged observability/usage-analytics ADR draft. The surviving maths ship as the
+  reworked #79 (core) / #80 (`@ratel-ai/sdk`) / #81 (`ratel-ai`) stack.

--- a/src/core/lib/README.md
+++ b/src/core/lib/README.md
@@ -66,4 +66,8 @@ Built-in sinks:
 
 Schema: `TraceEvent` is a tagged enum (search, index_churn, skill_search, skill_churn, skill_invoke, invoke_*, gateway_*, upstream_*, auth_*) wrapped in `TraceEnvelope { v, ts, session_id, ...event }`. The reliability profile is **query-log shaped** — best-effort, sampleable, lossy on backpressure. See ADR-0009 for the full rationale.
 
+## Usage estimation
+
+Network-free token/cost maths for showing what context selection saved and what a call cost. `estimate_tokens` is the `len / 4` heuristic; `tool_footprint` / `skill_footprint` (and `tool_tokens` / `skill_tokens`) price one definition; `ToolRegistry` / `SkillRegistry` expose `catalog_tokens()` (the full registered corpus) and `tokens_for(&ids)` (a search's hits), so `tokens_saved(catalog_tokens, tokens_for(hits))` is the realized saving. `estimate_cost_usd(model, input, output)` gives a coarse USD estimate. These bind directly into the TS and Python SDKs — no wire format lives here. See [ADR‑0015](../../../docs/adr/0015-usage-estimation-in-core.md).
+
 The custom `TraceSink` trait lets embedders forward events to their own pipeline (HTTP, structured logger, ring buffer). The trait carries a `sample_rate()` knob (defaulting to `1.0`); the rate-limiter implementation is deferred to a later release.

--- a/src/core/lib/src/lib.rs
+++ b/src/core/lib/src/lib.rs
@@ -10,6 +10,7 @@ mod skill_registry;
 mod tool;
 mod tool_registry;
 mod trace;
+mod usage;
 
 pub use skill::Skill;
 pub use skill_registry::{SkillHit, SkillRegistry};
@@ -18,4 +19,8 @@ pub use tool_registry::{SearchHit, ToolRegistry};
 pub use trace::{
     ChurnKind, JsonlSink, MemorySink, NoopSink, Origin, SearchHitTrace, SearchStage, SkillHitTrace,
     TraceEnvelope, TraceEvent, TraceSink,
+};
+pub use usage::{
+    estimate_cost_usd, estimate_tokens, skill_footprint, skill_tokens, tokens_saved,
+    tool_footprint, tool_tokens,
 };

--- a/src/core/lib/src/skill_registry.rs
+++ b/src/core/lib/src/skill_registry.rs
@@ -97,6 +97,21 @@ impl SkillRegistry {
         });
         hits
     }
+
+    /// Total context-token footprint of the full registered skill corpus.
+    pub fn catalog_tokens(&self) -> u64 {
+        self.skills.iter().map(crate::usage::skill_tokens).sum()
+    }
+
+    /// Footprint of the skills with the given ids — typically a search's hits.
+    pub fn tokens_for(&self, ids: &[String]) -> u64 {
+        let want: std::collections::HashSet<&str> = ids.iter().map(String::as_str).collect();
+        self.skills
+            .iter()
+            .filter(|s| want.contains(s.id.as_str()))
+            .map(crate::usage::skill_tokens)
+            .sum()
+    }
 }
 
 #[cfg(test)]

--- a/src/core/lib/src/tool_registry.rs
+++ b/src/core/lib/src/tool_registry.rs
@@ -94,4 +94,21 @@ impl ToolRegistry {
         });
         hits
     }
+
+    /// Total context-token footprint of the full registered catalog — what an
+    /// agent would carry without selection.
+    pub fn catalog_tokens(&self) -> u64 {
+        self.tools.iter().map(crate::usage::tool_tokens).sum()
+    }
+
+    /// Footprint of the tools with the given ids — typically a search's hits, to
+    /// compute the realized saving against [`Self::catalog_tokens`].
+    pub fn tokens_for(&self, ids: &[String]) -> u64 {
+        let want: std::collections::HashSet<&str> = ids.iter().map(String::as_str).collect();
+        self.tools
+            .iter()
+            .filter(|t| want.contains(t.id.as_str()))
+            .map(crate::usage::tool_tokens)
+            .sum()
+    }
 }

--- a/src/core/lib/src/usage.rs
+++ b/src/core/lib/src/usage.rs
@@ -1,0 +1,160 @@
+//! Usage-estimation maths — the network-free token/cost primitives shared across
+//! Ratel's SDKs.
+//!
+//! Pure and dependency-light: token-footprint estimation, per-definition tool /
+//! skill footprints, full-catalog-vs-selected savings, and coarse cost estimation.
+//! The host SDKs (Python, TS) bind these directly so the maths live in one place
+//! instead of each re-deriving them. No prompt/output text is retained here.
+
+use crate::skill::Skill;
+use crate::tool::Tool;
+
+/// Characters per token for the dependency-free heuristic estimate. Savings is a
+/// delta signal (full vs selected), so this constant bias largely cancels.
+const CHARS_PER_TOKEN: usize = 4;
+
+/// Estimate the token footprint of a string: `len / 4` over Unicode scalar values
+/// (matches the reference `len(text) // 4`). Non-empty text estimates at least 1.
+pub fn estimate_tokens(text: &str) -> u64 {
+    let chars = text.chars().count();
+    if chars == 0 {
+        0
+    } else {
+        (chars / CHARS_PER_TOKEN).max(1) as u64
+    }
+}
+
+/// True when a JSON schema carries no information worth pricing (absent or empty).
+fn schema_is_empty(value: &serde_json::Value) -> bool {
+    value.is_null()
+        || value.as_object().is_some_and(|m| m.is_empty())
+        || value.as_array().is_some_and(|a| a.is_empty())
+}
+
+/// The text a tool contributes to an agent's context: name, description, and its
+/// JSON schemas. This is the footprint priced by [`estimate_tokens`] — distinct
+/// from the BM25 *searchable* text, which is tuned for ranking, not size.
+pub fn tool_footprint(tool: &Tool) -> String {
+    let mut parts = vec![tool.name.clone(), tool.description.clone()];
+    for schema in [&tool.input_schema, &tool.output_schema] {
+        if schema_is_empty(schema) {
+            continue;
+        }
+        if let Ok(rendered) = serde_json::to_string(schema) {
+            parts.push(rendered);
+        }
+    }
+    parts.join(" ")
+}
+
+/// The text a skill contributes to context: name, description, tags, and body.
+pub fn skill_footprint(skill: &Skill) -> String {
+    let mut parts = vec![skill.name.clone(), skill.description.clone()];
+    if !skill.tags.is_empty() {
+        parts.push(skill.tags.join(" "));
+    }
+    if !skill.body.is_empty() {
+        parts.push(skill.body.clone());
+    }
+    parts.join(" ")
+}
+
+/// Estimated token footprint of a single tool's definition.
+pub fn tool_tokens(tool: &Tool) -> u64 {
+    estimate_tokens(&tool_footprint(tool))
+}
+
+/// Estimated token footprint of a single skill's definition.
+pub fn skill_tokens(skill: &Skill) -> u64 {
+    estimate_tokens(&skill_footprint(skill))
+}
+
+/// Context tokens kept out of the prompt by selection: the full footprint minus
+/// what was actually selected. Never negative.
+pub fn tokens_saved(full_tokens: u64, selected_tokens: u64) -> u64 {
+    full_tokens.saturating_sub(selected_tokens)
+}
+
+/// Coarse USD price per 1M tokens `(input, output)` for cost estimation. These are
+/// deliberately approximate, demo-grade defaults; a caller with real pricing passes
+/// its own cost and bypasses this.
+fn model_price_per_mtok(model: &str) -> (f64, f64) {
+    let m = model.to_ascii_lowercase();
+    if m.contains("opus") {
+        (15.0, 75.0)
+    } else if m.contains("sonnet") {
+        (3.0, 15.0)
+    } else if m.contains("haiku") {
+        (0.80, 4.0)
+    } else if m.contains("gpt-4o-mini") || m.contains("o4-mini") {
+        (0.15, 0.60)
+    } else if m.contains("gpt-4o") || m.contains("gpt-4.1") {
+        (2.50, 10.0)
+    } else {
+        (1.0, 3.0)
+    }
+}
+
+/// Estimate the USD cost of a generation from its model and token counts.
+pub fn estimate_cost_usd(model: &str, input_tokens: u64, output_tokens: u64) -> f64 {
+    let (input_price, output_price) = model_price_per_mtok(model);
+    (input_tokens as f64 * input_price + output_tokens as f64 * output_price) / 1_000_000.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tool(id: &str, name: &str, description: &str) -> Tool {
+        Tool {
+            id: id.into(),
+            name: name.into(),
+            description: description.into(),
+            input_schema: serde_json::json!({}),
+            output_schema: serde_json::json!({}),
+        }
+    }
+
+    #[test]
+    fn estimate_tokens_is_chars_over_four() {
+        assert_eq!(estimate_tokens(""), 0);
+        assert_eq!(estimate_tokens("abc"), 1); // floor(3/4)=0 -> min 1
+        assert_eq!(estimate_tokens("abcdefgh"), 2);
+    }
+
+    #[test]
+    fn estimate_tokens_counts_unicode_scalars_not_bytes() {
+        // "café" is 4 scalar values but 5 UTF-8 bytes.
+        assert_eq!(estimate_tokens("café"), 1);
+    }
+
+    #[test]
+    fn empty_schemas_are_not_priced() {
+        let t = tool("a", "name", "desc");
+        // footprint is just "name desc" (8 chars) -> 2 tokens, no "{}" noise.
+        assert_eq!(tool_footprint(&t), "name desc");
+        assert_eq!(tool_tokens(&t), estimate_tokens("name desc"));
+    }
+
+    #[test]
+    fn populated_schema_adds_to_footprint() {
+        let mut t = tool("a", "n", "d");
+        t.input_schema = serde_json::json!({"type": "object"});
+        assert!(tool_footprint(&t).contains("type"));
+        assert!(tool_tokens(&t) > tool_tokens(&tool("a", "n", "d")));
+    }
+
+    #[test]
+    fn savings_is_full_minus_selected_and_never_negative() {
+        assert_eq!(tokens_saved(1000, 200), 800);
+        assert_eq!(tokens_saved(100, 250), 0);
+    }
+
+    #[test]
+    fn cost_scales_with_tokens_and_model_tier() {
+        let opus = estimate_cost_usd("claude-opus-4-8", 1_000_000, 0);
+        let haiku = estimate_cost_usd("claude-haiku-4-5", 1_000_000, 0);
+        assert!(opus > haiku);
+        assert!((opus - 15.0).abs() < 1e-9);
+    }
+}


### PR DESCRIPTION
**Part 1 of 3** — usage-estimation maths in the Rust core. Rebased onto `main` after the cloud telemetry SDK (#88) landed; the original observability/usage-analytics **rollup** design is retired (see below).

### What's here
- **`usage` module** in `ratel-ai-core`: network-free token/cost primitives — `estimate_tokens`, `tool_footprint`/`skill_footprint`, `tool_tokens`/`skill_tokens`, `tokens_saved`, `estimate_cost_usd`.
- Registry helpers `catalog_tokens()` / `tokens_for()` on `ToolRegistry` and `SkillRegistry` (full corpus vs. a search's hits → the realized saving).
- **ADR-0015** — records the decision: keep the maths, drop the separate stream.

### What changed vs the original PR (rollup retired)
#88 shipped the unified **cloud-telemetry Event** (ADR-0013) as the one shape `POST /api/v1/events` accepts. The old rollup wire format (`Rollup`/`SourceTokens`) and the observability trace-tree (`TraceRoot`/`ObservationStart`/`ObservationEnd`/`Generation`/`TokensSaved`) contended with it and had no consumer, so they are **not adopted**. Usage/cost telemetry rides ADR-0013's Event via `@ratel-ai/cloud`. See [ADR-0015](docs/adr/0015-usage-estimation-in-core.md).

`fmt` / `clippy -D warnings` / core tests pass locally.

### Stack — merge in order
1. **RAT-305 — Rust core** ← _this PR_
2. RAT-306 — `@ratel-ai/sdk` bindings (#80)
3. RAT-308 — `ratel-ai` Python bindings (#81)

Supersedes the observability spike; #82 (extracted rollup client) stays closed — `@ratel-ai/cloud` shipped in #88.

Closes RAT-305. Part of RAT-291.
