### PR TITLE
feat(ts): usage-estimation bindings in @ratel-ai/sdk

### DIFF
--- a/src/sdk/ts/CHANGELOG.md
+++ b/src/sdk/ts/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+### Added
+
+- **Usage estimation** bound from `ratel-ai-core`: `estimateTokens` and `estimateCostUsd`, plus `ToolCatalog({ observe })` which records the full-catalog-vs-selected-top-K saving on each search into `lastSavings` (in-memory, best-effort, never emitted). No wire format — usage/cost telemetry rides `@ratel-ai/cloud`'s ADR-0013 event. See [ADR-0015](../../../docs/adr/0015-usage-estimation-in-core.md).
+
 ## [0.2.0] - 2026-06-16
 
 ### Changed

--- a/src/sdk/ts/native/src/lib.rs
+++ b/src/sdk/ts/native/src/lib.rs
@@ -10,6 +10,24 @@ use ratel_ai_core as core;
 use ratel_ai_core::{JsonlSink, MemorySink, NoopSink, Origin, TraceEvent};
 use serde_json::Value;
 
+/// Estimate the token footprint of a string (`len / 4` heuristic). Mirrors
+/// `ratel_ai_core::estimate_tokens` so the TS SDK reads token maths from the
+/// core instead of re-deriving it.
+#[napi]
+pub fn estimate_tokens(text: String) -> f64 {
+    core::estimate_tokens(&text) as f64
+}
+
+/// Estimate the USD cost of a generation from its model and token counts.
+#[napi]
+pub fn estimate_cost_usd(model: String, input_tokens: f64, output_tokens: f64) -> f64 {
+    core::estimate_cost_usd(
+        &model,
+        input_tokens.max(0.0) as u64,
+        output_tokens.max(0.0) as u64,
+    )
+}
+
 /// A constructed sink plus the `MemorySink` handle when the kind is `"memory"`
 /// (so the owner can drain it later).
 type BuiltTraceSink = (Arc<dyn core::TraceSink>, Option<Arc<MemorySink>>);
@@ -95,6 +113,18 @@ impl ToolRegistry {
             input_schema: tool.input_schema,
             output_schema: tool.output_schema,
         });
+    }
+
+    /// Total context-token footprint of the full registered catalog.
+    #[napi]
+    pub fn catalog_tokens(&self) -> f64 {
+        self.inner.catalog_tokens() as f64
+    }
+
+    /// Footprint of the tools with the given ids (e.g. a search's hits).
+    #[napi]
+    pub fn tokens_for(&self, ids: Vec<String>) -> f64 {
+        self.inner.tokens_for(&ids) as f64
     }
 
     #[napi]
@@ -208,6 +238,18 @@ impl SkillRegistry {
             metadata: skill.metadata.unwrap_or_default(),
             body: skill.body.unwrap_or_default(),
         });
+    }
+
+    /// Total context-token footprint of the full registered skill corpus.
+    #[napi]
+    pub fn catalog_tokens(&self) -> f64 {
+        self.inner.catalog_tokens() as f64
+    }
+
+    /// Footprint of the skills with the given ids (e.g. a search's hits).
+    #[napi]
+    pub fn tokens_for(&self, ids: Vec<String>) -> f64 {
+        self.inner.tokens_for(&ids) as f64
     }
 
     #[napi]

--- a/src/sdk/ts/src/catalog.test.ts
+++ b/src/sdk/ts/src/catalog.test.ts
@@ -139,3 +139,47 @@ describe("ToolCatalog tracing", () => {
     expect(search?.origin).toBe("agent");
   });
 });
+
+describe("ToolCatalog observe (tokens saved)", () => {
+  const sendEmail: ExecutableTool = {
+    id: "send_email",
+    name: "send_email",
+    description: "Send an email message to one or more recipients with a subject and body.",
+    inputSchema: { properties: { to: { type: "string" } } },
+    outputSchema: {},
+    execute: async () => ({}),
+  };
+
+  it("records lastSavings (in-memory only) when observing", () => {
+    const catalog = new ToolCatalog({ observe: true, trace: { kind: "memory", sessionId: "t" } });
+    catalog.register(readFile);
+    catalog.register(sendEmail);
+    catalog.drainTraceEvents(); // discard register churn
+
+    catalog.search("read a file from disk", 1);
+
+    const sv = catalog.lastSavings;
+    expect(sv).toBeDefined();
+    if (!sv) return;
+    expect(sv.topK).toBe(1);
+    expect(sv.fullCatalogTokens).toBeGreaterThan(sv.selectedTokens);
+    expect(sv.tokensSaved).toBeGreaterThan(0);
+
+    // Savings is in-memory only — nothing is emitted to the trace stream.
+    const events = catalog.drainTraceEvents() as Array<Record<string, unknown>>;
+    expect(events.some((e) => e.type === "tokens_saved")).toBe(false);
+  });
+
+  it("records nothing extra when not observing", () => {
+    const catalog = new ToolCatalog({ trace: { kind: "memory", sessionId: "t" } });
+    catalog.register(readFile);
+    catalog.register(sendEmail);
+    catalog.drainTraceEvents();
+
+    catalog.search("read a file", 1);
+
+    expect(catalog.lastSavings).toBeUndefined();
+    const events = catalog.drainTraceEvents() as Array<Record<string, unknown>>;
+    expect(events.some((e) => e.type === "tokens_saved")).toBe(false);
+  });
+});

--- a/src/sdk/ts/src/catalog.ts
+++ b/src/sdk/ts/src/catalog.ts
@@ -14,20 +14,38 @@ export type TraceSinkConfig =
 
 export type SearchOrigin = "direct" | "agent";
 
+/** Ratel's tokens-saved metric for one search: full catalog vs the selected top-K. */
+export interface ToolSavings {
+  fullCatalogTokens: number;
+  selectedTokens: number;
+  tokensSaved: number;
+  topK: number;
+}
+
 export interface ToolCatalogOptions {
   trace?: TraceSinkConfig;
+  /**
+   * Record Ratel's tokens-saved metric (full catalog vs selected top-K, computed
+   * natively in `ratel-ai-core`) on every search into `lastSavings`. In-memory
+   * only — best-effort, never emitted to the trace stream or the network.
+   */
+  observe?: boolean;
 }
 
 export class ToolCatalog {
   private readonly registry: ToolRegistry;
   private readonly executors = new Map<string, Executor>();
   private readonly tools = new Map<string, Tool>();
+  private readonly observe: boolean;
+  /** The most recent search's savings (full vs selected tokens), or undefined. */
+  lastSavings: ToolSavings | undefined;
 
   constructor(options: ToolCatalogOptions = {}) {
     this.registry = new ToolRegistry();
     if (options.trace) {
       this.registry.setTraceSink(options.trace);
     }
+    this.observe = options.observe ?? false;
   }
 
   register(tool: ExecutableTool): void {
@@ -38,7 +56,31 @@ export class ToolCatalog {
   }
 
   search(query: string, topK: number, origin: SearchOrigin = "direct"): SearchHit[] {
-    return this.registry.searchWithOrigin(query, topK, origin);
+    const hits = this.registry.searchWithOrigin(query, topK, origin);
+    if (this.observe) {
+      this.recordSavings(hits, topK);
+    }
+    return hits;
+  }
+
+  /**
+   * Record the full-catalog-vs-top-K token saving into `lastSavings`. Best-effort:
+   * never throws. The footprint maths run in the core (`catalogTokens` / `tokensFor`).
+   */
+  private recordSavings(hits: SearchHit[], topK: number): void {
+    try {
+      const full = Math.trunc(this.registry.catalogTokens());
+      const selected = Math.trunc(this.registry.tokensFor(hits.map((hit) => hit.toolId)));
+      const tokensSaved = Math.max(0, full - selected);
+      this.lastSavings = {
+        fullCatalogTokens: full,
+        selectedTokens: selected,
+        tokensSaved,
+        topK,
+      };
+    } catch {
+      // never break search over a metrics side-effect
+    }
   }
 
   has(toolId: string): boolean {

--- a/src/sdk/ts/src/index.ts
+++ b/src/sdk/ts/src/index.ts
@@ -1,10 +1,11 @@
 export type { SearchHit, Skill, SkillHit, Tool } from "../native/index.cjs";
-export { SkillRegistry, ToolRegistry } from "../native/index.cjs";
+export { estimateCostUsd, estimateTokens, SkillRegistry, ToolRegistry } from "../native/index.cjs";
 export type {
   ExecutableTool,
   Executor,
   SearchOrigin,
   ToolCatalogOptions,
+  ToolSavings,
   TraceSinkConfig,
 } from "./catalog.js";
 export { ToolCatalog } from "./catalog.js";

--- a/src/sdk/ts/src/usage.test.ts
+++ b/src/sdk/ts/src/usage.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { estimateCostUsd, estimateTokens } from "./index.js";
+
+// The maths live in `ratel-ai-core` (Rust) and are covered there; these guard that
+// the native binding is wired and re-exported from the SDK's public surface.
+describe("usage estimation (native binding)", () => {
+  it("estimateTokens is ~len/4 and never zero for non-empty text", () => {
+    expect(estimateTokens("")).toBe(0);
+    expect(estimateTokens("abc")).toBe(1); // floor(3/4)=0 -> min 1
+    expect(estimateTokens("abcdefgh")).toBe(2);
+  });
+
+  it("estimateCostUsd scales with tokens and model tier", () => {
+    const opus = estimateCostUsd("claude-opus-4-8", 1_000_000, 0);
+    const haiku = estimateCostUsd("claude-haiku-4-5", 1_000_000, 0);
+    expect(opus).toBeGreaterThan(haiku);
+    expect(opus).toBeCloseTo(15.0, 6);
+  });
+});


### PR DESCRIPTION
**Part 2 of 3** — surfaces the core usage-estimation maths in `@ratel-ai/sdk`. Stacked on #79.

### What's here
- NAPI wrappers `estimateTokens` / `estimateCostUsd` and registry `catalogTokens()` / `tokensFor()`, re-exported from the package entry point.
- `ToolCatalog({ observe })` records the full-catalog-vs-selected-top-K saving on each search into `lastSavings` — **in-memory only**, best-effort, never emitted to the trace stream or the network.

### Retired vs the original PR
The standalone `Rollup` / `buildRollup` / `Transport` seam is **dropped** — usage/cost telemetry rides `@ratel-ai/cloud`'s ADR-0013 event, not a separate rollup stream. See [ADR-0015](docs/adr/0015-usage-estimation-in-core.md).

### Verified locally
`build` (native + tsc) ✓ · `typecheck` ✓ · `biome` ✓ · `vitest` **64/64** ✓ · workspace `fmt` / `clippy -D warnings` ✓

Closes RAT-306. Part of RAT-291.
