### PR TITLE
docs(examples): point telemetry examples at cloud.ratel.sh/v1/traces

### DIFF
--- a/examples/telemetry-python/README.md
+++ b/examples/telemetry-python/README.md
@@ -15,7 +15,7 @@ uv run main.py
 To export a real trace instead of printing, set the endpoint and run again:
 
 ```bash
-export RATEL_URL=https://ingest.ratel.sh/v1/traces
+export RATEL_URL=https://cloud.ratel.sh/v1/traces
 export RATEL_API_KEY=sk-...          # optional; sent as Authorization: Bearer
 uv run main.py
 ```

--- a/examples/telemetry-python/main.py
+++ b/examples/telemetry-python/main.py
@@ -112,7 +112,7 @@ def main() -> None:
     # --- Production wiring: the same spans, exported to Ratel via init() ---
     # resolve_otlp_config is pure (no network), so we can show how endpoint + auth
     # resolve without sending anything:
-    cfg = resolve_otlp_config(api_key="sk-demo", endpoint="https://ingest.ratel.sh/v1/traces")
+    cfg = resolve_otlp_config(api_key="sk-demo", endpoint="https://cloud.ratel.sh/v1/traces")
     print("\n--- how init() resolves options -> exporter config (illustrative demo values) ---")
     print(f"  url:          {cfg.url}")
     print(f"  service_name: {cfg.service_name} (default {DEFAULT_SERVICE_NAME})")

--- a/examples/telemetry-ts/README.md
+++ b/examples/telemetry-ts/README.md
@@ -16,7 +16,7 @@ pnpm -F @ratel-ai/example-telemetry start
 To export a real trace instead of printing, set the endpoint and run again:
 
 ```bash
-export RATEL_URL=https://ingest.ratel.sh/v1/traces
+export RATEL_URL=https://cloud.ratel.sh/v1/traces
 export RATEL_API_KEY=sk-...          # optional; sent as Authorization: Bearer
 pnpm -F @ratel-ai/example-telemetry start
 ```

--- a/examples/telemetry-ts/src/index.ts
+++ b/examples/telemetry-ts/src/index.ts
@@ -110,7 +110,7 @@ async function main(): Promise<void> {
   // --- Production wiring: the same spans, exported to Ratel via init() ---
   // `resolveOtlpConfig` is pure (no network), so we can show how endpoint + auth
   // resolve without sending anything:
-  const cfg = resolveOtlpConfig({ apiKey: "sk-demo", endpoint: "https://ingest.ratel.sh/v1/traces" });
+  const cfg = resolveOtlpConfig({ apiKey: "sk-demo", endpoint: "https://cloud.ratel.sh/v1/traces" });
   console.log("\n--- how init() resolves options -> exporter config (illustrative demo values) ---");
   console.log(`  url:         ${cfg.url}`);
   console.log(`  serviceName: ${cfg.serviceName} (default ${DEFAULT_SERVICE_NAME})`);


### PR DESCRIPTION
Companion to ratel-websites#30 (OTLP trace ingest cutover). Ratel Cloud now ingests **stock OTLP** at `POST /api/v1/traces`, with the OTLP-standard `/v1/traces` path rewritten to it — so an exporter configured with `RATEL_URL=https://cloud.ratel.sh/v1/traces` works directly.

This updates the telemetry example placeholders (`examples/telemetry-{ts,python}`) from the unrouted `ingest.ratel.sh` alias to the live `cloud.ratel.sh/v1/traces`. No code change — the emitter packages already send to whatever `RATEL_URL`/`endpoint` is configured; only the illustrative host changes.

### Endpoint convention (resolved)
Emitters target `<host>/v1/traces` (the OTLP convention `@ratel-ai/telemetry-otlp` already uses). The Cloud app serves the route at `/api/v1/traces` and adds a `vercel.json` rewrite `/v1/traces → /api/v1/traces`, so the standard path works without an `/api` prefix. If a dedicated `ingest.ratel.sh` subdomain is later pointed at the Cloud app, `ingest.ratel.sh/v1/traces` works with no code change.

### Coordination note (not in this PR)
The in-flight RAT-292 branch (`kayra/rat-292-chat-message-collection`) still sends a PII-free **usage rollup** via `RatelClient.track()` to `POST /api/v1/events`. That metrics-rollup path is **superseded** by this OTLP ingest and should be dropped from that branch, keeping only its chat channel (`/api/v1/chats`, ADR-0014), which is unaffected.