### PR TITLE
fix(core): replace tools/skills in place on re-register

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,6 +1649,7 @@ dependencies = [
  "candle-nn",
  "candle-transformers",
  "hf-hub",
+ "indexmap",
  "serde",
  "serde_json",
  "tempfile",

--- a/docs/adr/0011-selectable-retrieval-methods.md
+++ b/docs/adr/0011-selectable-retrieval-methods.md
@@ -42,11 +42,13 @@ parallel to `SearchOrigin`.
   `Result<_, EmbedderError>`; `Bm25` is always `Ok`, while `Semantic`/`Hybrid` surface a failed
   model load (network, cache, underpowered machine) as a catchable error — a Python
   `RuntimeError` / a thrown JS error at the SDK edge.
-- **The embedding cache is incremental and in-process.** It is a growing *prefix* of the
-  corpus: `register` only appends a tool (never invalidates), and the not-yet-embedded tail is
-  embedded by `build_embeddings()` — so an existing vector is never recomputed (adding one tool
-  costs one embedding, not N). Core `register(&mut self, tool) -> ()` stays infallible and
-  model-free; a pure BM25 registry never populates the cache. The one-time model load emits a
+- **The embedding cache is incremental and in-process.** It is an **id-keyed** map of per-item
+  vectors: `register` inserts a tool by id (replacing an existing id in place and calling
+  `DenseCache::invalidate` to drop its stale vector), and `build_embeddings()` embeds every id
+  not currently cached — the newly registered *and* the invalidated-on-replace — so a cached
+  vector is recomputed only when its item changed (adding one tool, or re-registering one, costs
+  one embedding, not N). Core `register(&mut self, tool) -> ()` stays infallible and model-free;
+  a pure BM25 registry never populates the cache. The one-time model load emits a
   `TraceEvent::EmbedderLoad` flagging a slow (possibly underpowered) or failed load.
 - **Semantic is opt-in and eagerly built.** A catalog whose default method is `"semantic"` /
   `"hybrid"` (the opt-in flag) calls `build_embeddings()` after each `register`, so the cost lands at load
@@ -76,5 +78,6 @@ parallel to `SearchOrigin`.
   spikes' shape) — it made `register` fallible and loaded the model for BM25-only users; eager
   embedding is instead **opt-in** in semantic mode, driven from the SDK via `build_embeddings()`, so core
   `register` stays infallible. Rejected: full-corpus re-embed on `register` (the first cut of
-  this ADR) — the incremental prefix cache re-embeds only newly-registered tools. Rejected:
+  this ADR) — the incremental id-keyed cache re-embeds only ids not currently cached (newly
+  registered, or invalidated when a re-register replaces an id). Rejected:
   score-normalization fusion for hybrid — RRF needs no per-arm score calibration.

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -14,6 +14,9 @@ categories = ["text-processing", "algorithms"]
 
 [dependencies]
 bm25 = "2.3"
+# Id-keyed, insertion-ordered corpus storage: `register` replaces in place so a
+# re-registered id never duplicates (see ToolRegistry/DenseCache, RAT-378).
+indexmap = "2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 

--- a/src/core/src/dense_cache.rs
+++ b/src/core/src/dense_cache.rs
@@ -2,12 +2,18 @@
 //! hybrid engines.
 //!
 //! [`crate::ToolRegistry`] and [`crate::SkillRegistry`] rank two different item
-//! types (tools, skills) but embed and cosine-rank them identically: a growing
-//! **prefix** of per-item vectors, extended incrementally and never invalidated
-//! on `register`. This type owns that structure and its operations so the two
-//! registries share one implementation instead of two copies that could drift.
-//! The registries keep their own trace-emitting search wrappers, since the trace
-//! event shapes differ (tool vs skill). See ADR-0011.
+//! types (tools, skills) but embed and cosine-rank them identically: an **id-keyed
+//! map** of per-item vectors, extended incrementally. This type owns that
+//! structure and its operations so the two registries share one implementation
+//! instead of two copies that could drift. The registries keep their own
+//! trace-emitting search wrappers, since the trace event shapes differ (tool vs
+//! skill). See ADR-0011.
+//!
+//! Keying by id (not by position) is what lets `register` replace an item in
+//! place: on replace the registry calls [`DenseCache::invalidate`] to drop the
+//! stale vector, and the next [`DenseCache::extend`] re-embeds that id like any
+//! other missing one — so a re-registered id never leaves a stale embedding
+//! behind (RAT-378).
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -24,12 +30,12 @@ pub(crate) trait Embeddable {
     fn embed_text(&self) -> String;
 }
 
-/// Per-item dense vectors, a growing prefix of a registry's corpus.
+/// Per-item dense vectors, keyed by item id.
 pub(crate) struct DenseCache {
-    /// `vectors[i]` is the embedding for the registry's item `i`; any item beyond
-    /// `vectors.len()` is not yet embedded. Only appended to (never invalidated),
-    /// so an existing vector is never recomputed.
-    vectors: Mutex<Vec<Vec<f32>>>,
+    /// `vectors[id]` is the embedding for the registry item with that id; an id
+    /// absent from the map is not yet embedded. [`Self::extend`] fills in the
+    /// missing ids; [`Self::invalidate`] drops one so a replaced item re-embeds.
+    vectors: Mutex<HashMap<String, Vec<f32>>>,
     /// Test-only embedder override (`None` → the shared process bge-small, loaded
     /// lazily on first use). Lets tests inject a deterministic/failing embedder
     /// without touching the network.
@@ -39,7 +45,7 @@ pub(crate) struct DenseCache {
 impl DenseCache {
     pub(crate) fn new() -> Self {
         Self {
-            vectors: Mutex::new(Vec::new()),
+            vectors: Mutex::new(HashMap::new()),
             embedder_override: None,
         }
     }
@@ -47,7 +53,7 @@ impl DenseCache {
     #[cfg(test)]
     pub(crate) fn with_embedder(embedder: Arc<dyn Embedder>) -> Self {
         Self {
-            vectors: Mutex::new(Vec::new()),
+            vectors: Mutex::new(HashMap::new()),
             embedder_override: Some(embedder),
         }
     }
@@ -61,10 +67,18 @@ impl DenseCache {
         }
     }
 
-    /// Error unless the cache covers the whole corpus (`corpus_len` items). A
-    /// semantic/hybrid search never embeds inside the search path — the caller
+    /// Error unless the cache covers the whole corpus (`corpus_len` distinct ids).
+    /// A semantic/hybrid search never embeds inside the search path — the caller
     /// must have built first (a semantic-mode catalog does this at `register`),
     /// so no search silently pays the embedding cost. Loads no model.
+    ///
+    /// The registries key their corpus by id, so `corpus_len` is the number of
+    /// distinct ids and `vectors.len()` is the number of embedded ids; the two
+    /// match exactly once every id is embedded. A re-register that
+    /// [`Self::invalidate`]s an id drops `vectors.len()` below `corpus_len`, so a
+    /// search after churn correctly reports `EmbeddingsNotBuilt` until the next
+    /// [`Self::extend`] — the same "build after registering" contract as a fresh
+    /// register.
     pub(crate) fn require_built(&self, corpus_len: usize) -> Result<(), EmbedderError> {
         let cached = self
             .vectors
@@ -77,24 +91,43 @@ impl DenseCache {
         Ok(())
     }
 
-    /// Embed the items not yet in the cache and append them — the incremental
-    /// core of the prefix cache. Embeds only `items[cache.len()..]`, so an
-    /// already-embedded item is never recomputed (O(k) for k newly-registered
-    /// items). Idempotent: a no-op once the cache is caught up.
-    pub(crate) fn extend<T: Embeddable>(
+    /// Embed any item whose id is not yet cached and insert it by id — the
+    /// incremental core of the cache. Skips ids already present, so an
+    /// already-embedded item is never recomputed (O(k) for k missing ids: newly
+    /// registered *or* invalidated-on-replace). Idempotent: a no-op once every id
+    /// is cached.
+    pub(crate) fn extend<'a, T: Embeddable + 'a>(
         &self,
-        items: &[T],
+        items: impl IntoIterator<Item = &'a T>,
         sink: &dyn TraceSink,
     ) -> Result<(), EmbedderError> {
         let mut guard = self.vectors.lock().expect("embeddings mutex poisoned");
-        if guard.len() >= items.len() {
-            return Ok(());
-        }
-        let embedder = self.resolve_embedder(sink)?;
-        for item in &items[guard.len()..] {
-            guard.push(embedder.embed_doc(&item.embed_text())?);
+        // Resolve the embedder lazily on the first miss, so a fully-cached corpus
+        // never loads the model.
+        let mut embedder: Option<Arc<dyn Embedder>> = None;
+        for item in items {
+            if guard.contains_key(item.embed_id()) {
+                continue;
+            }
+            if embedder.is_none() {
+                embedder = Some(self.resolve_embedder(sink)?);
+            }
+            let vector = embedder
+                .as_ref()
+                .expect("embedder resolved on first miss")
+                .embed_doc(&item.embed_text())?;
+            guard.insert(item.embed_id().to_string(), vector);
         }
         Ok(())
+    }
+
+    /// Drop a cached embedding so the next [`Self::extend`] re-embeds this id.
+    /// Called by a registry's `register` when it replaces an existing id in place.
+    pub(crate) fn invalidate(&self, id: &str) {
+        self.vectors
+            .lock()
+            .expect("embeddings mutex poisoned")
+            .remove(id);
     }
 
     /// Embed a query for cosine ranking (uses the same embedder as
@@ -109,25 +142,26 @@ impl DenseCache {
 
     /// Cosine-rank `query_vec` against the cached vectors, best-first with ties
     /// broken by id. Assumes [`Self::extend`] already ran (`require_built`
-    /// passed). Collapses duplicate ids to the latest embedding (last-wins),
-    /// mirroring the BM25 engine's id-keyed dedup — so a re-registered item (a
-    /// later entry in the prefix) wins.
-    pub(crate) fn ranked<T: Embeddable>(
+    /// passed), so every item's id resolves to a vector; an id missing from the
+    /// cache (shouldn't happen post-`require_built`) is simply skipped. The
+    /// id-keyed corpus holds one entry per id, so there are no duplicates to
+    /// collapse.
+    pub(crate) fn ranked<'a, T: Embeddable + 'a>(
         &self,
-        items: &[T],
+        items: impl IntoIterator<Item = &'a T>,
         query_vec: &[f32],
         depth: usize,
     ) -> Vec<(String, f32)> {
         let guard = self.vectors.lock().expect("embeddings mutex poisoned");
-        let mut latest: HashMap<&str, &[f32]> = HashMap::new();
-        for (item, embedding) in items.iter().zip(guard.iter()) {
-            latest.insert(item.embed_id(), embedding.as_slice());
-        }
-        dense_search(
-            latest.into_iter().map(|(id, v)| (id.to_string(), v)),
-            query_vec,
-            depth,
-        )
+        let docs: Vec<(String, &[f32])> = items
+            .into_iter()
+            .filter_map(|item| {
+                guard
+                    .get(item.embed_id())
+                    .map(|v| (item.embed_id().to_string(), v.as_slice()))
+            })
+            .collect();
+        dense_search(docs, query_vec, depth)
     }
 }
 
@@ -217,14 +251,43 @@ mod tests {
     }
 
     #[test]
-    fn ranked_dedups_duplicate_ids_last_wins() {
-        let cache = DenseCache::with_embedder(Arc::new(CountingStub::new()));
-        // Same id twice: first "read", then "write". The later vector must win.
-        let items = vec![doc("x", "read"), doc("x", "write")];
-        cache.extend(&items, &NoopSink).unwrap();
-        let ranked = cache.ranked(&items, &[0.0, 1.0], 10); // query matches "write"
-        assert_eq!(ranked.len(), 1, "a duplicate id collapses to one entry");
+    fn invalidate_forces_re_embed_of_an_id() {
+        // Replace-in-place path: an id embedded as "read", then invalidated and
+        // re-embedded from "write". The new vector must win — the mechanism a
+        // re-registered tool/skill relies on (RAT-378).
+        let stub = Arc::new(CountingStub::new());
+        let cache = DenseCache::with_embedder(stub.clone());
+        cache.extend([&doc("x", "read")], &NoopSink).unwrap();
+        assert_eq!(stub.docs(), 1);
+
+        cache.invalidate("x");
+        // Re-embed x from its new content; the query matches "write".
+        cache.extend([&doc("x", "write")], &NoopSink).unwrap();
+        assert_eq!(stub.docs(), 2, "invalidated id is re-embedded, once");
+
+        let item = doc("x", "write");
+        let ranked = cache.ranked([&item], &[0.0, 1.0], 10);
+        assert_eq!(ranked.len(), 1);
         assert_eq!(ranked[0].0, "x");
-        assert!(ranked[0].1 > 0.9, "ranks with the last-registered vector");
+        assert!(ranked[0].1 > 0.9, "ranks with the re-embedded vector");
+    }
+
+    #[test]
+    fn require_built_fails_after_invalidate_until_rebuilt() {
+        let cache = DenseCache::with_embedder(Arc::new(CountingStub::new()));
+        let items = vec![doc("a", "read"), doc("b", "write")];
+        cache.extend(&items, &NoopSink).unwrap();
+        assert!(cache.require_built(items.len()).is_ok());
+
+        cache.invalidate("a");
+        assert!(
+            matches!(
+                cache.require_built(items.len()),
+                Err(EmbedderError::EmbeddingsNotBuilt)
+            ),
+            "an invalidated id drops the cache below the corpus until rebuilt"
+        );
+        cache.extend(&items, &NoopSink).unwrap();
+        assert!(cache.require_built(items.len()).is_ok());
     }
 }

--- a/src/core/src/skill_registry.rs
+++ b/src/core/src/skill_registry.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 use std::time::Instant;
 
+use indexmap::IndexMap;
+
 use crate::dense_cache::{DenseCache, Embeddable};
 use crate::embedding::EmbedderError;
 use crate::fusion::{RETRIEVE_DEPTH, RRF_K, rrf_fuse};
@@ -31,9 +33,12 @@ impl Embeddable for Skill {
 /// parallel type keeps the tool path untouched and lets skill telemetry stand on
 /// its own.
 pub struct SkillRegistry {
-    skills: Vec<Skill>,
+    /// Corpus keyed by skill id, in insertion order — the skill-side twin of
+    /// [`crate::ToolRegistry`]'s field. `register` replaces an existing id in
+    /// place, never duplicating it (RAT-378).
+    skills: IndexMap<String, Skill>,
     sink: Arc<dyn TraceSink>,
-    /// Dense embeddings for `skills`, a growing prefix built on demand — the
+    /// Dense embeddings for `skills`, keyed by id and built on demand — the
     /// skill-side twin of [`crate::ToolRegistry`]'s field (see [`DenseCache`]).
     dense: DenseCache,
 }
@@ -47,7 +52,7 @@ impl Default for SkillRegistry {
 impl SkillRegistry {
     pub fn new() -> Self {
         Self {
-            skills: Vec::new(),
+            skills: IndexMap::new(),
             sink: Arc::new(NoopSink),
             dense: DenseCache::new(),
         }
@@ -55,7 +60,7 @@ impl SkillRegistry {
 
     pub fn with_trace_sink(sink: Arc<dyn TraceSink>) -> Self {
         Self {
-            skills: Vec::new(),
+            skills: IndexMap::new(),
             sink,
             dense: DenseCache::new(),
         }
@@ -69,15 +74,29 @@ impl SkillRegistry {
         self.sink.record(event);
     }
 
+    /// Register a skill, or replace one in place if its id is already present —
+    /// see [`crate::ToolRegistry::register`]. Replacing invalidates the old id's
+    /// cached embedding; the corpus never holds a duplicate.
     pub fn register(&mut self, skill: Skill) {
         let skill_id = skill.id.clone();
-        self.skills.push(skill);
-        // Append only — the new skill is embedded by the next `build_embeddings`
-        // (a search never embeds); see [`crate::ToolRegistry::register`].
+        if self.skills.insert(skill_id.clone(), skill).is_some() {
+            // Replaced an existing id: drop its stale embedding.
+            self.dense.invalidate(&skill_id);
+        }
         self.sink.record(TraceEvent::SkillChurn {
             kind: ChurnKind::Add,
             skill_id,
         });
+    }
+
+    /// Number of registered skills (distinct ids).
+    pub fn len(&self) -> usize {
+        self.skills.len()
+    }
+
+    /// Whether no skills are registered.
+    pub fn is_empty(&self) -> bool {
+        self.skills.is_empty()
     }
 
     pub fn search(&self, query: &str, top_k: usize) -> Vec<SkillHit> {
@@ -107,7 +126,7 @@ impl SkillRegistry {
     /// Pre-compute embeddings for not-yet-embedded skills — see
     /// [`crate::ToolRegistry::build_embeddings`].
     pub fn build_embeddings(&self) -> Result<(), EmbedderError> {
-        self.dense.extend(&self.skills, self.sink.as_ref())
+        self.dense.extend(self.skills.values(), self.sink.as_ref())
     }
 
     // ---- engines -----------------------------------------------------------
@@ -116,7 +135,7 @@ impl SkillRegistry {
         let started = Instant::now();
         let hits: Vec<SkillHit> = bm25_search(
             self.skills
-                .iter()
+                .values()
                 .map(|s| (s.id.clone(), searchable_text(s))),
             query,
             top_k,
@@ -155,7 +174,7 @@ impl SkillRegistry {
         self.dense.require_built(self.skills.len())?;
         let query_vec = self.dense.embed_query(query, self.sink.as_ref())?;
         let t = Instant::now();
-        let ranked = self.dense.ranked(&self.skills, &query_vec, top_k);
+        let ranked = self.dense.ranked(self.skills.values(), &query_vec, top_k);
         let stage_ms = t.elapsed().as_millis() as u64;
         let hits: Vec<SkillHit> = ranked
             .into_iter()
@@ -194,7 +213,7 @@ impl SkillRegistry {
         let t = Instant::now();
         let bm25_ranked = bm25_search(
             self.skills
-                .iter()
+                .values()
                 .map(|s| (s.id.clone(), searchable_text(s))),
             query,
             depth,
@@ -208,7 +227,7 @@ impl SkillRegistry {
         self.dense.require_built(self.skills.len())?;
         let t = Instant::now();
         let query_vec = self.dense.embed_query(query, self.sink.as_ref())?;
-        let dense_ranked = self.dense.ranked(&self.skills, &query_vec, depth);
+        let dense_ranked = self.dense.ranked(self.skills.values(), &query_vec, depth);
         let dense_stage = SearchStage {
             name: "dense".into(),
             took_ms: t.elapsed().as_millis() as u64,
@@ -324,7 +343,7 @@ mod tests {
 
     fn with_embedder(embedder: Arc<dyn Embedder>) -> SkillRegistry {
         SkillRegistry {
-            skills: Vec::new(),
+            skills: IndexMap::new(),
             sink: Arc::new(NoopSink),
             dense: DenseCache::with_embedder(embedder),
         }
@@ -373,6 +392,38 @@ mod tests {
     fn search_on_empty_registry_returns_no_hits() {
         let reg = SkillRegistry::new();
         assert!(reg.search("anything", 5).is_empty());
+    }
+
+    #[test]
+    fn re_register_replaces_not_appends() {
+        // Re-registering a skill id replaces it in place — the corpus holds one
+        // entry per id, no duplicate (RAT-378, mirror of the tool path).
+        let mut reg = SkillRegistry::new();
+        reg.register(skill("s", "s", "REST API design", &["api"]));
+        reg.register(skill("s", "s", "HTML slides frontend", &["frontend"]));
+        assert_eq!(reg.len(), 1, "re-register replaces, not appends");
+        let hits = reg.search("html slides frontend", 5);
+        assert_eq!(hits.first().map(|h| h.skill_id.as_str()), Some("s"));
+        assert_eq!(hits.len(), 1, "one id in the corpus yields at most one hit");
+    }
+
+    #[test]
+    fn re_register_updates_the_ranked_vector() {
+        // Replace-in-place invalidates the old embedding; after rebuild a semantic
+        // query for the new content ranks the re-registered skill first.
+        let mut reg = with_embedder(Arc::new(StubEmbedder));
+        reg.register(skill("s", "s", "REST API design", &["api"])); // dense: api bucket
+        reg.build_embeddings().unwrap();
+        reg.register(skill("s", "s", "HTML slides frontend", &["frontend"])); // → frontend bucket
+        reg.build_embeddings().unwrap();
+        let hits = reg
+            .search_with_method("frontend slides", 5, Origin::Direct, SearchMethod::Semantic)
+            .unwrap();
+        assert_eq!(hits.first().map(|h| h.skill_id.as_str()), Some("s"));
+        assert!(
+            hits[0].score > 0.9,
+            "ranks with the re-embedded frontend vector"
+        );
     }
 
     #[test]

--- a/src/core/src/tool_registry.rs
+++ b/src/core/src/tool_registry.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 use std::time::Instant;
 
+use indexmap::IndexMap;
+
 use crate::dense_cache::{DenseCache, Embeddable};
 use crate::embedding::EmbedderError;
 use crate::fusion::{RETRIEVE_DEPTH, RRF_K, rrf_fuse};
@@ -27,10 +29,13 @@ impl Embeddable for Tool {
 }
 
 pub struct ToolRegistry {
-    tools: Vec<Tool>,
+    /// Corpus keyed by tool id, in insertion order. Keying by id makes `register`
+    /// replace an existing id in place (never a duplicate), so the BM25 corpus
+    /// stays one-entry-per-id — no `avgdl` drift, no leak (RAT-378).
+    tools: IndexMap<String, Tool>,
     sink: Arc<dyn TraceSink>,
-    /// Dense embeddings for `tools`, a growing prefix built on demand. `register`
-    /// only appends a tool (never invalidates); the missing tail is embedded by
+    /// Dense embeddings for `tools`, keyed by id and built on demand. `register`
+    /// invalidates a replaced id; the missing ids are embedded by
     /// [`Self::build_embeddings`] — a search never embeds the corpus (it requires
     /// the cache built first). A pure BM25 user never populates it and never loads
     /// the model (see ADR-0011 and [`DenseCache`]).
@@ -46,7 +51,7 @@ impl Default for ToolRegistry {
 impl ToolRegistry {
     pub fn new() -> Self {
         Self {
-            tools: Vec::new(),
+            tools: IndexMap::new(),
             sink: Arc::new(NoopSink),
             dense: DenseCache::new(),
         }
@@ -54,7 +59,7 @@ impl ToolRegistry {
 
     pub fn with_trace_sink(sink: Arc<dyn TraceSink>) -> Self {
         Self {
-            tools: Vec::new(),
+            tools: IndexMap::new(),
             sink,
             dense: DenseCache::new(),
         }
@@ -68,17 +73,31 @@ impl ToolRegistry {
         self.sink.record(event);
     }
 
+    /// Register a tool, or replace one in place if its id is already present.
+    /// Replacing invalidates the old id's cached embedding so the next
+    /// `build_embeddings` re-embeds the new content; the corpus never holds a
+    /// duplicate. Registration stays infallible and model-free (a search never
+    /// embeds), so BM25 users are unaffected (see ADR-0011).
     pub fn register(&mut self, tool: Tool) {
         let tool_id = tool.id.clone();
-        self.tools.push(tool);
-        // Just append — never touch the embeddings cache. The new tool sits
-        // beyond the cached prefix and gets embedded by the next `build_embeddings`
-        // (a search never embeds). Registration stays infallible and model-free,
-        // so BM25 users are unaffected (see ADR-0011).
+        if self.tools.insert(tool_id.clone(), tool).is_some() {
+            // Replaced an existing id: drop its stale embedding.
+            self.dense.invalidate(&tool_id);
+        }
         self.sink.record(TraceEvent::IndexChurn {
             kind: ChurnKind::Add,
             tool_id,
         });
+    }
+
+    /// Number of registered tools (distinct ids).
+    pub fn len(&self) -> usize {
+        self.tools.len()
+    }
+
+    /// Whether no tools are registered.
+    pub fn is_empty(&self) -> bool {
+        self.tools.is_empty()
     }
 
     /// Lexical BM25 retrieval. The default engine — needs no model and never
@@ -118,7 +137,7 @@ impl ToolRegistry {
     /// calls this after `register` in semantic mode so searches never pay the
     /// embedding cost; a BM25-only user never calls it and never loads the model.
     pub fn build_embeddings(&self) -> Result<(), EmbedderError> {
-        self.dense.extend(&self.tools, self.sink.as_ref())
+        self.dense.extend(self.tools.values(), self.sink.as_ref())
     }
 
     // ---- engines -----------------------------------------------------------
@@ -127,7 +146,7 @@ impl ToolRegistry {
         let started = Instant::now();
         let hits: Vec<SearchHit> = bm25_search(
             self.tools
-                .iter()
+                .values()
                 .map(|t| (t.id.clone(), searchable_text(t))),
             query,
             top_k,
@@ -166,7 +185,7 @@ impl ToolRegistry {
         self.dense.require_built(self.tools.len())?;
         let query_vec = self.dense.embed_query(query, self.sink.as_ref())?;
         let t = Instant::now();
-        let ranked = self.dense.ranked(&self.tools, &query_vec, top_k);
+        let ranked = self.dense.ranked(self.tools.values(), &query_vec, top_k);
         let stage_ms = t.elapsed().as_millis() as u64;
         let hits: Vec<SearchHit> = ranked
             .into_iter()
@@ -211,7 +230,7 @@ impl ToolRegistry {
         let t = Instant::now();
         let bm25_ranked = bm25_search(
             self.tools
-                .iter()
+                .values()
                 .map(|t| (t.id.clone(), searchable_text(t))),
             query,
             depth,
@@ -226,7 +245,7 @@ impl ToolRegistry {
         self.dense.require_built(self.tools.len())?;
         let t = Instant::now();
         let query_vec = self.dense.embed_query(query, self.sink.as_ref())?;
-        let dense_ranked = self.dense.ranked(&self.tools, &query_vec, depth);
+        let dense_ranked = self.dense.ranked(self.tools.values(), &query_vec, depth);
         let dense_stage = SearchStage {
             name: "dense".into(),
             took_ms: t.elapsed().as_millis() as u64,
@@ -361,7 +380,7 @@ mod tests {
 
     fn with_embedder(embedder: Arc<dyn Embedder>) -> ToolRegistry {
         ToolRegistry {
-            tools: Vec::new(),
+            tools: IndexMap::new(),
             sink: Arc::new(NoopSink),
             dense: DenseCache::with_embedder(embedder),
         }
@@ -578,13 +597,30 @@ mod tests {
     }
 
     #[test]
+    fn re_register_replaces_not_appends() {
+        // Re-registering an id must REPLACE it in place, not append a duplicate.
+        // A duplicate would inflate the BM25 corpus (avgdl drift, degrading scores
+        // corpus-wide) and leak the old Tool + its embedding. The corpus must hold
+        // exactly one entry per id (RAT-378).
+        let mut reg = ToolRegistry::new();
+        reg.register(tool("shared", "read a file"));
+        reg.register(tool("shared", "delete a file"));
+        assert_eq!(reg.len(), 1, "re-register replaces, not appends");
+        // The single surviving entry ranks with the latest content.
+        let hits = reg.search("delete a file", 5);
+        assert_eq!(hits.first().map(|h| h.tool_id.as_str()), Some("shared"));
+        assert_eq!(hits.len(), 1, "one id in the corpus yields at most one hit");
+    }
+
+    #[test]
     fn re_register_updates_the_ranked_vector() {
-        // Re-registering an id appends a fresh entry; last-wins dedup ranks with
-        // the latest embedding, so the updated content wins.
+        // Re-registering an id replaces it in place and invalidates its cached
+        // embedding; the next build_embeddings re-embeds the new content, so the
+        // updated content wins.
         let mut reg = with_embedder(Arc::new(StubEmbedder));
         reg.register(tool("t", "read a file")); // dense vec keyed on "read"
         reg.build_embeddings().unwrap();
-        reg.register(tool("t", "delete a file")); // re-register → keyed on "delete"
+        reg.register(tool("t", "delete a file")); // re-register → invalidated, keyed on "delete"
         reg.build_embeddings().unwrap();
         let hits = reg
             .search_with_method("delete", 5, Origin::Direct, SearchMethod::Semantic)

--- a/src/core/tests/tool_search.rs
+++ b/src/core/tests/tool_search.rs
@@ -110,6 +110,29 @@ fn re_registering_same_id_replaces_entry() {
     );
     assert_eq!(fresh_hits.len(), 1);
     assert_eq!(fresh_hits[0].tool_id, "shared");
+    // Replace-in-place: the corpus holds exactly one entry for the id, not two.
+    assert_eq!(registry.len(), 1);
+}
+
+#[test]
+fn re_register_keeps_corpus_size_stable() {
+    // Repeatedly re-registering the same id must not grow the corpus — the
+    // RAT-378 regression (a duplicate would drift BM25 avgdl and leak memory).
+    let mut registry = ToolRegistry::new();
+    for i in 0..50 {
+        registry.register(Tool {
+            id: "hot".into(),
+            name: "hot".into(),
+            description: format!("revision {i} of a hot-reloaded tool"),
+            input_schema: empty_schema(),
+            output_schema: empty_schema(),
+        });
+    }
+    assert_eq!(registry.len(), 1, "50 re-registers, one entry");
+    // The single surviving entry ranks once — never a duplicate hit.
+    let hits = registry.search("hot-reloaded tool", 5);
+    assert_eq!(hits.first().map(|h| h.tool_id.as_str()), Some("hot"));
+    assert_eq!(hits.len(), 1);
 }
 
 #[test]

--- a/src/sdk/python/tests/test_catalog.py
+++ b/src/sdk/python/tests/test_catalog.py
@@ -166,3 +166,23 @@ async def test_invoke_emits_error_telemetry_and_reraises() -> None:
     types = [e["type"] for e in events]
     assert types == ["invoke_start", "invoke_error"]
     assert events[1]["error"] == "kaboom"
+
+
+async def test_re_register_replaces_in_place() -> None:
+    # Re-registering an id replaces it in the native corpus, not appends a
+    # duplicate: the id ranks once and the latest executor wins (RAT-378).
+    catalog = ToolCatalog()
+    catalog.register(_read_file_tool(lambda args: {"contents": "v1"}))
+    catalog.register(
+        ExecutableTool(
+            id="read_file",
+            name="read_file",
+            description="Fetch and return a document over the network.",
+            input_schema={"properties": {"path": {"type": "string"}}},
+            output_schema={"properties": {"contents": {"type": "string"}}},
+            execute=lambda args: {"contents": "v2"},
+        )
+    )
+    hits = catalog.search("fetch a document over the network", 10)
+    assert [h.tool_id for h in hits].count("read_file") == 1
+    assert await catalog.invoke("read_file", {"path": "/x"}) == {"contents": "v2"}

--- a/src/sdk/python/tests/test_skill_catalog.py
+++ b/src/sdk/python/tests/test_skill_catalog.py
@@ -49,3 +49,23 @@ def test_minimal_skill_without_tags_or_body() -> None:
     assert catalog.has("min")
     assert catalog.invoke("min") == ""
     assert catalog.search("minimal", 5)[0].skill_id == "min"
+
+
+def test_re_register_replaces_in_place() -> None:
+    # Re-registering an id replaces it in the native corpus, not appends a
+    # duplicate: the id ranks once and the latest metadata wins (RAT-378).
+    catalog = SkillCatalog()
+    catalog.register(Skill(id="s", name="s", description="REST API design", tags=["api"]))
+    catalog.register(
+        Skill(
+            id="s",
+            name="s",
+            description="Build animation-rich HTML presentations from scratch.",
+            tags=["frontend"],
+            body="# Slides\n\nUpdated body.",
+        )
+    )
+    assert catalog.size() == 1
+    hits = catalog.search("animation-rich HTML presentations", 10)
+    assert [h.skill_id for h in hits].count("s") == 1
+    assert catalog.get("s").body == "# Slides\n\nUpdated body."

--- a/src/sdk/ts/src/catalog.test.ts
+++ b/src/sdk/ts/src/catalog.test.ts
@@ -212,4 +212,24 @@ describe("ToolCatalog tracing", () => {
     const search = events.find((e) => e.type === "search");
     expect(search?.origin).toBe("agent");
   });
+
+  it("re-registering an id replaces it in place — one hit, latest content wins", async () => {
+    const catalog = new ToolCatalog();
+    catalog.register({
+      ...readFile,
+      description: "Read a file from local disk.",
+      execute: async () => ({ contents: "v1" }),
+    });
+    catalog.register({
+      ...readFile,
+      description: "Fetch and return a document over the network.",
+      execute: async () => ({ contents: "v2" }),
+    });
+
+    // Native corpus is deduped by id: the id ranks once, not twice (RAT-378).
+    const hits = catalog.search("fetch a document over the network", 10);
+    expect(hits.filter((h) => h.toolId === "read_file")).toHaveLength(1);
+    // The latest executor wins.
+    expect(await catalog.invoke("read_file", { path: "/x" })).toEqual({ contents: "v2" });
+  });
 });

--- a/src/sdk/ts/src/skill-catalog.test.ts
+++ b/src/sdk/ts/src/skill-catalog.test.ts
@@ -101,4 +101,20 @@ describe("SkillCatalog tracing", () => {
     expect(invoke?.skill_id).toBe("api-design");
     expect(typeof invoke?.took_ms).toBe("number");
   });
+
+  it("re-registering an id replaces it in place — one hit, latest body wins", () => {
+    const catalog = new SkillCatalog();
+    catalog.register(apiDesign);
+    catalog.register({
+      ...apiDesign,
+      description: "Build animation-rich HTML presentations from scratch.",
+      body: "# Slides\n\nUpdated body.",
+    });
+
+    // Native corpus is deduped by id: the id ranks once, not twice (RAT-378).
+    const hits = catalog.search("animation-rich HTML presentations", 10);
+    expect(hits.filter((h) => h.skillId === "api-design")).toHaveLength(1);
+    // The latest metadata wins.
+    expect(catalog.get("api-design")?.body).toBe("# Slides\n\nUpdated body.");
+  });
 });


### PR DESCRIPTION
Registries appended on every register, so re-registering an id (MCP re-sync, hot-reload) left a stale duplicate in the corpus: BM25 avgdl drift degrading scores corpus-wide, plus an unbounded memory leak. The duplicate was invisible because bm25 and the dense cache deduped by id on output.

Key both registries by id (IndexMap) so register replaces in place, and make DenseCache id-keyed with an invalidate(id) the registry calls on replace, so build_embeddings re-embeds the changed id like any missing one. Adds len()/is_empty() as the observable corpus-size hook.

SDKs need no change — their id-keyed shadow maps already deduped; the core now matches them. Parity tests added.