### PR TITLE
feat(py-sdk): emit OpenTelemetry ratel.*/gen_ai.* funnel spans

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -25,7 +25,11 @@ jobs:
       - name: Create venv + install dev tools
         run: |
           uv venv --python 3.11 .venv
-          uv pip install --python .venv maturin pytest pytest-asyncio ruff mypy
+          # opentelemetry-sdk + the local vocabulary let the OTel emission tests
+          # (test_telemetry.py, ADR-0011) run rather than skip; both are optional at
+          # runtime (base SDK stays dependency-free).
+          uv pip install --python .venv maturin pytest pytest-asyncio ruff mypy \
+            opentelemetry-sdk -e ../../telemetry/python
       - name: Build native extension
         run: .venv/bin/maturin develop
       - name: Lint

--- a/src/sdk/python/README.md
+++ b/src/sdk/python/README.md
@@ -238,6 +238,21 @@ Sink kinds:
 
 `search_capabilities_tool` tags its emitted `search` event with `origin="agent"`; direct callers (`catalog.search(query, k)`) default to `"direct"`. Override per call via `catalog.search(query, k, "agent")`.
 
+### OpenTelemetry export
+
+Independently of the local sink above, the SDK **emits OpenTelemetry spans** for the same funnel — `execute_tool`, `ratel.search`, `ratel.skill.load`, `ratel.upstream.register`, `ratel.auth.flow` (the `gen_ai.*` / `ratel.*` vocabulary, [ADR 0011](../../../docs/adr/0011-sdk-otel-auto-instrumentation.md)). This is transparent: spans go to whatever OpenTelemetry provider is registered, and are a pass-through no-op when OpenTelemetry isn't installed. Two ways to turn export on:
+
+```python
+from ratel_ai import configure_telemetry
+
+# Greenfield: ship the SDK's spans to Ratel Cloud (needs the [otlp] extra:
+# pip install 'ratel-ai[otlp]'). RATEL_URL or endpoint= sets the destination.
+provider = configure_telemetry(api_key=os.environ["RATEL_API_KEY"])
+# ... later: provider.shutdown()
+```
+
+If you already run OpenTelemetry (your own collector, another instrumentation), **skip `configure_telemetry`** — the spans already flow to your provider — and add `ratel_span_processor` from `ratel_ai_telemetry` to dual-export the Ratel cut to Cloud. Message/tool content is captured on spans only when `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` is set (default off).
+
 ## Develop
 
 This package is part of the Cargo workspace at the repo root and builds into a local venv. From `src/sdk/python/`:

--- a/src/sdk/python/pyproject.toml
+++ b/src/sdk/python/pyproject.toml
@@ -32,6 +32,11 @@ dependencies = []
 # register_mcp_server() ingests upstream MCP servers via the official client.
 # Lazily imported, so the base SDK installs without it. Requires Python >=3.10.
 mcp = ["mcp>=1.0"]
+# OpenTelemetry export of the ratel.*/gen_ai.* funnel (ADR-0011). The base SDK
+# emits spans to whatever OTel provider is active and is a no-op without one, so it
+# stays dependency-free; this extra pulls the vocabulary + the OTLP exporter so
+# configure_telemetry() can ship spans to Ratel Cloud. Lazily imported.
+otlp = ["ratel-ai-telemetry[otlp]>=0.1.0rc4"]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",

--- a/src/sdk/python/ratel_ai/__init__.py
+++ b/src/sdk/python/ratel_ai/__init__.py
@@ -37,6 +37,12 @@ from .mcp import McpServerHandle, register_mcp_server
 from .skill_catalog import Skill, SkillCatalog
 from .skill_gateway import GET_SKILL_CONTENT_ID, get_skill_content_tool
 
+# OpenTelemetry export of the ratel.*/gen_ai.* funnel (ADR-0011). The SDK always
+# emits spans to the active OTel provider (a no-op until one is wired);
+# configure_telemetry is optional sugar that installs a Ratel-owned OTLP exporter
+# (needs the [otlp] extra).
+from .telemetry import configure_telemetry
+
 __all__ = [
     "GET_SKILL_CONTENT_ID",
     "INVOKE_TOOL_ID",
@@ -58,6 +64,7 @@ __all__ = [
     "ToolRegistry",
     "TraceSinkConfig",
     "UpstreamServerInfo",
+    "configure_telemetry",
     "format_upstream_line",
     "get_skill_content_tool",
     "invoke_tool_tool",

--- a/src/sdk/python/ratel_ai/catalog.py
+++ b/src/sdk/python/ratel_ai/catalog.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Union
 
 from ._native import SearchHit, ToolRegistry
+from .telemetry import SEARCH_TARGET_TOOL, trace_execute_tool, trace_search
 
 # Tool inputs are heterogeneous across the catalog; handlers may be sync or async.
 Executor = Callable[[dict[str, Any]], Union[Awaitable[Any], Any]]
@@ -114,7 +115,13 @@ class ToolCatalog:
         """Search the catalog. `method` overrides the catalog default for this
         call ("bm25" | "semantic" | "hybrid"); "semantic"/"hybrid" raise
         `RuntimeError` if the embedding model fails to load."""
-        return self._registry.search_with_method(query, top_k, origin, method or self._method)
+        return trace_search(
+            SEARCH_TARGET_TOOL,
+            query,
+            top_k,
+            origin,
+            lambda: self._registry.search_with_method(query, top_k, origin, method or self._method),
+        )
 
     def has(self, tool_id: str) -> bool:
         return tool_id in self._executors
@@ -146,41 +153,47 @@ class ToolCatalog:
         fn = self._executors.get(tool_id)
         if fn is None:
             raise ValueError(f"unknown toolId: {tool_id}")
-        self._registry.record_event(
-            {
-                "type": "invoke_start",
-                "tool_id": tool_id,
-                "args_size_bytes": _args_size_bytes(args),
-            }
-        )
-        started = time.monotonic()
-        try:
-            # Executors may be sync (a plain dict-returning function) or async
-            # (`async def`, e.g. MCP/HTTP tools) — so call first, then await only
-            # if awaitable. Never bare-`await fn(args)`: in Python that raises on a
-            # sync result. This is the canonical place that absorbs the difference;
-            # callers must route here, not re-derive it.
-            result = fn(args)
-            if inspect.isawaitable(result):
-                result = await result
+
+        async def _run() -> Any:
             self._registry.record_event(
                 {
-                    "type": "invoke_end",
+                    "type": "invoke_start",
                     "tool_id": tool_id,
-                    "took_ms": _elapsed_ms(started),
+                    "args_size_bytes": _args_size_bytes(args),
                 }
             )
-            return result
-        except Exception as err:
-            self._registry.record_event(
-                {
-                    "type": "invoke_error",
-                    "tool_id": tool_id,
-                    "took_ms": _elapsed_ms(started),
-                    "error": _error_message(err),
-                }
-            )
-            raise
+            started = time.monotonic()
+            try:
+                # Executors may be sync (a plain dict-returning function) or async
+                # (`async def`, e.g. MCP/HTTP tools) — so call first, then await only
+                # if awaitable. Never bare-`await fn(args)`: in Python that raises on a
+                # sync result. This is the canonical place that absorbs the difference;
+                # callers must route here, not re-derive it.
+                result = fn(args)
+                if inspect.isawaitable(result):
+                    result = await result
+                self._registry.record_event(
+                    {
+                        "type": "invoke_end",
+                        "tool_id": tool_id,
+                        "took_ms": _elapsed_ms(started),
+                    }
+                )
+                return result
+            except Exception as err:
+                self._registry.record_event(
+                    {
+                        "type": "invoke_error",
+                        "tool_id": tool_id,
+                        "took_ms": _elapsed_ms(started),
+                        "error": _error_message(err),
+                    }
+                )
+                raise
+
+        # The `execute_tool` OTel span wraps the local trace stream; both record the
+        # same invocation, on their two independent channels (ADR-0007).
+        return await trace_execute_tool(tool_id, args, _run)
 
 
 def _args_size_bytes(args: Any) -> int:

--- a/src/sdk/python/ratel_ai/gateway.py
+++ b/src/sdk/python/ratel_ai/gateway.py
@@ -17,6 +17,7 @@ from typing import Any, Callable, Union
 
 from .catalog import ExecutableTool, ToolCatalog
 from .skill_catalog import SkillCatalog
+from .telemetry import record_auth_needed
 
 SEARCH_CAPABILITIES_ID = "search_capabilities"
 INVOKE_TOOL_ID = "invoke_tool"
@@ -339,6 +340,7 @@ def invoke_tool_tool(
                     maybe = on_unauthorized(upstream)
                     if inspect.isawaitable(maybe):
                         await maybe
+                record_auth_needed(upstream)
                 catalog.record_event(
                     {"type": "gateway_error", "tool_id": tool_id, "error": "needs_auth"}
                 )

--- a/src/sdk/python/ratel_ai/mcp.py
+++ b/src/sdk/python/ratel_ai/mcp.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass
 from typing import Any, Callable
 
 from .catalog import ExecutableTool, ToolCatalog
+from .telemetry import trace_upstream_register
 
 
 def _require_mcp() -> None:
@@ -74,37 +75,43 @@ async def register_mcp_server(
     """
     _require_mcp()
 
-    list_result = await session.list_tools()
-    tools = list_result.tools
-    catalog.record_event(
-        {
-            "type": "upstream_register",
-            "server": name,
-            "transport": transport_label,
-            "tool_count": len(tools),
-        }
-    )
-
-    tool_ids: list[str] = []
-    for tool in tools:
-        tool_id = f"{name}__{tool.name}"
-        catalog.register(
-            ExecutableTool(
-                id=tool_id,
-                name=tool.name,
-                description=getattr(tool, "description", None) or "",
-                input_schema=getattr(tool, "inputSchema", None) or {},
-                output_schema=getattr(tool, "outputSchema", None) or {"type": "object"},
-                execute=_make_executor(catalog, session, name, tool_id, tool.name),
-            )
+    # The whole registration (list + ingest) is one `ratel.upstream.register` span;
+    # per-tool invocations later get their own `execute_tool` spans (ADR-0007).
+    async def _run(report_tool_count: Callable[[int], None]) -> McpServerHandle:
+        list_result = await session.list_tools()
+        tools = list_result.tools
+        report_tool_count(len(tools))
+        catalog.record_event(
+            {
+                "type": "upstream_register",
+                "server": name,
+                "transport": transport_label,
+                "tool_count": len(tools),
+            }
         )
-        tool_ids.append(tool_id)
 
-    return McpServerHandle(
-        tool_ids=tool_ids,
-        server_instructions=instructions,
-        close=on_close or _noop_close,
-    )
+        tool_ids: list[str] = []
+        for tool in tools:
+            tool_id = f"{name}__{tool.name}"
+            catalog.register(
+                ExecutableTool(
+                    id=tool_id,
+                    name=tool.name,
+                    description=getattr(tool, "description", None) or "",
+                    input_schema=getattr(tool, "inputSchema", None) or {},
+                    output_schema=getattr(tool, "outputSchema", None) or {"type": "object"},
+                    execute=_make_executor(catalog, session, name, tool_id, tool.name),
+                )
+            )
+            tool_ids.append(tool_id)
+
+        return McpServerHandle(
+            tool_ids=tool_ids,
+            server_instructions=instructions,
+            close=on_close or _noop_close,
+        )
+
+    return await trace_upstream_register(name, transport_label, _run)
 
 
 def _make_executor(

--- a/src/sdk/python/ratel_ai/skill_catalog.py
+++ b/src/sdk/python/ratel_ai/skill_catalog.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from ._native import SkillHit, SkillRegistry
 from .catalog import SearchMethod, SearchOrigin, TraceSinkConfig
+from .telemetry import SEARCH_TARGET_SKILL, trace_search, trace_skill_load
 
 __all__ = ["Skill", "SkillCatalog", "SkillHit"]
 
@@ -77,7 +78,13 @@ class SkillCatalog:
         origin: SearchOrigin = "direct",
         method: SearchMethod | None = None,
     ) -> list[SkillHit]:
-        return self._registry.search_with_method(query, top_k, origin, method or self._method)
+        return trace_search(
+            SEARCH_TARGET_SKILL,
+            query,
+            top_k,
+            origin,
+            lambda: self._registry.search_with_method(query, top_k, origin, method or self._method),
+        )
 
     def has(self, skill_id: str) -> bool:
         return skill_id in self._skills
@@ -103,13 +110,17 @@ class SkillCatalog:
         skill = self._skills.get(skill_id)
         if skill is None:
             raise ValueError(f"unknown skillId: {skill_id}")
-        started = time.monotonic()
-        body = skill.body
-        self._registry.record_event(
-            {
-                "type": "skill_invoke",
-                "skill_id": skill_id,
-                "took_ms": int((time.monotonic() - started) * 1000),
-            }
-        )
-        return body
+
+        def _run() -> str:
+            started = time.monotonic()
+            body = skill.body
+            self._registry.record_event(
+                {
+                    "type": "skill_invoke",
+                    "skill_id": skill_id,
+                    "took_ms": int((time.monotonic() - started) * 1000),
+                }
+            )
+            return body
+
+        return trace_skill_load(skill_id, _run)

--- a/src/sdk/python/ratel_ai/telemetry.py
+++ b/src/sdk/python/ratel_ai/telemetry.py
@@ -1,0 +1,206 @@
+"""OpenTelemetry emission for the SDK funnel — the Python mirror of
+`src/sdk/ts/src/telemetry.ts` (ADR-0011, ADR-0007).
+
+The catalog / gateway / skill / MCP paths call these helpers to open a span around
+each operation, alongside the local `record_event` stream (untouched). Span names
+and attribute keys come from the OTel-free `ratel_ai_telemetry` vocabulary.
+
+Emission is **transparent and optional**: the OpenTelemetry API and the vocabulary
+are imported lazily. If neither is installed (the base `ratel-ai` install), every
+helper is a straight pass-through — zero overhead, no spans. Installing
+`ratel-ai[otlp]` (or having OpenTelemetry present) lights emission up; spans then go
+to whatever provider is registered, exactly as a host deployment wires it. Content
+(`ratel.search.query`, tool args/result) rides span attributes only when the
+ecosystem capture gate is on (default off).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar
+
+try:
+    from opentelemetry import trace as _otel_trace
+    from opentelemetry.trace import SpanKind, Status, StatusCode
+    from ratel_ai_telemetry import (
+        EXECUTE_TOOL,
+        GEN_AI_OPERATION_NAME,
+        GEN_AI_TOOL_CALL_ARGUMENTS,
+        GEN_AI_TOOL_CALL_RESULT,
+        GEN_AI_TOOL_NAME,
+        RATEL_AUTH_FLOW,
+        RATEL_AUTH_OUTCOME,
+        RATEL_ORIGIN,
+        RATEL_SEARCH,
+        RATEL_SEARCH_HIT_COUNT,
+        RATEL_SEARCH_QUERY,
+        RATEL_SEARCH_TARGET,
+        RATEL_SEARCH_TOP_K,
+        RATEL_SKILL_ID,
+        RATEL_SKILL_LOAD,
+        RATEL_TOOL_ARGS_SIZE_BYTES,
+        RATEL_UPSTREAM_REGISTER,
+        RATEL_UPSTREAM_SERVER,
+        RATEL_UPSTREAM_TOOL_COUNT,
+        RATEL_UPSTREAM_TRANSPORT,
+        AuthOutcome,
+        ContentCapture,
+        content_capture_mode,
+    )
+
+    _ENABLED = True
+except ModuleNotFoundError:
+    _ENABLED = False
+
+_TRACER_NAME = "ratel-ai"
+
+#: `ratel.search.target` values (mirror `SearchTarget` without a hard import at the
+#: call sites, so the catalog modules stay dependency-free when telemetry is absent).
+SEARCH_TARGET_TOOL = "tool"
+SEARCH_TARGET_SKILL = "skill"
+
+T = TypeVar("T")
+
+
+def _tracer() -> Any:
+    return _otel_trace.get_tracer(_TRACER_NAME)
+
+
+def _capture_content_on_span() -> bool:
+    mode = content_capture_mode()
+    return mode in (ContentCapture.SPAN_ONLY, ContentCapture.SPAN_AND_EVENT)
+
+
+def _args_size_bytes(args: Any) -> int:
+    try:
+        return len(json.dumps(args))
+    except Exception:
+        return 0
+
+
+def _safe_json(value: Any) -> str:
+    try:
+        return json.dumps(value)
+    except Exception:
+        return ""
+
+
+async def trace_execute_tool(
+    tool_id: str,
+    args: dict[str, Any],
+    run: Callable[[], Awaitable[T]],
+) -> T:
+    """Wrap a tool invocation in a standard `execute_tool` span (`gen_ai.operation.name
+    = execute_tool`, enriched with `ratel.*`) — the OTel gen_ai tool operation, so a
+    generic backend understands it (ADR-0007). No-op pass-through when disabled.
+    """
+    if not _ENABLED:
+        return await run()
+    with _tracer().start_as_current_span(
+        f"{EXECUTE_TOOL} {tool_id}", kind=SpanKind.INTERNAL
+    ) as span:
+        span.set_attribute(GEN_AI_OPERATION_NAME, EXECUTE_TOOL)
+        span.set_attribute(GEN_AI_TOOL_NAME, tool_id)
+        span.set_attribute(RATEL_TOOL_ARGS_SIZE_BYTES, _args_size_bytes(args))
+        if _capture_content_on_span():
+            span.set_attribute(GEN_AI_TOOL_CALL_ARGUMENTS, _safe_json(args))
+        # start_as_current_span records the exception + sets ERROR status on raise.
+        result = await run()
+        if _capture_content_on_span():
+            span.set_attribute(GEN_AI_TOOL_CALL_RESULT, _safe_json(result))
+        span.set_status(Status(StatusCode.OK))
+        return result
+
+
+def trace_search(
+    target: str,
+    query: str,
+    top_k: int,
+    origin: str,
+    run: Callable[[], T],
+) -> T:
+    """Wrap a capability search (tool or skill) in a `ratel.search` span. Synchronous:
+    the native BM25 search returns inline; the hit count becomes `ratel.search.hit_count`.
+    """
+    if not _ENABLED:
+        return run()
+    with _tracer().start_as_current_span(RATEL_SEARCH, kind=SpanKind.INTERNAL) as span:
+        span.set_attribute(RATEL_SEARCH_TARGET, target)
+        span.set_attribute(RATEL_SEARCH_TOP_K, top_k)
+        span.set_attribute(RATEL_ORIGIN, origin)
+        if _capture_content_on_span():
+            span.set_attribute(RATEL_SEARCH_QUERY, query)
+        hits = run()
+        span.set_attribute(RATEL_SEARCH_HIT_COUNT, len(hits))  # type: ignore[arg-type]
+        span.set_status(Status(StatusCode.OK))
+        return hits
+
+
+def trace_skill_load(skill_id: str, run: Callable[[], T]) -> T:
+    """Wrap a skill-content load in a `ratel.skill.load` span."""
+    if not _ENABLED:
+        return run()
+    with _tracer().start_as_current_span(RATEL_SKILL_LOAD, kind=SpanKind.INTERNAL) as span:
+        span.set_attribute(RATEL_SKILL_ID, skill_id)
+        body = run()
+        span.set_status(Status(StatusCode.OK))
+        return body
+
+
+async def trace_upstream_register(
+    server: str,
+    transport: str,
+    run: Callable[[Callable[[int], None]], Awaitable[T]],
+) -> T:
+    """Wrap an upstream-MCP registration in a `ratel.upstream.register` span. `run`
+    receives a `report_tool_count` callback to set `ratel.upstream.tool_count` once the
+    tool list is known.
+    """
+    if not _ENABLED:
+        return await run(lambda _n: None)
+    with _tracer().start_as_current_span(RATEL_UPSTREAM_REGISTER, kind=SpanKind.INTERNAL) as span:
+        span.set_attribute(RATEL_UPSTREAM_SERVER, server)
+        span.set_attribute(RATEL_UPSTREAM_TRANSPORT, transport)
+        result = await run(lambda n: span.set_attribute(RATEL_UPSTREAM_TOOL_COUNT, n))
+        span.set_status(Status(StatusCode.OK))
+        return result
+
+
+def record_auth_needed(server: str | None = None) -> None:
+    """Mark an upstream tool call that failed with a 401 / needs-reauthorization: a
+    short `ratel.auth.flow` span carrying `ratel.auth.outcome = needs_auth`.
+    """
+    if not _ENABLED:
+        return
+    span = _tracer().start_span(RATEL_AUTH_FLOW, kind=SpanKind.INTERNAL)
+    if server:
+        span.set_attribute(RATEL_UPSTREAM_SERVER, server)
+    span.set_attribute(RATEL_AUTH_OUTCOME, AuthOutcome.NEEDS_AUTH.value)
+    span.end()
+
+
+def configure_telemetry(
+    *,
+    api_key: str | None = None,
+    endpoint: str | None = None,
+    headers: dict[str, str] | None = None,
+    service_name: str | None = None,
+) -> Any:
+    """Convenience wiring for the greenfield case: register a Ratel-owned OTLP exporter
+    so the spans this SDK emits are shipped to Ratel Cloud (or any OTLP endpoint).
+    Delegates to `ratel_ai_telemetry.init`, which needs the OpenTelemetry SDK — install
+    it with ``pip install 'ratel-ai[otlp]'``. A host already running its own OpenTelemetry
+    provider should skip this (the SDK's spans flow to that provider) and add
+    `ratel_span_processor` from `ratel_ai_telemetry`. Returns the provider as a shutdown
+    handle (``provider.shutdown()`` / ``provider.force_flush()``).
+    """
+    try:
+        from ratel_ai_telemetry import init
+    except ModuleNotFoundError as exc:  # pragma: no cover - exercised only without the extra
+        raise ModuleNotFoundError(
+            "configure_telemetry() needs the OpenTelemetry exporter. Install the extra: "
+            "pip install 'ratel-ai[otlp]' — or register your own OpenTelemetry provider, "
+            "since the SDK emits ratel.*/gen_ai.* spans to whatever provider is active."
+        ) from exc
+    return init(api_key=api_key, endpoint=endpoint, headers=headers, service_name=service_name)

--- a/src/sdk/python/tests/test_telemetry.py
+++ b/src/sdk/python/tests/test_telemetry.py
@@ -1,0 +1,169 @@
+"""OpenTelemetry emission tests — mirrors `src/sdk/ts/src/telemetry.test.ts`.
+
+Instrumentation is verified through the public OTel API: register an in-memory
+exporter as the global provider, drive the SDK, and read the spans back. The SDK
+never imports the exporter — it emits to whatever provider is active, exactly as a
+host deployment would wire it. These tests need the OpenTelemetry SDK
+(`ratel-ai[otlp]` or a bare `opentelemetry-sdk`); they skip if it is absent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("opentelemetry.sdk.trace", reason="OpenTelemetry SDK not installed")
+
+from opentelemetry import trace  # noqa: E402
+from opentelemetry.sdk.trace import TracerProvider  # noqa: E402
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor  # noqa: E402
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (  # noqa: E402
+    InMemorySpanExporter,
+)
+from opentelemetry.trace import StatusCode  # noqa: E402
+
+from ratel_ai import (  # noqa: E402
+    ExecutableTool,
+    Skill,
+    SkillCatalog,
+    ToolCatalog,
+    TraceSinkConfig,
+)
+
+CAPTURE_ENV = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
+
+# OpenTelemetry forbids overriding the global provider once set, so register one
+# provider for the whole module and give each test a clean exporter via clear().
+_EXPORTER = InMemorySpanExporter()
+_PROVIDER = TracerProvider()
+_PROVIDER.add_span_processor(SimpleSpanProcessor(_EXPORTER))
+trace.set_tracer_provider(_PROVIDER)
+
+
+@pytest.fixture()
+def exporter(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """The shared in-memory exporter, cleared so each test sees only its own spans."""
+    monkeypatch.delenv(CAPTURE_ENV, raising=False)
+    _EXPORTER.clear()
+    return _EXPORTER
+
+
+def _read_file() -> ExecutableTool:
+    return ExecutableTool(
+        id="read_file",
+        name="read_file",
+        description="Read a file from local disk and return its textual contents.",
+        input_schema={"properties": {"path": {"type": "string"}}},
+        output_schema={"properties": {"contents": {"type": "string"}}},
+        execute=lambda args: {"contents": f"contents of {args.get('path')}"},
+    )
+
+
+def _spans_named(exp: Any, name: str) -> list[Any]:
+    return [s for s in exp.get_finished_spans() if s.name == name]
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_span_attributes(exporter: Any) -> None:
+    catalog = ToolCatalog()
+    catalog.register(_read_file())
+    await catalog.invoke("read_file", {"path": "/tmp/x"})
+
+    spans = _spans_named(exporter, "execute_tool read_file")
+    assert len(spans) == 1
+    attrs = spans[0].attributes
+    assert attrs["gen_ai.operation.name"] == "execute_tool"
+    assert attrs["gen_ai.tool.name"] == "read_file"
+    assert attrs["ratel.tool.args_size_bytes"] > 0
+    assert spans[0].status.status_code == StatusCode.OK
+
+
+@pytest.mark.asyncio
+async def test_content_not_captured_by_default(exporter: Any) -> None:
+    catalog = ToolCatalog()
+    catalog.register(_read_file())
+    await catalog.invoke("read_file", {"path": "/secret"})
+
+    attrs = _spans_named(exporter, "execute_tool read_file")[0].attributes
+    assert "gen_ai.tool.call.arguments" not in attrs
+    assert "gen_ai.tool.call.result" not in attrs
+
+
+@pytest.mark.asyncio
+async def test_content_captured_when_gate_set(
+    exporter: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(CAPTURE_ENV, "SPAN_AND_EVENT")
+    catalog = ToolCatalog()
+    catalog.register(_read_file())
+    await catalog.invoke("read_file", {"path": "/p"})
+
+    attrs = _spans_named(exporter, "execute_tool read_file")[0].attributes
+    assert attrs["gen_ai.tool.call.arguments"] == '{"path": "/p"}'
+    assert "contents of /p" in attrs["gen_ai.tool.call.result"]
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_span_error(exporter: Any) -> None:
+    def boom(_args: dict[str, Any]) -> Any:
+        raise RuntimeError("kaboom")
+
+    catalog = ToolCatalog()
+    catalog.register(
+        ExecutableTool(id="boom", name="boom", description="throws", execute=boom)
+    )
+    with pytest.raises(RuntimeError, match="kaboom"):
+        await catalog.invoke("boom", {})
+
+    span = _spans_named(exporter, "execute_tool boom")[0]
+    assert span.status.status_code == StatusCode.ERROR
+    assert any(e.name == "exception" for e in span.events)
+
+
+@pytest.mark.asyncio
+async def test_local_stream_intact_alongside_span(exporter: Any) -> None:
+    catalog = ToolCatalog(trace=TraceSinkConfig("memory", session_id="s"))
+    catalog.register(_read_file())
+    await catalog.invoke("read_file", {"path": "/tmp/x"})
+
+    local = catalog.drain_trace_events()
+    invoke_events = [e["type"] for e in local if str(e["type"]).startswith("invoke_")]
+    assert invoke_events == ["invoke_start", "invoke_end"]
+    assert len(_spans_named(exporter, "execute_tool read_file")) == 1
+
+
+def test_ratel_search_span_tool(exporter: Any) -> None:
+    catalog = ToolCatalog()
+    catalog.register(_read_file())
+    catalog.search("read file", 5, "agent")
+
+    attrs = _spans_named(exporter, "ratel.search")[0].attributes
+    assert attrs["ratel.search.target"] == "tool"
+    assert attrs["ratel.search.top_k"] == 5
+    assert attrs["ratel.origin"] == "agent"
+    assert attrs["ratel.search.hit_count"] > 0
+    assert "ratel.search.query" not in attrs  # content off by default
+
+
+def test_ratel_search_span_skill_with_query(
+    exporter: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(CAPTURE_ENV, "SPAN_ONLY")
+    skills = SkillCatalog()
+    skills.register(Skill(id="pdf", name="pdf", description="fill pdf forms", body="b"))
+    skills.search("pdf", 3)
+
+    attrs = _spans_named(exporter, "ratel.search")[0].attributes
+    assert attrs["ratel.search.target"] == "skill"
+    assert attrs["ratel.search.query"] == "pdf"
+
+
+def test_ratel_skill_load_span(exporter: Any) -> None:
+    skills = SkillCatalog()
+    skills.register(Skill(id="pdf", name="pdf", description="d", body="BODY"))
+    assert skills.invoke("pdf") == "BODY"
+
+    span = _spans_named(exporter, "ratel.skill.load")[0]
+    assert span.attributes["ratel.skill.id"] == "pdf"
+    assert span.status.status_code == StatusCode.OK


### PR DESCRIPTION
> **Stacked on #98** (`feat/sdk-otel-ts`). Review/merge that first; this branch targets it, so the diff here is the Python mirror only.

## What

Python half of Task 3 (ADR-0011): `ratel-ai` now **emits OpenTelemetry** for the
same funnel the TS SDK does — a faithful mirror of #98.

- `ratel_ai/telemetry.py` — the emission seam. One span per funnel boundary
  (`execute_tool {id}`, `ratel.search`, `ratel.skill.load`, `ratel.upstream.register`,
  `ratel.auth.flow`) via `opentelemetry` + the OTel-free `ratel_ai_telemetry`
  vocabulary, alongside the untouched `record_event` local stream.
- Instrumented `catalog.py`, `skill_catalog.py`, `gateway.py` (needs_auth), `mcp.py`.
- `configure_telemetry(...)` — greenfield Cloud export via the new `[otlp]` extra
  (`pip install 'ratel-ai[otlp]'`); exported from `ratel_ai`.

## Design (mirrors #98, adapted to Python)

- **Transparent + optional, base stays dependency-free**: the OTel API and vocabulary
  are imported lazily in `telemetry.py`; if neither is installed every helper is a
  straight pass-through (zero overhead, no spans). `ratel-ai[otlp]` (or any present
  OpenTelemetry) lights emission up — spans then flow to the active provider. Hosts
  already on OTel add `ratel_span_processor`; no `configure_telemetry` needed.
- Content (`ratel.search.query`, tool args/result) gated by
  `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` (default off).
- Errors → OTel span status `ERROR` + exception event (handled by
  `start_as_current_span`'s defaults).

## Test plan

- [x] `tests/test_telemetry.py` drives the SDK through an in-memory OTel exporter:
      execute_tool attrs + OK/ERROR status, ratel.search target=tool/skill + counts,
      ratel.skill.load, content on/off gating, local stream intact alongside the span.
      Skips cleanly if OpenTelemetry isn't installed.
- [x] Full Python suite green (59), `ruff` + `mypy` clean.
- [x] **CI updated**: the SDK job installs `opentelemetry-sdk` + the local
      `ratel-ai-telemetry` so the emission tests run instead of skip.
