### PR TITLE
feat(cloud): new @ratel-ai/cloud package — extracted RatelClient

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,25 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
 
+  src/integrations/cloud:
+    dependencies:
+      '@ratel-ai/sdk':
+        specifier: workspace:^
+        version: link:../../sdk/ts
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.4.13
+        version: 2.4.13
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.12.2
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
+
   src/sdk/ts:
     dependencies:
       '@modelcontextprotocol/sdk':

--- a/src/integrations/README.md
+++ b/src/integrations/README.md
@@ -6,6 +6,7 @@ Auxiliary tooling that sits on top of the library (`@ratel-ai/sdk` / `ratel-ai-c
 
 ```
 cli/           @ratel-ai/cli       — `ratel` CLI: inspect telemetry, manage MCP scopes (transitional), front Claude Code
+cloud/         @ratel-ai/cloud     — cloud analytics client: batch + ship usage rollups to the Ratel dashboard
 ```
 
 ## `cli/` — `@ratel-ai/cli`
@@ -16,3 +17,7 @@ The `ratel` binary. Two roles:
 2. **Showcase-adjacent, transitional.** `ratel serve` / `ratel mcp …` / `ratel backup …` keep working — they consume the same published `@ratel-ai/mcp-server` that the showcase repo's `ratel-mcp` CLI uses. Over time these verbs migrate to `ratel-mcp`; the local `ratel` binary narrows to library artifacts.
 
 For the canonical MCP UX (`mcp import` / `add` / `auth` / `serve`), reach for `npx -y @ratel-ai/mcp-server` from [`ratel-ai/ratel-mcp`](https://github.com/ratel-ai/ratel-mcp). See [`cli/README.md`](cli/README.md) for the full verb reference of `@ratel-ai/cli` as it stands today.
+
+## `cloud/` — `@ratel-ai/cloud`
+
+The cloud analytics client. Batches the *usage rollups* `@ratel-ai/sdk` assembles (`buildRollup`) and ships them to `{host}/api/v1/events` — the shape the Ratel dashboard renders. Env-configured (`RATEL_API_KEY`, `RATEL_HOST`), best-effort, a no-op without an API key. See [`cloud/README.md`](cloud/README.md). Design: [ADR-0013](../../docs/adr/0013-observability-and-analytics.md).

--- a/src/integrations/cloud/CHANGELOG.md
+++ b/src/integrations/cloud/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to `@ratel-ai/cloud` are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this package adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- Initial release: **`RatelClient`** — a best-effort, batched cloud analytics client that ships the *usage rollups* assembled by `@ratel-ai/sdk` to `POST {host}/api/v1/events`, the shape Ratel's dashboard renders. Env-configured (`RATEL_API_KEY`, `RATEL_HOST`), a no-op without an API key, never throws; retries 5xx, drops 4xx, samples by `sampleRate`, auto-flushes by size/interval, and flushes on process exit. Extracted from `@ratel-ai/sdk` per [ADR-0013](../../../docs/adr/0013-observability-and-analytics.md).
+- `getClient()` / `configure()` / `setGlobalClient()` process-wide singleton helpers, plus `RatelClientOptions`.

--- a/src/integrations/cloud/LICENSE.md
+++ b/src/integrations/cloud/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Agentified
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/integrations/cloud/README.md
+++ b/src/integrations/cloud/README.md
@@ -1,0 +1,42 @@
+# `@ratel-ai/cloud`
+
+Ship Ratel usage analytics to your dashboard. The cloud client for [`@ratel-ai/sdk`](../../sdk/ts): it batches the *usage rollups* the SDK assembles and POSTs them to `{host}/api/v1/events` — the exact shape Ratel's cloud dashboard renders. Best-effort, never throws into your code, and a no-op without an API key.
+
+Design: [ADR-0013](../../../docs/adr/0013-observability-and-analytics.md).
+
+## Install
+
+```bash
+npm install @ratel-ai/cloud
+```
+
+## Usage
+
+`RatelClient` is env-configured (`RATEL_API_KEY`, `RATEL_HOST` — default `https://cloud.ratel.sh`). Call `track(...)` once per agent interaction with the per-source token spend; everything but `tokensByCategory` is optional. The rollup is assembled by `@ratel-ai/sdk`'s `buildRollup` (token / cost maths from `ratel-ai-core`).
+
+```ts
+import { RatelClient } from "@ratel-ai/cloud";
+
+const client = new RatelClient(); // env-configured; no-op without RATEL_API_KEY
+
+client.track({
+  tokensByCategory: { skills: 120, tools: 2000, history: 3400, memory: 260, user_input: 340 },
+  savedByCategory: { tools: 7200 }, // optional: kept out of the prompt this run
+  model: "claude-sonnet-4-6",
+  outputTokens: 180,
+});
+
+await client.flush(); // send everything buffered
+```
+
+`track()` buffers and auto-flushes once `flushAt` rollups accrue (or `flushIntervalMs` after the last call); `flush()` sends the rest; `shutdown()` stops background flushing and ships what's left. The send is best-effort — a failed POST is dropped, never surfaced into your code. Retries 5xx, drops 4xx, samples by `sampleRate`, and flushes on process exit.
+
+For a process-wide singleton, use `getClient()` / `configure(options)`.
+
+## API
+
+- `new RatelClient(options?)` / `RatelClientOptions` — `apiKey`, `host`, `enabled`, `sampleRate`, `flushAt`, `flushIntervalMs`, `timeoutMs`, `transport`.
+- `client.track(input)` · `client.flush()` · `client.shutdown()` · `client.canExport`.
+- `getClient()` · `configure(options)` · `setGlobalClient(client)`.
+
+Rollup assembly (`buildRollup`), the `Transport` seam, and the `TrackInput` / `Rollup` / `SourceTokens` types live in [`@ratel-ai/sdk`](../../sdk/ts).

--- a/src/integrations/cloud/package.json
+++ b/src/integrations/cloud/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@ratel-ai/cloud",
+  "version": "0.2.0",
+  "description": "Ratel cloud analytics client — batch and ship usage rollups to the Ratel dashboard.",
+  "private": false,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "license": "MIT",
+  "author": "Agentified",
+  "homepage": "https://github.com/ratel-ai/ratel",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ratel-ai/ratel.git",
+    "directory": "src/integrations/cloud"
+  },
+  "bugs": {
+    "url": "https://github.com/ratel-ai/ratel/issues"
+  },
+  "keywords": [
+    "ratel",
+    "observability",
+    "analytics",
+    "context-engineering",
+    "ai-agents"
+  ],
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "files": [
+    "dist",
+    "LICENSE.md",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "prepack": "tsc",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check src",
+    "test": "vitest run"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.13",
+    "@types/node": "^24.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^4.1.5"
+  },
+  "dependencies": {
+    "@ratel-ai/sdk": "workspace:^"
+  }
+}

--- a/src/integrations/cloud/src/client.test.ts
+++ b/src/integrations/cloud/src/client.test.ts
@@ -1,0 +1,154 @@
+import type { Rollup } from "@ratel-ai/sdk";
+import { describe, expect, it, vi } from "vitest";
+import { configure, getClient, RatelClient, setGlobalClient } from "./client.js";
+
+describe("RatelClient", () => {
+  it("tracks and flushes through the transport", async () => {
+    const batches: Rollup[][] = [];
+    const client = new RatelClient({
+      transport: (batch) => {
+        batches.push([...batch]);
+      },
+    });
+    client.track({
+      tokensByCategory: { tools: 2000 },
+      savedByCategory: { tools: 7000 },
+      model: "claude-haiku-4-5",
+    });
+    await client.flush();
+    expect(batches).toHaveLength(1);
+    const event = batches[0][0];
+    expect(event.tokens_by_category).toEqual({
+      skills: 0,
+      tools: 2000,
+      history: 0,
+      memory: 0,
+      user_input: 0,
+    });
+    expect((event.saved_by_category as Record<string, number>).tools).toBe(7000);
+    expect(event.cost_usd as number).toBeGreaterThan(0);
+  });
+
+  it("auto-flushes at the size threshold", async () => {
+    const batches: Rollup[][] = [];
+    const client = new RatelClient({
+      flushAt: 2,
+      transport: (batch) => {
+        batches.push([...batch]);
+      },
+    });
+    client.track({ tokensByCategory: { tools: 1 } });
+    client.track({ tokensByCategory: { tools: 2 } });
+    await new Promise((resolve) => setTimeout(resolve, 0)); // let the void flush() settle
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(2);
+  });
+
+  it("is a no-op without a key or transport", async () => {
+    const client = new RatelClient({ host: "https://cloud.ratel.sh" });
+    client.track({ tokensByCategory: { tools: 1 } }); // must not throw
+    await client.flush();
+    expect(client.canExport).toBe(false);
+  });
+
+  it("never throws when the transport rejects", async () => {
+    const client = new RatelClient({
+      transport: () => {
+        throw new Error("boom");
+      },
+    });
+    client.track({ tokensByCategory: { tools: 1 } });
+    await expect(client.flush()).resolves.toBeUndefined();
+  });
+});
+
+describe("getClient / configure / setGlobalClient", () => {
+  it("getClient returns a process-wide singleton", () => {
+    setGlobalClient(null);
+    expect(getClient()).toBe(getClient());
+    setGlobalClient(null);
+  });
+
+  it("configure replaces the global client", () => {
+    setGlobalClient(null);
+    const first = getClient();
+    const second = configure({ apiKey: "rk-test" });
+    expect(second).not.toBe(first);
+    expect(getClient()).toBe(second);
+    setGlobalClient(null);
+  });
+});
+
+describe("RatelClient background flush", () => {
+  it("auto-flushes shortly after track, with no explicit flush", async () => {
+    const batches: Rollup[][] = [];
+    const client = new RatelClient({
+      transport: (batch) => {
+        batches.push([...batch]);
+      },
+      flushIntervalMs: 10,
+    });
+    client.track({ tokensByCategory: { tools: 1 } });
+    expect(batches).toHaveLength(0);
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(batches).toHaveLength(1);
+  });
+
+  it("shutdown ships what is still buffered", async () => {
+    const batches: Rollup[][] = [];
+    const client = new RatelClient({
+      transport: (batch) => {
+        batches.push([...batch]);
+      },
+      flushIntervalMs: 10_000,
+    });
+    client.track({ tokensByCategory: { tools: 5 } });
+    await client.shutdown();
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(1);
+  });
+});
+
+describe("RatelClient transport reliability", () => {
+  it("drops everything at sampleRate 0", async () => {
+    const batches: Rollup[][] = [];
+    const client = new RatelClient({
+      transport: (batch) => {
+        batches.push([...batch]);
+      },
+      sampleRate: 0,
+    });
+    client.track({ tokensByCategory: { tools: 1 } });
+    await client.flush();
+    expect(batches).toHaveLength(0);
+  });
+
+  it("retries on 5xx then succeeds (default fetch path)", async () => {
+    let calls = 0;
+    const fetchMock = vi.fn(async () => {
+      calls += 1;
+      return { ok: calls >= 2, status: calls >= 2 ? 202 : 500 } as unknown as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new RatelClient({ apiKey: "rk-test", flushIntervalMs: 10_000, timeoutMs: 100 });
+    client.track({ tokensByCategory: { tools: 1 } });
+    await client.flush();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await client.shutdown();
+    vi.unstubAllGlobals();
+  });
+
+  it("drops on 4xx without retry and warns once (default fetch path)", async () => {
+    const fetchMock = vi.fn(async () => ({ ok: false, status: 401 }) as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const client = new RatelClient({ apiKey: "rk-test", flushIntervalMs: 10_000 });
+    client.track({ tokensByCategory: { tools: 1 } });
+    await client.flush();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+    await client.shutdown();
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/integrations/cloud/src/client.ts
+++ b/src/integrations/cloud/src/client.ts
@@ -1,0 +1,217 @@
+import { buildRollup, type Rollup, type TrackInput, type Transport } from "@ratel-ai/sdk";
+
+/**
+ * The Ratel cloud analytics client (ADR-0013) — the TypeScript mirror of the
+ * Python SDK's `RatelClient`. Records one usage *rollup* per agent interaction
+ * (assembled by `@ratel-ai/sdk`'s `buildRollup`) and ships it to
+ * `POST {host}/api/v1/events` — the exact shape Ratel's dashboard renders.
+ * Best-effort and batched; never throws into caller code, and absent an API key
+ * it is a no-op.
+ */
+
+/** Read an environment variable without a hard dependency on Node's `process` types. */
+function envVar(name: string): string | undefined {
+  const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process
+    ?.env;
+  return env?.[name];
+}
+
+/** Register a best-effort process-exit flush without depending on Node's `process` types. */
+function onBeforeExit(handler: () => void): (() => void) | undefined {
+  const proc = (
+    globalThis as {
+      process?: {
+        on?: (event: string, handler: () => void) => void;
+        off?: (event: string, handler: () => void) => void;
+      };
+    }
+  ).process;
+  if (!proc?.on) return undefined;
+  proc.on("beforeExit", handler);
+  return () => proc.off?.("beforeExit", handler);
+}
+
+export interface RatelClientOptions {
+  apiKey?: string;
+  host?: string;
+  enabled?: boolean;
+  /** Fraction of interactions to record, 0..1 (default 1 = all). */
+  sampleRate?: number;
+  /** Flush automatically once this many rollups are buffered (default 50). */
+  flushAt?: number;
+  /** Flush automatically this long after the last `track()` (default 1000ms). */
+  flushIntervalMs?: number;
+  /** Per-request timeout for the default fetch transport (default 5000ms). */
+  timeoutMs?: number;
+  /** Override the network transport — primarily for tests. */
+  transport?: Transport;
+}
+
+export class RatelClient {
+  private readonly apiKey: string | undefined;
+  private readonly eventsUrl: string;
+  private readonly enabled: boolean;
+  private readonly sampleRate: number;
+  private readonly flushAt: number;
+  private readonly flushIntervalMs: number;
+  private readonly timeoutMs: number;
+  private readonly transport: Transport | undefined;
+  private buffer: Rollup[] = [];
+  private readonly warned = new Set<string>();
+  private scheduled: ReturnType<typeof setTimeout> | undefined;
+  private removeExitHandler: (() => void) | undefined;
+
+  constructor(options: RatelClientOptions = {}) {
+    this.apiKey = options.apiKey ?? envVar("RATEL_API_KEY");
+    const host = (options.host ?? envVar("RATEL_HOST") ?? "https://cloud.ratel.sh").replace(
+      /\/+$/,
+      "",
+    );
+    this.eventsUrl = `${host}/api/v1/events`;
+    this.enabled = options.enabled ?? Boolean(this.apiKey);
+    this.sampleRate = options.sampleRate ?? 1;
+    this.flushAt = options.flushAt ?? 50;
+    this.flushIntervalMs = options.flushIntervalMs ?? 1000;
+    this.timeoutMs = options.timeoutMs ?? 5000;
+    this.transport = options.transport;
+    // For real (network) usage, ship whatever is buffered when the process winds
+    // down. Skipped under a custom transport so tests don't accumulate listeners.
+    if (this.canExport && this.transport == null) {
+      this.removeExitHandler = onBeforeExit(() => {
+        void this.flush();
+      });
+    }
+  }
+
+  /** True when the client should ship: a transport is set, or it's enabled with a key. */
+  get canExport(): boolean {
+    return this.transport != null || (this.enabled && Boolean(this.apiKey));
+  }
+
+  /** Record one interaction's usage rollup. Best-effort; never throws. */
+  track(input: TrackInput): void {
+    if (!this.canExport) return;
+    if (this.sampleRate < 1 && Math.random() >= this.sampleRate) return;
+    try {
+      this.buffer.push(buildRollup(input));
+      if (this.buffer.length >= this.flushAt) {
+        void this.flush();
+      } else {
+        this.scheduleFlush();
+      }
+    } catch {
+      // assembling/buffering must never break the caller
+    }
+  }
+
+  /** Send everything buffered. Resolves once the send settles (or is swallowed). */
+  async flush(): Promise<void> {
+    if (this.scheduled !== undefined) {
+      clearTimeout(this.scheduled);
+      this.scheduled = undefined;
+    }
+    if (this.buffer.length === 0) return;
+    const batch = this.buffer;
+    this.buffer = [];
+    try {
+      await this.send(batch);
+    } catch {
+      // best-effort: a failed send is dropped, never surfaced
+    }
+  }
+
+  /** Stop background flushing and ship anything still buffered. */
+  async shutdown(): Promise<void> {
+    if (this.removeExitHandler) {
+      this.removeExitHandler();
+      this.removeExitHandler = undefined;
+    }
+    await this.flush();
+  }
+
+  private scheduleFlush(): void {
+    if (this.scheduled !== undefined) return;
+    const handle = setTimeout(() => {
+      this.scheduled = undefined;
+      void this.flush();
+    }, this.flushIntervalMs);
+    // An unref'd timer never keeps the process alive on its own.
+    (handle as unknown as { unref?: () => void }).unref?.();
+    this.scheduled = handle;
+  }
+
+  private async send(batch: ReadonlyArray<Rollup>): Promise<void> {
+    if (this.transport) {
+      await this.transport(batch);
+      return;
+    }
+    const body = JSON.stringify(batch);
+    const headers = {
+      Authorization: `Bearer ${this.apiKey}`,
+      "Content-Type": "application/json",
+    };
+    let delay = 200;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+      try {
+        const response = await fetch(this.eventsUrl, {
+          method: "POST",
+          headers,
+          body,
+          signal: controller.signal,
+        });
+        if (response.ok) return;
+        if (response.status >= 400 && response.status < 500) {
+          // Bad key/payload — retrying won't help. Drop and warn once.
+          this.warnOnce(
+            `http_${response.status}`,
+            `ratel: ingest rejected (${response.status}); dropping batch`,
+          );
+          return;
+        }
+        // 5xx — fall through to retry.
+      } catch {
+        if (attempt === 2) {
+          this.warnOnce("network", "ratel: ingest unreachable; dropping batch");
+        }
+      } finally {
+        clearTimeout(timer);
+      }
+      if (attempt < 2) {
+        await new Promise((resolve) => setTimeout(resolve, delay + Math.random() * 200));
+        delay *= 2;
+      }
+    }
+    this.warnOnce("retries", "ratel: ingest failed after retries; dropping batch");
+  }
+
+  private warnOnce(key: string, message: string): void {
+    if (this.warned.has(key)) return;
+    this.warned.add(key);
+    console.warn(message);
+  }
+}
+
+let globalClient: RatelClient | null = null;
+
+/** The process-wide client, created from the environment on first use. */
+export function getClient(): RatelClient {
+  if (globalClient === null) {
+    globalClient = new RatelClient();
+  }
+  return globalClient;
+}
+
+/** Replace the process-wide client with one built from `options`, shutting down the old. */
+export function configure(options: RatelClientOptions): RatelClient {
+  const previous = globalClient;
+  globalClient = new RatelClient(options);
+  if (previous) void previous.shutdown();
+  return globalClient;
+}
+
+/** Install (or clear) the process-wide client. Primarily for tests. */
+export function setGlobalClient(client: RatelClient | null): void {
+  globalClient = client;
+}

--- a/src/integrations/cloud/src/index.ts
+++ b/src/integrations/cloud/src/index.ts
@@ -1,0 +1,2 @@
+export type { RatelClientOptions } from "./client.js";
+export { configure, getClient, RatelClient, setGlobalClient } from "./client.js";

--- a/src/integrations/cloud/tsconfig.json
+++ b/src/integrations/cloud/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
**Part 3 of 4** — observability spike split. This PR introduces the new **`@ratel-ai/cloud`** package: the concrete cloud client, extracted from `@ratel-ai/sdk`.

### What's here
- New package `@ratel-ai/cloud` at `src/integrations/cloud/` (auto-discovered by the `src/integrations/*` workspace glob; mirrors `@ratel-ai/cli`).
- `RatelClient` (`track` / `flush` / `shutdown`, env config, batching, 5xx-retry / 4xx-drop, sampling, process-exit flush) + `getClient` / `configure` / `setGlobalClient` + `RatelClientOptions`.
- Builds on `@ratel-ai/sdk`'s `buildRollup` + `Transport` seam (imported, not duplicated). The client tests moved here from the SDK.
- `src/integrations/README.md` updated for the new child; lockfile linked.

### Verified locally
`build` ✓ · `typecheck` ✓ · `biome` ✓ · `vitest` **11/11** ✓ (resolves `@ratel-ai/sdk` via the workspace).

### Stack — merge in order
1. RAT-305 — Rust core (#79)
2. RAT-306 — `@ratel-ai/sdk` (#80)
3. **RAT-307 — `@ratel-ai/cloud`** ← _this PR_ (stacked on #80)
4. RAT-308 — `ratel-ai` Python parity (#81)

Base is the `@ratel-ai/sdk` branch; GitHub retargets to `main` as the stack merges.

Closes RAT-307. Part of RAT-291.
