### PR TITLE
docs: document the in-repo API surface (rustdoc, TSDoc, docstrings)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,12 +123,15 @@ importers:
       '@opentelemetry/sdk-trace-base':
         specifier: ^2.9.0
         version: 2.9.0(@opentelemetry/api@1.9.1)
+      typedoc:
+        specifier: ^0.28.20
+        version: 0.28.20(typescript@5.9.3)
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
 
   src/telemetry/ts:
     devDependencies:
@@ -152,7 +155,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
 
   src/telemetry/ts-otlp:
     dependencies:
@@ -186,7 +189,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
 
@@ -433,6 +436,9 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@gerrit0/mini-shiki@3.23.0':
+    resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -1175,6 +1181,21 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
+
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1190,11 +1211,17 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
@@ -1257,12 +1284,20 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
+
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
+    engines: {node: 18 || 20 || >=22}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1357,6 +1392,10 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -1605,12 +1644,25 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
+
+  lunr@2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  markdown-it@14.3.0:
+    resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -1627,6 +1679,10 @@ packages:
   mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1694,6 +1750,10 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
@@ -1821,10 +1881,20 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  typedoc@0.28.20:
+    resolution: {integrity: sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==}
+    engines: {node: '>= 18', pnpm: '>= 10'}
+    hasBin: true
+    peerDependencies:
+      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
@@ -1936,6 +2006,11 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -2099,6 +2174,14 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.7':
     optional: true
+
+  '@gerrit0/mini-shiki@3.23.0':
+    dependencies:
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
 
   '@hono/node-server@1.19.14(hono@4.12.16)':
     dependencies:
@@ -2715,6 +2798,26 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.1':
@@ -2731,11 +2834,17 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/json-schema@7.0.15': {}
 
   '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/unist@3.0.3': {}
 
   '@vercel/oidc@3.2.0': {}
 
@@ -2748,13 +2857,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -2808,6 +2917,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  balanced-match@4.0.4: {}
+
   before-after-hook@4.0.0: {}
 
   body-parser@2.2.2:
@@ -2823,6 +2934,10 @@ snapshots:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  brace-expansion@5.0.7:
+    dependencies:
+      balanced-match: 4.0.4
 
   bytes@3.1.2: {}
 
@@ -2888,6 +3003,8 @@ snapshots:
   emnapi@1.10.0: {}
 
   encodeurl@2.0.0: {}
+
+  entities@4.5.0: {}
 
   es-define-property@1.0.1: {}
 
@@ -3141,11 +3258,28 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
+
+  lunr@2.3.9: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-it@14.3.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.2
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   math-intrinsics@1.1.0: {}
+
+  mdurl@2.0.0: {}
 
   media-typer@1.1.0: {}
 
@@ -3156,6 +3290,10 @@ snapshots:
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.7
 
   ms@2.1.3: {}
 
@@ -3203,6 +3341,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  punycode.js@2.3.1: {}
 
   qs@6.15.1:
     dependencies:
@@ -3360,7 +3500,18 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
+  typedoc@0.28.20(typescript@5.9.3):
+    dependencies:
+      '@gerrit0/mini-shiki': 3.23.0
+      lunr: 2.3.9
+      markdown-it: 14.3.0
+      minimatch: 10.2.5
+      typescript: 5.9.3
+      yaml: 2.9.0
+
   typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
 
   undici-types@7.16.0: {}
 
@@ -3370,7 +3521,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0):
+  vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -3382,11 +3533,12 @@ snapshots:
       esbuild: 0.27.7
       fsevents: 2.3.3
       tsx: 4.21.0
+      yaml: 2.9.0
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -3403,7 +3555,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -3421,6 +3573,8 @@ snapshots:
       stackback: 0.0.2
 
   wrappy@1.0.2: {}
+
+  yaml@2.9.0: {}
 
   zod-to-json-schema@3.25.2(zod@4.4.1):
     dependencies:

--- a/src/core/src/embedding.rs
+++ b/src/core/src/embedding.rs
@@ -58,15 +58,31 @@ const SLOW_LOAD_REASON: &str = "embedding model load was slow — this machine m
 pub enum EmbedderError {
     /// Model files could not be fetched: offline, DNS/TLS, timeout, or the
     /// pinned revision returned a 4xx.
-    Download { model: String, source: String },
+    Download {
+        /// The embedding model's HuggingFace repo id.
+        model: String,
+        /// The underlying fetch error.
+        source: String,
+    },
     /// The HuggingFace cache could not be written: permissions, disk full, or a
     /// read-only filesystem.
-    CacheUnwritable { source: String },
+    CacheUnwritable {
+        /// The underlying filesystem error.
+        source: String,
+    },
     /// The fetched model is unusable: corrupt weights, or a config/tokenizer that
     /// failed to parse.
-    Load { model: String, source: String },
+    Load {
+        /// The embedding model's HuggingFace repo id.
+        model: String,
+        /// The underlying load error.
+        source: String,
+    },
     /// Embedding a specific text failed (tokenization or the forward pass).
-    Inference { source: String },
+    Inference {
+        /// The underlying tokenizer/inference error.
+        source: String,
+    },
     /// A semantic/hybrid search was requested but the embedding cache is not
     /// built for the current corpus — `build_embeddings` was never run. No model
     /// is loaded; the caller must build the embeddings first.

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -1,6 +1,77 @@
-//! `ratel-ai-core` — the Rust core of Ratel.
+//! Tool and skill retrieval for AI agents — the Rust core of the Ratel
+//! context engineering platform.
 //!
-//! See `README.md` and `docs/adr/` for design.
+//! Agents degrade when every tool definition is stuffed into the context
+//! window. This crate keeps the full catalog *outside* the context and
+//! retrieves only the entries relevant to the task at hand: register tools
+//! and skills once, then search them per turn. Everything runs in-process —
+//! no server, no infrastructure.
+//!
+//! # Mental model
+//!
+//! Two registries hold the corpus, one per capability kind:
+//!
+//! - [`ToolRegistry`] indexes [`Tool`]s — callable endpoints described by a
+//!   name, a description, and JSON schemas.
+//! - [`SkillRegistry`] indexes [`Skill`]s — reusable instruction playbooks
+//!   whose body is dispatched on demand.
+//!
+//! Both rank a query with one of three engines, selected by [`SearchMethod`]:
+//!
+//! - [`SearchMethod::Bm25`] (default) — lexical BM25. Needs no model and
+//!   never fails; [`ToolRegistry::search`] and [`SkillRegistry::search`] use
+//!   it unconditionally.
+//! - [`SearchMethod::Semantic`] — cosine similarity over dense embeddings
+//!   from a local `bge-small-en-v1.5` model, downloaded into the HuggingFace
+//!   cache on first use (ADR-0011).
+//! - [`SearchMethod::Hybrid`] — the BM25 and dense rankings fused with
+//!   Reciprocal Rank Fusion.
+//!
+//! Semantic and hybrid searches rank against an embedding cache built by
+//! [`ToolRegistry::build_embeddings`] / [`SkillRegistry::build_embeddings`];
+//! a search itself never embeds the corpus and never downloads the model.
+//!
+//! Every register and search also emits a [`TraceEvent`] on the registry's
+//! [`TraceSink`] — the local trace stream behind the inspector and usage
+//! reporting (ADR-0007). The default sink is [`NoopSink`] (discard);
+//! [`MemorySink`] buffers for tests and introspection, [`JsonlSink`] appends
+//! to a local file.
+//!
+//! # Example: register and search (BM25)
+//!
+//! ```
+//! use ratel_ai_core::{Tool, ToolRegistry};
+//!
+//! let mut registry = ToolRegistry::new();
+//! registry.register(Tool {
+//!     id: "read_file".into(),
+//!     name: "read_file".into(),
+//!     description: "Read a file from disk".into(),
+//!     input_schema: serde_json::json!({
+//!         "properties": {
+//!             "path": { "type": "string", "description": "absolute path" }
+//!         }
+//!     }),
+//!     output_schema: serde_json::json!({}),
+//! });
+//! registry.register(Tool {
+//!     id: "send_email".into(),
+//!     name: "send_email".into(),
+//!     description: "Send an email to a recipient".into(),
+//!     input_schema: serde_json::json!({}),
+//!     output_schema: serde_json::json!({}),
+//! });
+//!
+//! let hits = registry.search("read a file", 5);
+//! assert_eq!(hits[0].tool_id, "read_file");
+//! ```
+//!
+//! The language SDKs (`@ratel-ai/sdk` on npm, `ratel-ai` on PyPI) bundle this
+//! crate and surface the same model; the agent-facing capability tools
+//! (`search_capabilities` / `invoke_tool` / `get_skill_content`) sit on top
+//! of them. Design rationale lives in the repo's `docs/adr/`.
+
+#![warn(missing_docs)]
 
 mod dense_cache;
 mod dense_search;

--- a/src/core/src/method.rs
+++ b/src/core/src/method.rs
@@ -60,6 +60,23 @@ impl std::error::Error for ParseSearchMethodError {}
 impl FromStr for SearchMethod {
     type Err = ParseSearchMethodError;
 
+    /// Parse the SDK identifier: `"bm25"`, `"semantic"` (with `"dense"`
+    /// accepted as an alias), or `"hybrid"`.
+    ///
+    /// # Errors
+    ///
+    /// Any other string is a [`ParseSearchMethodError`] naming the rejected
+    /// input.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ratel_ai_core::SearchMethod;
+    ///
+    /// assert_eq!("hybrid".parse::<SearchMethod>(), Ok(SearchMethod::Hybrid));
+    /// assert_eq!("dense".parse::<SearchMethod>(), Ok(SearchMethod::Semantic));
+    /// assert!("keyword".parse::<SearchMethod>().is_err());
+    /// ```
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "bm25" => Ok(SearchMethod::Bm25),

--- a/src/core/src/skill.rs
+++ b/src/core/src/skill.rs
@@ -2,23 +2,36 @@ use std::collections::HashMap;
 
 /// A skill registered for retrieval — the on-demand analog of a [`crate::Tool`].
 ///
-/// `name`, `description`, and `tags` drive ranking (see [`crate::skill_indexing`]).
-/// `tags` are author-declared labels and task phrases ("frontend", "login form")
-/// folded into the BM25 text so a terse intent prompt matches the skill. `tools`
-/// are the ids of tools the body's instructions call — an explicit dependency
-/// edge, **not** indexed; `search_capabilities` pulls them into its tools
-/// bucket so the agent gets a skill and the tools it needs in one turn
-/// instead of a second search. `metadata` is free-form, non-indexed context for
-/// higher layers — e.g. `{"stacks": ["react"]}` for the push-path ranker to
-/// boost/filter by project context, deliberately *not* matched as query terms.
-/// `body` is the dispatch payload and is also not indexed, so a long body never
-/// skews relevance.
+/// `name`, `description`, and `tags` drive ranking (they are folded into the
+/// searchable text). `tags` are author-declared labels and task phrases
+/// ("frontend", "login form") folded into the BM25 text so a terse intent
+/// prompt matches the skill. `tools` are the ids of tools the body's
+/// instructions call — an explicit dependency edge, **not** indexed;
+/// `search_capabilities` pulls them into its tools bucket so the agent gets a
+/// skill and the tools it needs in one turn instead of a second search.
+/// `metadata` is free-form, non-indexed context for higher layers — e.g.
+/// `{"stacks": ["react"]}` for the push-path ranker to boost/filter by project
+/// context, deliberately *not* matched as query terms. `body` is the dispatch
+/// payload and is also not indexed, so a long body never skews relevance.
 pub struct Skill {
+    /// Stable identifier, returned in [`crate::SkillHit::skill_id`].
+    /// Registering the same id again replaces the entry in place. Not indexed
+    /// for ranking.
     pub id: String,
+    /// Skill name. Indexed both verbatim and space-split, so
+    /// snake_case/camelCase/kebab constituent words match.
     pub name: String,
+    /// What the skill is for — the primary ranking text.
     pub description: String,
+    /// Author-declared labels and task phrases, indexed alongside the
+    /// description.
     pub tags: Vec<String>,
+    /// Ids of tools the body's instructions call — a dependency edge for
+    /// higher layers, not indexed.
     pub tools: Vec<String>,
+    /// Free-form, non-indexed context for higher layers (push-path
+    /// boosting/filtering); never matched as query terms.
     pub metadata: HashMap<String, Vec<String>>,
+    /// The skill's full instructions — the dispatch payload, not indexed.
     pub body: String,
 }

--- a/src/core/src/skill_registry.rs
+++ b/src/core/src/skill_registry.rs
@@ -14,8 +14,16 @@ use crate::trace::{
     ChurnKind, NoopSink, Origin, SearchStage, SkillHitTrace, TraceEvent, TraceSink,
 };
 
+/// One ranked match from a [`SkillRegistry`] search, best-first in the
+/// returned `Vec` — the skill-side twin of [`crate::SearchHit`].
 pub struct SkillHit {
+    /// Id of the matching skill ([`Skill::id`]).
     pub skill_id: String,
+    /// Relevance score — higher is better; the scale depends on the
+    /// [`SearchMethod`] exactly as documented on [`crate::SearchHit::score`]:
+    /// raw BM25 relevance for `Bm25`, cosine similarity (at most `1.0`) for
+    /// `Semantic`, a Reciprocal Rank Fusion sum for `Hybrid`. Ties break by
+    /// `skill_id` ascending.
     pub score: f32,
 }
 
@@ -50,6 +58,8 @@ impl Default for SkillRegistry {
 }
 
 impl SkillRegistry {
+    /// An empty registry with tracing off ([`NoopSink`]) — see
+    /// [`crate::ToolRegistry::new`].
     pub fn new() -> Self {
         Self {
             skills: IndexMap::new(),
@@ -58,6 +68,8 @@ impl SkillRegistry {
         }
     }
 
+    /// An empty registry recording trace events to `sink` from the start —
+    /// see [`crate::ToolRegistry::with_trace_sink`].
     pub fn with_trace_sink(sink: Arc<dyn TraceSink>) -> Self {
         Self {
             skills: IndexMap::new(),
@@ -66,10 +78,15 @@ impl SkillRegistry {
         }
     }
 
+    /// Replace the trace sink; subsequent events go to `sink` — see
+    /// [`crate::ToolRegistry::set_trace_sink`].
     pub fn set_trace_sink(&mut self, sink: Arc<dyn TraceSink>) {
         self.sink = sink;
     }
 
+    /// Record an arbitrary [`TraceEvent`] on the registry's sink — see
+    /// [`crate::ToolRegistry::record_event`]. The SDK skill catalogs emit
+    /// their `skill_invoke` (content-load) events through this.
     pub fn record_event(&self, event: TraceEvent) {
         self.sink.record(event);
     }
@@ -99,15 +116,47 @@ impl SkillRegistry {
         self.skills.is_empty()
     }
 
+    /// Lexical BM25 retrieval — the skill-side twin of
+    /// [`crate::ToolRegistry::search`]: no model, never fails. Returns at most
+    /// `top_k` hits, best-first (see [`SkillHit::score`]). Traced as
+    /// [`Origin::Direct`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ratel_ai_core::{Skill, SkillRegistry};
+    ///
+    /// let mut registry = SkillRegistry::new();
+    /// registry.register(Skill {
+    ///     id: "api-design".into(),
+    ///     name: "api-design".into(),
+    ///     description: "REST API design patterns: resource naming, pagination".into(),
+    ///     tags: vec!["backend".into(), "api".into()],
+    ///     tools: vec![],
+    ///     metadata: std::collections::HashMap::new(),
+    ///     body: "# API design\n...".into(),
+    /// });
+    ///
+    /// let hits = registry.search("design a REST endpoint", 5);
+    /// assert_eq!(hits[0].skill_id, "api-design");
+    /// ```
     pub fn search(&self, query: &str, top_k: usize) -> Vec<SkillHit> {
         self.search_with_origin(query, top_k, Origin::Direct)
     }
 
+    /// [`Self::search`] with an explicit trace [`Origin`] — see
+    /// [`crate::ToolRegistry::search_with_origin`].
     pub fn search_with_origin(&self, query: &str, top_k: usize, origin: Origin) -> Vec<SkillHit> {
         self.bm25_search_traced(query, top_k, origin)
     }
 
     /// Retrieve with an explicit [`SearchMethod`]. See
+    /// [`crate::ToolRegistry::search_with_method`].
+    ///
+    /// # Errors
+    ///
+    /// Never errors for [`SearchMethod::Bm25`]; for `Semantic`/`Hybrid`, the
+    /// same [`EmbedderError`] cases as
     /// [`crate::ToolRegistry::search_with_method`].
     pub fn search_with_method(
         &self,
@@ -125,6 +174,12 @@ impl SkillRegistry {
 
     /// Pre-compute embeddings for not-yet-embedded skills — see
     /// [`crate::ToolRegistry::build_embeddings`].
+    ///
+    /// # Errors
+    ///
+    /// The same [`EmbedderError`] cases as
+    /// [`crate::ToolRegistry::build_embeddings`]: model download/cache/load
+    /// failures on first use, or an `Inference` failure embedding a skill.
     pub fn build_embeddings(&self) -> Result<(), EmbedderError> {
         self.dense.extend(self.skills.values(), self.sink.as_ref())
     }

--- a/src/core/src/tool.rs
+++ b/src/core/src/tool.rs
@@ -1,7 +1,26 @@
+/// A tool registered for retrieval — one entry in a [`crate::ToolRegistry`]
+/// corpus.
+///
+/// `name`, `description`, and the two schemas drive ranking: they are
+/// flattened into the searchable text (identifiers are additionally
+/// space-split so `read_file` also matches "read" and "file"; from the
+/// schemas, property names, property descriptions, and enum values are
+/// indexed — structural JSON keywords are not). `id` is the stable key hits
+/// carry back and is not itself indexed.
 pub struct Tool {
+    /// Stable identifier, returned in [`crate::SearchHit::tool_id`].
+    /// Registering the same id again replaces the entry in place. Not indexed
+    /// for ranking.
     pub id: String,
+    /// Model-facing tool name (e.g. `read_file`). Indexed both verbatim and
+    /// space-split, so snake_case/camelCase constituent words match.
     pub name: String,
+    /// What the tool does — the primary ranking text.
     pub description: String,
+    /// JSON Schema of the tool's arguments. Property names, property
+    /// descriptions, and enum values are folded into the searchable text.
     pub input_schema: serde_json::Value,
+    /// JSON Schema of the tool's result, indexed the same way as
+    /// [`Self::input_schema`].
     pub output_schema: serde_json::Value,
 }

--- a/src/core/src/tool_registry.rs
+++ b/src/core/src/tool_registry.rs
@@ -14,8 +14,25 @@ use crate::trace::{
     ChurnKind, NoopSink, Origin, SearchHitTrace, SearchStage, TraceEvent, TraceSink,
 };
 
+/// One ranked match from a [`ToolRegistry`] search, best-first in the
+/// returned `Vec`.
 pub struct SearchHit {
+    /// Id of the matching tool ([`Tool::id`]).
     pub tool_id: String,
+    /// Relevance score — higher is better, and the scale depends on the
+    /// [`SearchMethod`] that produced the hit:
+    ///
+    /// - `Bm25`: raw BM25 relevance (non-negative, unbounded; `k1=0.9`,
+    ///   `b=0.4`, tuned for short tool text per ADR-0004).
+    /// - `Semantic`: cosine similarity of the L2-normalized query and
+    ///   document embeddings (at most `1.0`).
+    /// - `Hybrid`: the Reciprocal Rank Fusion sum `Σ 1/(60 + rank)` over the
+    ///   BM25 and dense rankings — with two arms at most `2/60 ≈ 0.033`, so
+    ///   only the ordering is meaningful, not the magnitude.
+    ///
+    /// Scores are comparable within one result list, not across methods or
+    /// corpora. Ties are broken by `tool_id` ascending, so ordering is
+    /// deterministic across processes.
     pub score: f32,
 }
 
@@ -28,6 +45,22 @@ impl Embeddable for Tool {
     }
 }
 
+/// Retrieval index over [`Tool`]s — the registry behind the SDKs' tool
+/// catalogs.
+///
+/// Tools are [`Self::register`]ed into an id-keyed corpus (re-registering an
+/// id replaces it in place) and ranked by one of three engines selected per
+/// call via [`SearchMethod`]. The plain [`Self::search`] path is lexical BM25:
+/// infallible, model-free, ready as soon as tools are registered. Semantic
+/// and hybrid go through [`Self::search_with_method`] and require
+/// [`Self::build_embeddings`] first — a search never embeds the corpus (see
+/// ADR-0011).
+///
+/// Every register and search emits a [`TraceEvent`] on the registry's
+/// [`TraceSink`] ([`NoopSink`] by default). [`SkillRegistry`] is the
+/// skill-side twin with the same shape.
+///
+/// [`SkillRegistry`]: crate::SkillRegistry
 pub struct ToolRegistry {
     /// Corpus keyed by tool id, in insertion order. Keying by id makes `register`
     /// replace an existing id in place (never a duplicate), so the BM25 corpus
@@ -49,6 +82,8 @@ impl Default for ToolRegistry {
 }
 
 impl ToolRegistry {
+    /// An empty registry with tracing off ([`NoopSink`]); attach a real sink
+    /// later with [`Self::set_trace_sink`].
     pub fn new() -> Self {
         Self {
             tools: IndexMap::new(),
@@ -57,6 +92,7 @@ impl ToolRegistry {
         }
     }
 
+    /// An empty registry recording trace events to `sink` from the start.
     pub fn with_trace_sink(sink: Arc<dyn TraceSink>) -> Self {
         Self {
             tools: IndexMap::new(),
@@ -65,10 +101,16 @@ impl ToolRegistry {
         }
     }
 
+    /// Replace the trace sink; subsequent register/search/`record_event`
+    /// events go to `sink`. Already-recorded events are not replayed.
     pub fn set_trace_sink(&mut self, sink: Arc<dyn TraceSink>) {
         self.sink = sink;
     }
 
+    /// Record an arbitrary [`TraceEvent`] on the registry's sink. Higher
+    /// layers (the SDK catalogs and capability tools) use this to emit their
+    /// invoke/upstream/auth lifecycle events into the same stream as the
+    /// registry's own search and churn events (ADR-0007).
     pub fn record_event(&self, event: TraceEvent) {
         self.sink.record(event);
     }
@@ -78,6 +120,25 @@ impl ToolRegistry {
     /// `build_embeddings` re-embeds the new content; the corpus never holds a
     /// duplicate. Registration stays infallible and model-free (a search never
     /// embeds), so BM25 users are unaffected (see ADR-0011).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ratel_ai_core::{Tool, ToolRegistry};
+    ///
+    /// let tool = |desc: &str| Tool {
+    ///     id: "read_file".into(),
+    ///     name: "read_file".into(),
+    ///     description: desc.into(),
+    ///     input_schema: serde_json::json!({}),
+    ///     output_schema: serde_json::json!({}),
+    /// };
+    ///
+    /// let mut registry = ToolRegistry::new();
+    /// registry.register(tool("Read a file"));
+    /// registry.register(tool("Read a file from disk")); // same id: replaced
+    /// assert_eq!(registry.len(), 1);
+    /// ```
     pub fn register(&mut self, tool: Tool) {
         let tool_id = tool.id.clone();
         if self.tools.insert(tool_id.clone(), tool).is_some() {
@@ -103,10 +164,34 @@ impl ToolRegistry {
     /// Lexical BM25 retrieval. The default engine — needs no model and never
     /// fails, so the public `search`/`search_with_origin` stay infallible and
     /// byte-for-byte compatible with the BM25-only releases.
+    ///
+    /// Returns at most `top_k` hits, best-first (see [`SearchHit::score`] for
+    /// the score semantics). Traced as [`Origin::Direct`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ratel_ai_core::{Tool, ToolRegistry};
+    ///
+    /// let mut registry = ToolRegistry::new();
+    /// registry.register(Tool {
+    ///     id: "read_file".into(),
+    ///     name: "read_file".into(),
+    ///     description: "Read a file from disk".into(),
+    ///     input_schema: serde_json::json!({}),
+    ///     output_schema: serde_json::json!({}),
+    /// });
+    ///
+    /// let hits = registry.search("read a file", 5);
+    /// assert_eq!(hits[0].tool_id, "read_file");
+    /// ```
     pub fn search(&self, query: &str, top_k: usize) -> Vec<SearchHit> {
         self.search_with_origin(query, top_k, Origin::Direct)
     }
 
+    /// [`Self::search`] with an explicit trace [`Origin`], so consumers of the
+    /// trace stream can tell agent-synthesized searches from direct library
+    /// calls. Same BM25 engine, same infallibility.
     pub fn search_with_origin(&self, query: &str, top_k: usize, origin: Origin) -> Vec<SearchHit> {
         self.bm25_search_traced(query, top_k, origin)
     }
@@ -117,6 +202,39 @@ impl ToolRegistry {
     /// the model or embed the corpus in-search (the model loads at
     /// `build_embeddings`). The SDK layer picks the method (a per-catalog default or
     /// a per-call override) and calls this.
+    ///
+    /// # Errors
+    ///
+    /// Never errors for [`SearchMethod::Bm25`]. For `Semantic` and `Hybrid`:
+    /// [`EmbedderError::EmbeddingsNotBuilt`] when the cache does not cover the
+    /// corpus (call [`Self::build_embeddings`] after registering), or any
+    /// other [`EmbedderError`] from loading the model / embedding the query.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ratel_ai_core::{Origin, SearchMethod, Tool, ToolRegistry};
+    /// # fn main() -> Result<(), ratel_ai_core::EmbedderError> {
+    /// let mut registry = ToolRegistry::new();
+    /// registry.register(Tool {
+    ///     id: "delete_file".into(),
+    ///     name: "delete_file".into(),
+    ///     description: "Delete a path from the filesystem".into(),
+    ///     input_schema: serde_json::json!({}),
+    ///     output_schema: serde_json::json!({}),
+    /// });
+    /// registry.build_embeddings()?; // loads the model on first use
+    ///
+    /// // Lexically unrelated query, semantically close:
+    /// let hits = registry.search_with_method(
+    ///     "remove a document",
+    ///     5,
+    ///     Origin::Direct,
+    ///     SearchMethod::Semantic,
+    /// )?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn search_with_method(
         &self,
         query: &str,
@@ -136,6 +254,14 @@ impl ToolRegistry {
     /// Incremental — embeds only tools registered since the last call. The SDK
     /// calls this after `register` in semantic mode so searches never pay the
     /// embedding cost; a BM25-only user never calls it and never loads the model.
+    ///
+    /// # Errors
+    ///
+    /// Any [`EmbedderError`] from the embedding model: `Download` /
+    /// `CacheUnwritable` / `Load` on the first-use model fetch (network, cache
+    /// permissions, corrupt weights — see ADR-0011), or `Inference` if
+    /// embedding a tool's text fails. A failed load is not cached, so a later
+    /// call retries once the cause clears.
     pub fn build_embeddings(&self) -> Result<(), EmbedderError> {
         self.dense.extend(self.tools.values(), self.sink.as_ref())
     }

--- a/src/core/src/trace/event.rs
+++ b/src/core/src/trace/event.rs
@@ -7,14 +7,23 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Origin {
+    /// A direct API call — SDK helpers, library callers, benchmarks. Wire
+    /// value `direct`.
     Direct,
+    /// A call the agent synthesized inside its loop, via the capability
+    /// tools. Wire value `agent`.
     Agent,
 }
 
+/// How a registry corpus changed — carried by [`TraceEvent::IndexChurn`]
+/// (tools) and [`TraceEvent::SkillChurn`] (skills).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ChurnKind {
+    /// An item was registered — including a replace-in-place re-register of
+    /// an existing id. Wire value `add`.
     Add,
+    /// An item was removed from the corpus. Wire value `remove`.
     Remove,
 }
 
@@ -24,136 +33,264 @@ pub enum ChurnKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EmbedderLoadStatus {
+    /// The model loaded within the expected budget. Wire value `ok`.
     Ok,
+    /// The model loaded, but slowly — the machine may be underpowered for it.
+    /// Wire value `slow`.
     Slow,
+    /// The load errored (network, cache, corrupt weights); the accompanying
+    /// `reason` carries the error. Wire value `failed`.
     Failed,
 }
 
+/// One ranked tool hit inside a [`TraceEvent::Search`] event.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SearchHitTrace {
+    /// Id of the matching tool.
     pub tool_id: String,
+    /// The engine score, widened to `f64` — same per-method semantics as
+    /// [`crate::SearchHit::score`].
     pub score: f64,
 }
 
+/// Timing and top score of one engine stage of a search. BM25 searches emit
+/// one `bm25` stage, semantic searches one `dense` stage; hybrid emits
+/// `bm25`, `dense`, and `rrf`, in that order. Semantic and hybrid searches
+/// that short-circuit on an empty corpus or `top_k == 0` emit no stages.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SearchStage {
+    /// Stage name: `"bm25"`, `"dense"`, or `"rrf"`.
     pub name: String,
+    /// Stage wall time, in milliseconds.
     pub took_ms: u64,
+    /// Best score the stage produced (that stage's scale); `None` when it
+    /// returned no hits.
     pub top_score: Option<f64>,
 }
 
+/// One ranked skill hit inside a [`TraceEvent::SkillSearch`] event — the
+/// skill-side twin of [`SearchHitTrace`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SkillHitTrace {
+    /// Id of the matching skill.
     pub skill_id: String,
+    /// The engine score, widened to `f64` — same per-method semantics as
+    /// [`crate::SkillHit::score`].
     pub score: f64,
 }
 
 /// Every event produced by any layer of Ratel. New variants are additive;
 /// renames or removals are breaking — see ADR-0007.
+///
+/// On the wire each event is a JSON object whose `type` tag is the variant
+/// name in snake_case (`IndexChurn` → `index_churn`), with the variant's
+/// fields flattened beside it; sinks wrap it in a [`TraceEnvelope`]. All
+/// `took_ms` fields are wall time in milliseconds.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TraceEvent {
+    /// A [`crate::ToolRegistry`] search completed (any [`crate::SearchMethod`]).
+    /// Carries the query, the requested `top_k`, the ranked `hits` with
+    /// scores, the per-engine `stages` timings, and the total wall time.
     Search {
+        /// The search text.
         query: String,
+        /// Direct library call vs agent-synthesized.
         origin: Origin,
+        /// Requested result count.
         top_k: u32,
+        /// The ranked results, best-first.
         hits: Vec<SearchHitTrace>,
+        /// Per-engine stage timings (`bm25` / `dense` / `rrf`).
         stages: Vec<SearchStage>,
+        /// Total search wall time, in milliseconds.
         took_ms: u64,
     },
+    /// The tool corpus changed: [`crate::ToolRegistry::register`] emits this
+    /// with [`ChurnKind::Add`] for both a fresh registration and a
+    /// replace-in-place re-register.
     IndexChurn {
+        /// Whether the id was added or removed.
         kind: ChurnKind,
+        /// Id of the affected tool.
         tool_id: String,
     },
+    /// A [`crate::SkillRegistry`] search completed — the skill-side twin of
+    /// [`TraceEvent::Search`], with the same shape.
     SkillSearch {
+        /// The search text.
         query: String,
+        /// Direct library call vs agent-synthesized.
         origin: Origin,
+        /// Requested result count.
         top_k: u32,
+        /// The ranked results, best-first.
         hits: Vec<SkillHitTrace>,
+        /// Per-engine stage timings (`bm25` / `dense` / `rrf`).
         stages: Vec<SearchStage>,
+        /// Total search wall time, in milliseconds.
         took_ms: u64,
     },
+    /// The skill corpus changed — the skill-side twin of
+    /// [`TraceEvent::IndexChurn`], emitted by [`crate::SkillRegistry::register`].
     SkillChurn {
+        /// Whether the id was added or removed.
         kind: ChurnKind,
+        /// Id of the affected skill.
         skill_id: String,
     },
+    /// A skill's body was loaded for dispatch (the `get_skill_content` path).
+    /// Emitted by the SDK skill catalogs via
+    /// [`crate::SkillRegistry::record_event`].
     SkillInvoke {
+        /// Id of the loaded skill.
         skill_id: String,
+        /// Load wall time, in milliseconds.
         took_ms: u64,
     },
+    /// A tool invocation began. Emitted by the SDK catalogs just before the
+    /// tool's executor runs; paired with [`TraceEvent::InvokeEnd`] or
+    /// [`TraceEvent::InvokeError`].
     InvokeStart {
+        /// Id of the invoked tool.
         tool_id: String,
+        /// Size of the serialized argument payload, in bytes.
         args_size_bytes: u64,
     },
+    /// A tool invocation completed successfully.
     InvokeEnd {
+        /// Id of the invoked tool.
         tool_id: String,
+        /// Invocation wall time, in milliseconds.
         took_ms: u64,
     },
+    /// A tool invocation failed; `error` carries the executor's message.
     InvokeError {
+        /// Id of the invoked tool.
         tool_id: String,
+        /// Wall time until the failure, in milliseconds.
         took_ms: u64,
+        /// The failure message.
         error: String,
     },
+    /// The agent searched the catalog through the capability tools
+    /// (`search_capabilities`, or the deprecated `search_tools`). Carries only
+    /// the hit *count*; the ranked list with scores is on the underlying
+    /// [`TraceEvent::Search`] / [`TraceEvent::SkillSearch`] the registries
+    /// emit for the same call. The `gateway_*` wire prefix is frozen
+    /// (ADR-0007: renames are breaking).
     GatewaySearch {
+        /// The search text.
         query: String,
+        /// Direct library call vs agent-synthesized.
         origin: Origin,
+        /// Requested result count.
         top_k: u32,
+        /// Number of results returned.
         hits: u32,
+        /// Total search wall time, in milliseconds.
         took_ms: u64,
     },
+    /// The agent invoked a tool through the `invoke_tool` capability tool and
+    /// it succeeded.
     GatewayInvoke {
+        /// Id of the invoked tool.
         tool_id: String,
+        /// Invocation wall time, in milliseconds.
         took_ms: u64,
     },
+    /// A capability-tool call failed: an unknown tool/skill id, an executor
+    /// error, or an upstream that needs auth.
     GatewayError {
+        /// Id of the tool (or skill) the call named.
         tool_id: String,
+        /// The failure message (e.g. `needs_auth`).
         error: String,
     },
+    /// An upstream MCP server's tools were ingested into the catalog
+    /// (the SDK's `register_mcp_server`).
     UpstreamRegister {
+        /// Upstream server name.
         server: String,
+        /// Transport used to reach it (e.g. `stdio` / `http` / `sse`).
         transport: String,
+        /// Number of tools ingested.
         tool_count: u32,
     },
+    /// A proxied call to a tool backed by an upstream MCP server completed.
     UpstreamInvoke {
+        /// Upstream server name.
         server: String,
+        /// Id of the invoked tool.
         tool_id: String,
+        /// Invocation wall time, in milliseconds.
         took_ms: u64,
     },
+    /// A proxied upstream call failed; `error` carries the upstream's message.
     UpstreamError {
+        /// Upstream server name.
         server: String,
+        /// Id of the invoked tool.
         tool_id: String,
+        /// The failure message.
         error: String,
     },
+    /// A credential refresh for an upstream MCP server was attempted.
     AuthRefresh {
+        /// Upstream server name.
         upstream: String,
+        /// Whether the refresh produced valid credentials.
         ok: bool,
     },
+    /// An upstream MCP server challenged for auth (e.g. a 401): user
+    /// interaction is required before its tools work.
     AuthNeeds {
+        /// Upstream server name.
         upstream: String,
     },
+    /// An interactive auth flow (e.g. OAuth) started for an upstream MCP
+    /// server; paired with [`TraceEvent::AuthFlowEnd`].
     AuthFlowStart {
+        /// Upstream server name.
         upstream: String,
     },
+    /// The interactive auth flow ended.
     AuthFlowEnd {
+        /// Upstream server name.
         upstream: String,
+        /// Whether the flow produced valid credentials.
         ok: bool,
     },
     /// Emitted once, on the first (cold) load of the embedding model. `status`
     /// flags a slow load (possibly underpowered machine) or a failed one;
     /// `reason` carries the hint / error. See `embedding.rs` and ADR-0011.
     EmbedderLoad {
+        /// The embedding model's HuggingFace repo id.
         model: String,
+        /// Load outcome: ok, slow, or failed.
         status: EmbedderLoadStatus,
+        /// Load wall time, in milliseconds (`0` when the load failed before
+        /// timing).
         took_ms: u64,
+        /// The slow-load hint or the load error; `None` on a normal load.
         reason: Option<String>,
     },
 }
 
+/// The versioned wrapper a sink writes around each [`TraceEvent`]: schema
+/// version, timestamp, and session id. On the wire the event is flattened
+/// (`#[serde(flatten)]`), so its `type` tag and fields sit beside `v` / `ts` /
+/// `session_id` in one JSON object.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TraceEnvelope {
+    /// Envelope schema version; currently `1`.
     pub v: u32,
+    /// Event time, in milliseconds since the Unix epoch.
     pub ts: u64,
+    /// The session the event belongs to, as given to the sink — correlates
+    /// all events from one agent session.
     pub session_id: String,
+    /// The event itself, flattened into the envelope on the wire.
     #[serde(flatten)]
     pub event: TraceEvent,
 }

--- a/src/core/src/trace/sink.rs
+++ b/src/core/src/trace/sink.rs
@@ -11,29 +11,44 @@ const ENVELOPE_VERSION: u32 = 1;
 /// A best-effort sink for trace events. Implementations must be cheap on the
 /// hot path — see ADR-0007 for the query-log reliability profile (lossy on
 /// backpressure is fine, blocking the agent loop is not).
+///
+/// Three implementations ship with the crate: [`NoopSink`] (discard — the
+/// registries' default), [`MemorySink`] (in-memory buffer for tests and
+/// introspection), and [`JsonlSink`] (append-to-file local persistence).
 pub trait TraceSink: Send + Sync {
+    /// Record one event. Called synchronously on the hot path, so it must be
+    /// cheap and non-blocking; on failure, drop the event rather than
+    /// propagate (trace events are observations, never load-bearing).
     fn record(&self, event: TraceEvent);
 
-    /// Per-sink rate limit hint. Currently a documentation knob; v0.1.5 doesn't
-    /// rate-limit anywhere, but the contract is in place so consumers can
-    /// adopt it without a breaking change.
+    /// Per-sink rate limit hint. Currently a documentation knob — nothing
+    /// rate-limits yet — but the contract is in place so consumers can adopt
+    /// it without a breaking change.
     fn sample_rate(&self) -> f64 {
         1.0
     }
 }
 
+/// A sink that discards every event — the default of a registry built with
+/// [`crate::ToolRegistry::new`] / [`crate::SkillRegistry::new`], and the
+/// right choice when tracing is off.
 pub struct NoopSink;
 
 impl TraceSink for NoopSink {
     fn record(&self, _event: TraceEvent) {}
 }
 
+/// A sink that buffers enveloped events in memory, for tests and in-process
+/// introspection: record, then assert on [`Self::snapshot`] or
+/// [`Self::drain`]. The buffer is unbounded, so drain it periodically if the
+/// producer is long-lived.
 pub struct MemorySink {
     session_id: String,
     events: Mutex<Vec<TraceEnvelope>>,
 }
 
 impl MemorySink {
+    /// An empty sink whose envelopes are stamped with `session_id`.
     pub fn new(session_id: impl Into<String>) -> Self {
         Self {
             session_id: session_id.into(),
@@ -41,15 +56,20 @@ impl MemorySink {
         }
     }
 
+    /// A copy of the recorded envelopes, oldest first, leaving the buffer in
+    /// place.
     pub fn snapshot(&self) -> Vec<TraceEnvelope> {
         self.events.lock().expect("trace sink poisoned").clone()
     }
 
+    /// Remove and return the recorded envelopes, oldest first, emptying the
+    /// buffer.
     pub fn drain(&self) -> Vec<TraceEnvelope> {
         let mut guard = self.events.lock().expect("trace sink poisoned");
         std::mem::take(&mut *guard)
     }
 
+    /// The session id stamped on every envelope this sink records.
     pub fn session_id(&self) -> &str {
         &self.session_id
     }
@@ -64,12 +84,25 @@ impl TraceSink for MemorySink {
     }
 }
 
+/// A sink that appends events to a JSONL file, one [`TraceEnvelope`] per
+/// line — local persistence for the offline inspector and reporting
+/// (ADR-0007; the consuming shells bucket files under `~/.ratel/telemetry/`,
+/// but the sink accepts any path). Writes are best-effort: a serialization or
+/// I/O failure drops the event rather than disturb the agent loop.
 pub struct JsonlSink {
     session_id: String,
     file: Mutex<BufWriter<File>>,
 }
 
 impl JsonlSink {
+    /// Open (or create) the JSONL file at `path` in append mode, creating
+    /// missing parent directories. On Unix the file's permissions are
+    /// tightened to `0600` (best-effort) since traces can carry query text.
+    ///
+    /// # Errors
+    ///
+    /// Any [`std::io::Error`] from creating the parent directories or opening
+    /// the file.
     pub fn new(session_id: impl Into<String>, path: impl AsRef<Path>) -> std::io::Result<Self> {
         let path: PathBuf = path.as_ref().to_path_buf();
         if let Some(parent) = path.parent()

--- a/src/sdk/python/native/src/lib.rs
+++ b/src/sdk/python/native/src/lib.rs
@@ -13,12 +13,17 @@ use ratel_ai_core as core;
 use ratel_ai_core::{JsonlSink, MemorySink, NoopSink, Origin, TraceEvent};
 use serde_json::Value;
 
-/// A single search result: the matched tool id and its BM25 score. Mirrors the
-/// TS SDK's `SearchHit` (camelCase `toolId` there → snake_case `tool_id` here).
+/// A single search result: the matched tool id and its relevance score. Mirrors
+/// the TS SDK's `SearchHit` (camelCase `toolId` there → snake_case `tool_id` here).
 #[pyclass(frozen)]
 pub struct SearchHit {
+    /// Id of the matched tool, as passed to `register`.
     #[pyo3(get)]
     pub tool_id: String,
+    /// Relevance score; higher ranks first. The scale depends on the search
+    /// method: raw BM25 (unbounded) for `"bm25"`, cosine similarity for
+    /// `"semantic"`, reciprocal-rank-fusion for `"hybrid"` — scores from
+    /// different methods are not comparable.
     #[pyo3(get)]
     pub score: f64,
 }
@@ -33,12 +38,15 @@ impl SearchHit {
     }
 }
 
-/// A single skill search result: the matched skill id and its BM25 score. The
-/// skill analogue of [`SearchHit`] (`tool_id` → `skill_id`).
+/// A single skill search result: the matched skill id and its relevance score.
+/// The skill analogue of [`SearchHit`] (`tool_id` → `skill_id`).
 #[pyclass(frozen)]
 pub struct SkillHit {
+    /// Id of the matched skill, as passed to `register`.
     #[pyo3(get)]
     pub skill_id: String,
+    /// Relevance score; higher ranks first. Same method-dependent scale as
+    /// [`SearchHit::score`], computed against the skill corpus.
     #[pyo3(get)]
     pub score: f64,
 }
@@ -72,6 +80,9 @@ impl ToolRegistry {
         }
     }
 
+    /// Register a tool's metadata into the index (or replace it in place when
+    /// `id` is already registered). The schemas must be JSON-serializable dicts;
+    /// anything else raises `ValueError`.
     fn register(
         &mut self,
         id: String,
@@ -94,6 +105,8 @@ impl ToolRegistry {
         Ok(())
     }
 
+    /// Lexical BM25 search: the top `top_k` tools for `query`, best first.
+    /// Model-free and infallible; the trace event records origin `"direct"`.
     fn search(&self, query: String, top_k: u32) -> Vec<SearchHit> {
         self.inner
             .search(&query, top_k as usize)
@@ -105,6 +118,9 @@ impl ToolRegistry {
             .collect()
     }
 
+    /// BM25 search tagged with who initiated it: `"agent"` (a model calling a
+    /// capability tool) or anything else → `"direct"` (host code). The origin
+    /// only labels the emitted trace event — ranking is identical to `search`.
     fn search_with_origin(&self, query: String, top_k: u32, origin: String) -> Vec<SearchHit> {
         let parsed = match origin.as_str() {
             "agent" => Origin::Agent,
@@ -162,6 +178,9 @@ impl ToolRegistry {
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 
+    /// Record an SDK-layer trace event into the active sink. `event` must be a
+    /// dict matching one of the core-owned `TraceEvent` shapes (ADR-0007, e.g.
+    /// `{"type": "gateway_search", ...}`); anything else raises `ValueError`.
     fn record_event(&self, event: &Bound<'_, PyAny>) -> PyResult<()> {
         let value: Value = pythonize::depythonize(event)
             .map_err(|e| PyValueError::new_err(format!("invalid trace event: {e}")))?;
@@ -171,6 +190,11 @@ impl ToolRegistry {
         Ok(())
     }
 
+    /// Route trace events to a sink. `kind` is `"noop"` (drop everything, the
+    /// initial state), `"memory"` (buffer for `drain_trace_events`; requires
+    /// `session_id`) or `"jsonl"` (append to a file; requires `session_id` and
+    /// `path`). Raises `ValueError` on an unknown kind, a missing required
+    /// argument, or a jsonl path that cannot be opened.
     #[pyo3(signature = (kind, session_id=None, path=None))]
     fn set_trace_sink(
         &mut self,
@@ -243,6 +267,10 @@ impl SkillRegistry {
         }
     }
 
+    /// Register a skill's metadata into the index (or replace it in place when
+    /// `id` is already registered). `tags` are indexed for ranking; `tools` and
+    /// `metadata` ride along un-indexed for higher layers; `body` is the full
+    /// instruction text, stored for on-demand load.
     // Mirrors `ToolRegistry::register`'s flat-param style (PyO3 has no by-value
     // object arg like the TS NAPI `Skill`); a skill simply has more fields.
     #[allow(clippy::too_many_arguments)]
@@ -267,6 +295,7 @@ impl SkillRegistry {
         });
     }
 
+    /// Lexical BM25 search over the skill corpus — see [`ToolRegistry::search`].
     fn search(&self, query: String, top_k: u32) -> Vec<SkillHit> {
         self.inner
             .search(&query, top_k as usize)
@@ -278,6 +307,8 @@ impl SkillRegistry {
             .collect()
     }
 
+    /// BM25 search tagged with who initiated it — see
+    /// [`ToolRegistry::search_with_origin`].
     fn search_with_origin(&self, query: String, top_k: u32, origin: String) -> Vec<SkillHit> {
         let parsed = match origin.as_str() {
             "agent" => Origin::Agent,
@@ -328,6 +359,8 @@ impl SkillRegistry {
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 
+    /// Record an SDK-layer trace event into the active sink — see
+    /// [`ToolRegistry::record_event`].
     fn record_event(&self, event: &Bound<'_, PyAny>) -> PyResult<()> {
         let value: Value = pythonize::depythonize(event)
             .map_err(|e| PyValueError::new_err(format!("invalid trace event: {e}")))?;
@@ -337,6 +370,8 @@ impl SkillRegistry {
         Ok(())
     }
 
+    /// Route trace events to a sink — see [`ToolRegistry::set_trace_sink`] for
+    /// the kind / session_id / path rules and `ValueError` conditions.
     #[pyo3(signature = (kind, session_id=None, path=None))]
     fn set_trace_sink(
         &mut self,
@@ -374,6 +409,8 @@ impl SkillRegistry {
         Ok(())
     }
 
+    /// Drain captured envelopes from the active sink — see
+    /// [`ToolRegistry::drain_trace_events`].
     fn drain_trace_events<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
         let out = PyList::empty(py);
         let Some(sink) = self.memory_sink.as_ref() else {

--- a/src/sdk/python/pyproject.toml
+++ b/src/sdk/python/pyproject.toml
@@ -63,7 +63,14 @@ line-length = 100
 target-version = "py39"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP", "B", "W"]
+select = ["E", "F", "I", "UP", "B", "W", "D"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.per-file-ignores]
+# Tests document themselves through their names; don't require docstrings there.
+"tests/**" = ["D"]
 
 # Runtime floor is 3.9 (via `from __future__ import annotations`); mypy's minimum
 # supported target is 3.10, so we type-check against that.

--- a/src/sdk/python/ratel_ai/_native.pyi
+++ b/src/sdk/python/ratel_ai/_native.pyi
@@ -1,22 +1,35 @@
 """Type stubs for the compiled PyO3 extension (`ratel_ai._native`).
 
-Mirrors `src/sdk/python/native/src/lib.rs`. The native layer is a pure
-pass-through over `ratel-ai-core`; the ergonomic SDK surface lives in the pure
-Python modules of this package.
+Mirrors `src/sdk/python/native/src/lib.rs` — docstrings here are adapted from
+that file's `///` docs, so what an IDE shows matches the runtime `__doc__`. The
+native layer is a pure pass-through over `ratel-ai-core`; the ergonomic SDK
+surface lives in the pure Python modules of this package.
 """
 
 from typing import Any
 
 class SearchHit:
-    """A single BM25 search result."""
+    """A single search result: the matched tool id and its relevance score."""
 
     @property
-    def tool_id(self) -> str: ...
+    def tool_id(self) -> str:
+        """Id of the matched tool, as passed to `register`."""
+
     @property
-    def score(self) -> float: ...
+    def score(self) -> float:
+        """Relevance score; higher ranks first.
+
+        The scale depends on the search method: raw BM25 (unbounded) for
+        "bm25", cosine similarity for "semantic", reciprocal-rank-fusion for
+        "hybrid" — scores from different methods are not comparable.
+        """
 
 class ToolRegistry:
-    """Metadata-only BM25 index over `ratel-ai-core`."""
+    """Metadata-only BM25 index over `ratel-ai-core`.
+
+    Executors and the capability-tool / MCP layers live in the pure-Python
+    `ratel_ai` package above this binding.
+    """
 
     def __init__(self) -> None: ...
     def register(
@@ -26,32 +39,99 @@ class ToolRegistry:
         description: str,
         input_schema: dict[str, Any],
         output_schema: dict[str, Any],
-    ) -> None: ...
-    def search(self, query: str, top_k: int) -> list[SearchHit]: ...
-    def search_with_origin(self, query: str, top_k: int, origin: str) -> list[SearchHit]: ...
+    ) -> None:
+        """Register a tool's metadata into the index.
+
+        Replaces in place when `id` is already registered. The schemas must be
+        JSON-serializable dicts; anything else raises `ValueError`.
+        """
+
+    def search(self, query: str, top_k: int) -> list[SearchHit]:
+        """Lexical BM25 search: the top `top_k` tools for `query`, best first.
+
+        Model-free and infallible; the trace event records origin "direct".
+        """
+
+    def search_with_origin(self, query: str, top_k: int, origin: str) -> list[SearchHit]:
+        """BM25 search tagged with who initiated it.
+
+        `origin` is "agent" (a model calling a capability tool) or anything
+        else → "direct" (host code). The origin only labels the emitted trace
+        event — ranking is identical to `search`.
+        """
+
     def search_with_method(
         self, query: str, top_k: int, origin: str, method: str
-    ) -> list[SearchHit]: ...
-    def build_embeddings(self) -> None: ...
-    def record_event(self, event: dict[str, Any]) -> None: ...
+    ) -> list[SearchHit]:
+        """Search with an explicit method ("bm25" | "semantic" | "hybrid").
+
+        "bm25" is infallible; "semantic"/"hybrid" rank against the prebuilt
+        embedding cache and raise `RuntimeError` (`EmbeddingsNotBuilt`) if it
+        isn't built — the model loads at `build_embeddings`, never inside a
+        search. An unknown method string raises `ValueError`.
+        """
+
+    def build_embeddings(self) -> None:
+        """Pre-compute embeddings for not-yet-embedded tools (incremental).
+
+        A later semantic/hybrid search then only embeds the query. Raises
+        `RuntimeError` if the model fails to load. The catalog calls this
+        after `register` in semantic mode; BM25-only callers never do.
+        """
+
+    def record_event(self, event: dict[str, Any]) -> None:
+        """Record an SDK-layer trace event into the active sink.
+
+        `event` must be a dict matching one of the core-owned `TraceEvent`
+        shapes (ADR-0007, e.g. `{"type": "gateway_search", ...}`); anything
+        else raises `ValueError`.
+        """
+
     def set_trace_sink(
         self,
         kind: str,
         session_id: str | None = ...,
         path: str | None = ...,
-    ) -> None: ...
-    def drain_trace_events(self) -> list[dict[str, Any]]: ...
+    ) -> None:
+        """Route trace events to a sink.
+
+        `kind` is "noop" (drop everything, the initial state), "memory"
+        (buffer for `drain_trace_events`; requires `session_id`) or "jsonl"
+        (append to a file; requires `session_id` and `path`). Raises
+        `ValueError` on an unknown kind, a missing required argument, or a
+        jsonl path that cannot be opened.
+        """
+
+    def drain_trace_events(self) -> list[dict[str, Any]]:
+        """Drain captured envelopes from the active sink.
+
+        Returns `[]` unless the active sink is "memory".
+        """
 
 class SkillHit:
-    """A single skill BM25 search result."""
+    """A single skill search result: the matched skill id and its relevance score.
+
+    The skill analogue of `SearchHit` (`tool_id` → `skill_id`).
+    """
 
     @property
-    def skill_id(self) -> str: ...
+    def skill_id(self) -> str:
+        """Id of the matched skill, as passed to `register`."""
+
     @property
-    def score(self) -> float: ...
+    def score(self) -> float:
+        """Relevance score; higher ranks first.
+
+        Same method-dependent scale as `SearchHit.score`, computed against the
+        skill corpus.
+        """
 
 class SkillRegistry:
-    """Metadata-only BM25 index over the skill corpus (separate from tools)."""
+    """Metadata-only BM25 index over the skill corpus (separate from tools).
+
+    The on-demand analogue of `ToolRegistry`: a separate index, so skills are
+    ranked independently of tools (own corpus statistics, own top-K).
+    """
 
     def __init__(self) -> None: ...
     def register(
@@ -63,18 +143,38 @@ class SkillRegistry:
         tools: list[str],
         metadata: dict[str, list[str]],
         body: str,
-    ) -> None: ...
-    def search(self, query: str, top_k: int) -> list[SkillHit]: ...
-    def search_with_origin(self, query: str, top_k: int, origin: str) -> list[SkillHit]: ...
+    ) -> None:
+        """Register a skill's metadata into the index.
+
+        Replaces in place when `id` is already registered. `tags` are indexed
+        for ranking; `tools` and `metadata` ride along un-indexed for higher
+        layers; `body` is the full instruction text, stored for on-demand load.
+        """
+
+    def search(self, query: str, top_k: int) -> list[SkillHit]:
+        """Lexical BM25 search over the skill corpus — see `ToolRegistry.search`."""
+
+    def search_with_origin(self, query: str, top_k: int, origin: str) -> list[SkillHit]:
+        """BM25 search tagged with who initiated it — see `ToolRegistry.search_with_origin`."""
+
     def search_with_method(
         self, query: str, top_k: int, origin: str, method: str
-    ) -> list[SkillHit]: ...
-    def build_embeddings(self) -> None: ...
-    def record_event(self, event: dict[str, Any]) -> None: ...
+    ) -> list[SkillHit]:
+        """Search with an explicit method — see `ToolRegistry.search_with_method`."""
+
+    def build_embeddings(self) -> None:
+        """See `ToolRegistry.build_embeddings`."""
+
+    def record_event(self, event: dict[str, Any]) -> None:
+        """Record an SDK-layer trace event — see `ToolRegistry.record_event`."""
+
     def set_trace_sink(
         self,
         kind: str,
         session_id: str | None = ...,
         path: str | None = ...,
-    ) -> None: ...
-    def drain_trace_events(self) -> list[dict[str, Any]]: ...
+    ) -> None:
+        """Route trace events to a sink — see `ToolRegistry.set_trace_sink`."""
+
+    def drain_trace_events(self) -> list[dict[str, Any]]:
+        """Drain captured envelopes — see `ToolRegistry.drain_trace_events`."""

--- a/src/sdk/python/ratel_ai/capabilities.py
+++ b/src/sdk/python/ratel_ai/capabilities.py
@@ -20,7 +20,10 @@ from .skill_catalog import SkillCatalog
 from .telemetry import record_auth_needed
 
 SEARCH_CAPABILITIES_ID = "search_capabilities"
+"""Id (and name) of the discovery tool built by `search_capabilities_tool`."""
+
 INVOKE_TOOL_ID = "invoke_tool"
+"""Id (and name) of the invocation tool built by `invoke_tool_tool`."""
 
 _DEFAULT_TOP_K_TOOLS = 5
 _DEFAULT_TOP_K_SKILLS = 3
@@ -62,15 +65,45 @@ _MAX_DESCRIPTION_LEN = 160
 
 @dataclass
 class UpstreamServerInfo:
+    """An upstream MCP server, as advertised in the capability-tool descriptions.
+
+    Pass a list of these to `search_capabilities_tool` (or the deprecated
+    `search_tools_tool`) to append a "this catalog aggregates…" listing to the
+    tool description shown to the model, and to enrich each search result's
+    server group with the upstream's description and instructions.
+
+    Attributes:
+        name: the catalog namespace of the server — the `<name>` prefix of its
+            `<name>__<tool>` tool ids.
+        description: what the server offers; compacted to one line in listings.
+        instructions: the server's usage instructions (from its MCP
+            `initialize` result), surfaced on matching server groups.
+        tool_count: number of tools the server contributed, shown in listings.
+        needs_auth: True when the upstream rejected its boot connection with a
+            401 / re-auth needed; listings append "(auth required)".
+    """
+
     name: str
     description: str | None = None
     instructions: str | None = None
     tool_count: int | None = None
-    # True when the upstream rejected its boot connection with 401 / re-auth needed.
     needs_auth: bool = False
 
 
 def format_upstream_line(s: UpstreamServerInfo) -> str:
+    """Render one upstream server as a listing bullet for a tool description.
+
+    Format: ``- <name> — <description> (<N> tools) (auth required)``, where the
+    description is whitespace-collapsed and truncated to ~160 chars, and each
+    trailing part appears only when the corresponding field is set.
+
+    Args:
+        s: the upstream server to render.
+
+    Returns:
+        A single `- `-prefixed line, ready to join into the
+        "this catalog aggregates…" listing.
+    """
     line = f"- {s.name}"
     if s.description:
         line += f" — {_compact_description(s.description)}"
@@ -108,11 +141,26 @@ def search_capabilities_tool(
     *,
     upstream_servers: Sequence[UpstreamServerInfo] | None = None,
 ) -> ExecutableTool:
-    """Unified discovery over tools AND skills.
+    """Build the `search_capabilities` tool: unified discovery over tools AND skills.
 
-    Returns two independently-ranked buckets, each with its own top-K budget — so a
-    relevant skill is never starved out of the results by a large number of matching
-    tools (and the two BM25 corpora are never score-compared).
+    The returned tool ranks two independent buckets, each with its own top-K
+    budget — so a relevant skill is never starved out of the results by a large
+    number of matching tools (and the two BM25 corpora are never
+    score-compared). Tools land grouped by upstream server; a matched skill's
+    declared tools are pulled into the tools bucket additively (score 0), so
+    the agent gets the playbook and its toolkit in one turn. The `skills`
+    bucket (and the mention of `get_skill_content` in the description) is only
+    advertised when a non-empty `skill_catalog` is wired in.
+
+    Args:
+        catalog: the tool catalog to search.
+        skill_catalog: optional skill catalog, ranked against the same query
+            in its own bucket.
+        upstream_servers: upstream MCP servers to advertise in the tool
+            description and to enrich result server groups with.
+
+    Returns:
+        An `ExecutableTool` to put in the agent's direct tool list.
     """
     upstreams = list(upstream_servers or [])
     upstream_by_name = {u.name: u for u in upstreams}
@@ -276,9 +324,10 @@ def search_capabilities_tool(
     )
 
 
-# Notified when the underlying tool raises UnauthorizedError, with the upstream
-# name inferred from the toolId. May be sync or async.
 OnUnauthorized = Callable[[str], Union[Awaitable[None], None]]
+"""Notified when the underlying tool raises `UnauthorizedError`, with the
+upstream server name inferred from the toolId. May be sync or async.
+"""
 
 
 def invoke_tool_tool(
@@ -286,6 +335,27 @@ def invoke_tool_tool(
     *,
     on_unauthorized: OnUnauthorized | None = None,
 ) -> ExecutableTool:
+    """Build the `invoke_tool` tool: run any catalog tool by id.
+
+    The returned tool resolves `toolId`, forwards the nested `args` object to
+    `ToolCatalog.invoke`, and never raises into the host: an unknown id,
+    malformed `args`, or a tool exception all come back as a structured
+    `{"error": ..., "isError": True}` payload the model can recover from. A
+    flattened call (arguments at the top level instead of nested under `args`)
+    is tolerated. When the tool raises an `UnauthorizedError`, the payload is
+    `{"error": "needs_auth", ...}` with a re-auth hint and, for namespaced
+    `<server>__<tool>` ids, the upstream server name.
+
+    Args:
+        catalog: the catalog to resolve and run tool ids against.
+        on_unauthorized: called with the upstream server name when a tool
+            raises `UnauthorizedError`; may be sync or async. Skipped when the
+            tool id has no `<server>__` namespace prefix.
+
+    Returns:
+        An `ExecutableTool` to put in the agent's direct tool list.
+    """
+
     async def execute(input: dict[str, Any]) -> Any:
         tool_id = input.get("toolId")
         if not isinstance(tool_id, str) or not catalog.has(tool_id):

--- a/src/sdk/python/ratel_ai/catalog.py
+++ b/src/sdk/python/ratel_ai/catalog.py
@@ -17,11 +17,23 @@ from typing import Any, Callable, Union
 from ._native import SearchHit, ToolRegistry
 from .telemetry import SEARCH_TARGET_TOOL, trace_execute_tool, trace_search
 
-# Tool inputs are heterogeneous across the catalog; handlers may be sync or async.
 Executor = Callable[[dict[str, Any]], Union[Awaitable[Any], Any]]
+"""A tool handler: takes the tool's arguments dict, returns the result.
 
-SearchOrigin = str  # "direct" | "agent"
-SearchMethod = str  # "bm25" | "semantic" | "hybrid"
+May be sync or async (tool inputs are heterogeneous across the catalog);
+`ToolCatalog.invoke` absorbs the difference.
+"""
+
+SearchOrigin = str
+"""Who initiated a search: ``"direct"`` (host code, the default) or ``"agent"``
+(a model calling a capability tool). Labels the emitted trace event only —
+ranking is unaffected.
+"""
+
+SearchMethod = str
+"""Retrieval engine: ``"bm25"`` (lexical, model-free, the default),
+``"semantic"`` (dense embeddings) or ``"hybrid"`` (both, fused).
+"""
 
 
 @dataclass
@@ -64,19 +76,39 @@ class ToolCatalog:
         trace: TraceSinkConfig | None = None,
         method: SearchMethod = "bm25",
     ) -> None:
+        """Create an empty catalog.
+
+        Args:
+            trace: where trace events go; `None` keeps the default no-op sink.
+            method: default retrieval method for `search` — "bm25" (the
+                historical, model-free behavior), "semantic" or "hybrid". A
+                per-call `method=` overrides it. A semantic/hybrid catalog
+                eagerly embeds each tool at registration so searches never pay
+                the embedding cost; a BM25 catalog never touches the model.
+        """
         self._registry = ToolRegistry()
         self._executors: dict[str, Executor] = {}
         self._tools: dict[str, Tool] = {}
-        # Default retrieval method for `search`; "bm25" keeps the historical
-        # (model-free) behavior. A per-call `method=` overrides it.
         self._method: SearchMethod = method
-        # Semantic/hybrid default → eagerly embed each tool at registration so
-        # searches never pay the embedding cost. BM25 default does nothing.
         self._eager: bool = method in ("semantic", "hybrid")
         if trace is not None:
             self._registry.set_trace_sink(trace.kind, trace.session_id, trace.path)
 
     def register(self, tool: ExecutableTool) -> None:
+        """Add a tool to the catalog (metadata into the index, handler by id).
+
+        Registering an id that is already present replaces it in place — the
+        index never holds a duplicate.
+
+        Args:
+            tool: the tool to register; `execute` must be set.
+
+        Raises:
+            ValueError: if `tool.execute` is `None`, or if `input_schema` /
+                `output_schema` contain values that are not JSON-serializable.
+            RuntimeError: on a semantic/hybrid catalog, if the embedding model
+                fails to load while eagerly embedding the new tool.
+        """
         if tool.execute is None:
             raise ValueError(f"tool {tool.id!r} has no execute handler")
         self._registry.register(
@@ -100,9 +132,16 @@ class ToolCatalog:
             self._registry.build_embeddings()
 
     def build_embeddings(self) -> None:
-        """Pre-compute embeddings for any not-yet-embedded tools. Call after a
-        bulk register, or rely on the automatic per-register embedding that a
-        semantic/hybrid catalog does. No-op for a BM25 catalog's cache."""
+        """Pre-compute embeddings for any not-yet-embedded tools.
+
+        Incremental: only tools registered since the last call are embedded.
+        Call after a bulk register, or rely on the automatic per-register
+        embedding that a semantic/hybrid catalog does. A BM25 catalog never
+        needs it.
+
+        Raises:
+            RuntimeError: if the embedding model fails to load.
+        """
         self._registry.build_embeddings()
 
     def search(
@@ -112,9 +151,23 @@ class ToolCatalog:
         origin: SearchOrigin = "direct",
         method: SearchMethod | None = None,
     ) -> list[SearchHit]:
-        """Search the catalog. `method` overrides the catalog default for this
-        call ("bm25" | "semantic" | "hybrid"); "semantic"/"hybrid" raise
-        `RuntimeError` if the embedding model fails to load."""
+        """Rank registered tools against a natural-language query.
+
+        Args:
+            query: what the caller wants to do.
+            top_k: max hits to return.
+            origin: who initiated the search — labels the trace event only.
+            method: per-call override of the catalog's default retrieval
+                method ("bm25" | "semantic" | "hybrid").
+
+        Returns:
+            Up to `top_k` `SearchHit`s, best first.
+
+        Raises:
+            ValueError: if `method` is not "bm25", "semantic" or "hybrid".
+            RuntimeError: for "semantic"/"hybrid" when the embedding cache is
+                not built (call `build_embeddings`) or query embedding fails.
+        """
         return trace_search(
             SEARCH_TARGET_TOOL,
             query,
@@ -124,12 +177,15 @@ class ToolCatalog:
         )
 
     def has(self, tool_id: str) -> bool:
+        """Return whether a tool with this id is registered."""
         return tool_id in self._executors
 
     def get(self, tool_id: str) -> Tool | None:
+        """Return the metadata-only `Tool` for an id, or `None` if unknown."""
         return self._tools.get(tool_id)
 
     def get_executable(self, tool_id: str) -> ExecutableTool | None:
+        """Return the `ExecutableTool` (metadata plus handler) for an id, or `None`."""
         tool = self._tools.get(tool_id)
         execute = self._executors.get(tool_id)
         if tool is None or execute is None:
@@ -144,12 +200,44 @@ class ToolCatalog:
         )
 
     def record_event(self, event: dict[str, Any]) -> None:
+        """Record a trace event into the catalog's sink.
+
+        Args:
+            event: a dict matching one of the core-owned `TraceEvent` shapes
+                (ADR-0007), e.g. `{"type": "gateway_search", ...}`.
+
+        Raises:
+            ValueError: if the dict doesn't match any known event shape.
+        """
         self._registry.record_event(event)
 
     def drain_trace_events(self) -> list[dict[str, Any]]:
+        """Drain captured trace envelopes; `[]` unless the sink is "memory"."""
         return self._registry.drain_trace_events()
 
     async def invoke(self, tool_id: str, args: dict[str, Any]) -> Any:
+        """Run a registered tool's handler and return its result.
+
+        This is the canonical place that absorbs the sync/async executor
+        difference: the handler is called first and the result awaited only if
+        it is awaitable, so plain functions and `async def` executors (e.g.
+        MCP/HTTP tools) are both supported. Callers must route invocations
+        here rather than re-deriving that logic. Emits `invoke_start` /
+        `invoke_end` / `invoke_error` trace events and wraps the call in an
+        `execute_tool` OTel span (ADR-0007).
+
+        Args:
+            tool_id: id of a registered tool.
+            args: the arguments dict passed to the handler.
+
+        Returns:
+            Whatever the handler returns (awaited if it returned an awaitable).
+
+        Raises:
+            ValueError: if `tool_id` is not registered.
+            Exception: whatever the handler raises, re-raised after an
+                `invoke_error` trace event is recorded.
+        """
         fn = self._executors.get(tool_id)
         if fn is None:
             raise ValueError(f"unknown toolId: {tool_id}")
@@ -164,11 +252,8 @@ class ToolCatalog:
             )
             started = time.monotonic()
             try:
-                # Executors may be sync (a plain dict-returning function) or async
-                # (`async def`, e.g. MCP/HTTP tools) — so call first, then await only
-                # if awaitable. Never bare-`await fn(args)`: in Python that raises on a
-                # sync result. This is the canonical place that absorbs the difference;
-                # callers must route here, not re-derive it.
+                # Call first, await only if awaitable (see the `invoke` docstring).
+                # Never bare-`await fn(args)`: in Python that raises on a sync result.
                 result = fn(args)
                 if inspect.isawaitable(result):
                     result = await result

--- a/src/sdk/python/ratel_ai/compat.py
+++ b/src/sdk/python/ratel_ai/compat.py
@@ -7,9 +7,9 @@ against `ratel-ai==0.1.x` working after an upgrade, the old `search_tools_tool` 
 tools-only `{groups}` result and the `search_tools` id — not aliased to the new
 two-bucket tool.
 
-.. deprecated:: 0.2.0
-   Migrate to :func:`ratel_ai.search_capabilities_tool` /
-   :data:`ratel_ai.SEARCH_CAPABILITIES_ID`. Tracked for removal in RAT-250.
+Deprecated:
+    Since 0.2.0: migrate to `ratel_ai.search_capabilities_tool` /
+    `ratel_ai.SEARCH_CAPABILITIES_ID`. Tracked for removal in RAT-250.
 """
 
 from __future__ import annotations
@@ -22,6 +22,9 @@ from .capabilities import UpstreamServerInfo, format_upstream_line
 from .catalog import ExecutableTool, ToolCatalog
 
 SEARCH_TOOLS_ID = "search_tools"
+"""Id (and name) of the deprecated pre-0.2.0 discovery tool built by
+`search_tools_tool`; superseded by `ratel_ai.SEARCH_CAPABILITIES_ID`.
+"""
 
 _SEARCH_TOOLS_BASE_DESCRIPTION = (
     "Discover tools beyond the ones already visible in your direct tool list. "
@@ -49,14 +52,24 @@ def search_tools_tool(
     *,
     upstream_servers: Sequence[UpstreamServerInfo] | None = None,
 ) -> ExecutableTool:
-    """Pre-0.2.0 tools-only discovery tool (id ``search_tools``, ``{groups}`` result).
+    """Build the pre-0.2.0 tools-only discovery tool (id ``search_tools``).
 
-    New code should use :func:`ratel_ai.search_capabilities_tool`, which also
-    returns a reserved ``skills`` bucket. Registering both lets a host serve the
-    old and new names during a migration window.
+    Keeps the original behaviour: a flat ``{groups}`` result and no skills
+    bucket. New code should use `ratel_ai.search_capabilities_tool` instead.
+    Registering both lets a host serve the old and new names during a
+    migration window.
 
-    .. deprecated:: 0.2.0
-       Use :func:`ratel_ai.search_capabilities_tool`. Tracked for removal in RAT-250.
+    Args:
+        catalog: the tool catalog to search.
+        upstream_servers: upstream MCP servers to advertise in the tool
+            description and to enrich result server groups with.
+
+    Returns:
+        An `ExecutableTool` to put in the agent's direct tool list.
+
+    Deprecated:
+        Since 0.2.0: use `ratel_ai.search_capabilities_tool`. Tracked for
+        removal in RAT-250.
     """
     upstreams = list(upstream_servers or [])
     upstream_by_name = {u.name: u for u in upstreams}

--- a/src/sdk/python/ratel_ai/mcp.py
+++ b/src/sdk/python/ratel_ai/mcp.py
@@ -45,6 +45,19 @@ def _require_mcp() -> None:
 
 @dataclass
 class McpServerHandle:
+    """What `register_mcp_server` returns: the registration's outcome.
+
+    Attributes:
+        tool_ids: the namespaced `<server>__<tool>` ids registered into the
+            catalog, in upstream listing order.
+        server_instructions: the `instructions` value passed to
+            `register_mcp_server` (the caller reads it from its own
+            `initialize` result), or `None`.
+        close: async teardown — the `on_close` passed to
+            `register_mcp_server`, or a no-op. The session itself stays
+            caller-owned either way.
+    """
+
     tool_ids: list[str]
     server_instructions: str | None
     close: Callable[[], Awaitable[None]]
@@ -72,6 +85,13 @@ async def register_mcp_server(
         transport_label: recorded on the `upstream_register` trace event.
         instructions: the upstream's server instructions (from `initialize`), if any.
         on_close: optional async teardown invoked by the handle's `close()`.
+
+    Returns:
+        An `McpServerHandle` with the registered tool ids.
+
+    Raises:
+        ImportError: if the optional `mcp` package is not installed
+            (`pip install 'ratel-ai[mcp]'`).
     """
     _require_mcp()
 

--- a/src/sdk/python/ratel_ai/skill_catalog.py
+++ b/src/sdk/python/ratel_ai/skill_catalog.py
@@ -45,6 +45,14 @@ class SkillCatalog:
         trace: TraceSinkConfig | None = None,
         method: SearchMethod = "bm25",
     ) -> None:
+        """Create an empty skill catalog.
+
+        Args:
+            trace: where trace events go; `None` keeps the default no-op sink.
+            method: default retrieval method for `search` — see
+                `ToolCatalog.__init__`; a semantic/hybrid catalog eagerly
+                embeds each skill at registration.
+        """
         self._registry = SkillRegistry()
         self._skills: dict[str, Skill] = {}
         self._method: SearchMethod = method
@@ -53,6 +61,19 @@ class SkillCatalog:
             self._registry.set_trace_sink(trace.kind, trace.session_id, trace.path)
 
     def register(self, skill: Skill) -> None:
+        """Add a skill to the catalog (metadata into the index, body stored).
+
+        Registering an id that is already present replaces it in place — the
+        index never holds a duplicate. Name, description and tags are indexed
+        for ranking; `tools`, `metadata` and `body` are stored but not indexed.
+
+        Args:
+            skill: the skill to register.
+
+        Raises:
+            RuntimeError: on a semantic/hybrid catalog, if the embedding model
+                fails to load while eagerly embedding the new skill.
+        """
         self._registry.register(
             skill.id,
             skill.name,
@@ -67,8 +88,10 @@ class SkillCatalog:
             self._registry.build_embeddings()
 
     def build_embeddings(self) -> None:
-        """Pre-compute embeddings for not-yet-embedded skills. See
-        `ToolCatalog.build_embeddings`."""
+        """Pre-compute embeddings for not-yet-embedded skills.
+
+        See `ToolCatalog.build_embeddings` for when to call and what it raises.
+        """
         self._registry.build_embeddings()
 
     def search(
@@ -78,6 +101,15 @@ class SkillCatalog:
         origin: SearchOrigin = "direct",
         method: SearchMethod | None = None,
     ) -> list[SkillHit]:
+        """Rank registered skills against a natural-language query.
+
+        The skill twin of `ToolCatalog.search` — same arguments, same
+        method-override and `ValueError`/`RuntimeError` semantics, ranked
+        against the skill corpus.
+
+        Returns:
+            Up to `top_k` `SkillHit`s, best first.
+        """
         return trace_search(
             SEARCH_TARGET_SKILL,
             query,
@@ -87,25 +119,43 @@ class SkillCatalog:
         )
 
     def has(self, skill_id: str) -> bool:
+        """Return whether a skill with this id is registered."""
         return skill_id in self._skills
 
     def get(self, skill_id: str) -> Skill | None:
+        """Return the registered `Skill` for an id, or `None` if unknown."""
         return self._skills.get(skill_id)
 
     def size(self) -> int:
+        """Return the number of registered skills."""
         return len(self._skills)
 
     def record_event(self, event: dict[str, Any]) -> None:
+        """Record a trace event into the catalog's sink.
+
+        See `ToolCatalog.record_event` for the event contract.
+        """
         self._registry.record_event(event)
 
     def drain_trace_events(self) -> list[dict[str, Any]]:
+        """Drain captured trace envelopes; `[]` unless the sink is "memory"."""
         return self._registry.drain_trace_events()
 
     def invoke(self, skill_id: str) -> str:
         """Return a skill's body for dispatch, recording a `skill_invoke` event.
 
-        Raises `ValueError` on an unknown id — callers at the capability-tool boundary
-        translate that into a structured error for the agent.
+        Synchronous, unlike `ToolCatalog.invoke` — the body is already in
+        memory, there is no handler to run.
+
+        Args:
+            skill_id: id of a registered skill.
+
+        Returns:
+            The skill's body (Markdown), verbatim as registered.
+
+        Raises:
+            ValueError: on an unknown id — callers at the capability-tool
+                boundary translate this into a structured error for the agent.
         """
         skill = self._skills.get(skill_id)
         if skill is None:

--- a/src/sdk/python/ratel_ai/skill_tools.py
+++ b/src/sdk/python/ratel_ai/skill_tools.py
@@ -14,11 +14,28 @@ from .catalog import ExecutableTool
 from .skill_catalog import SkillCatalog
 
 GET_SKILL_CONTENT_ID = "get_skill_content"
+"""Id (and name) of the skill-loading tool built by `get_skill_content_tool`."""
 
 __all__ = ["GET_SKILL_CONTENT_ID", "get_skill_content_tool"]
 
 
 def get_skill_content_tool(catalog: SkillCatalog) -> ExecutableTool:
+    """Build the `get_skill_content` tool: load a skill's full body by id.
+
+    The returned tool resolves `skillId` and answers `{"body": <markdown>}` via
+    `SkillCatalog.invoke` (which records a `skill_invoke` trace event). It
+    never raises into the host: an unknown or non-string id comes back as a
+    structured `{"error": ..., "isError": True}` payload the model can recover
+    from, mirroring `invoke_tool`.
+
+    Args:
+        catalog: the skill catalog to load bodies from.
+
+    Returns:
+        An `ExecutableTool` to put in the agent's direct tool list alongside
+        `search_capabilities`.
+    """
+
     async def execute(input: dict[str, Any]) -> dict[str, Any]:
         skill_id = input.get("skillId")
         if not isinstance(skill_id, str) or not catalog.has(skill_id):

--- a/src/sdk/python/ratel_ai/telemetry.py
+++ b/src/sdk/python/ratel_ai/telemetry.py
@@ -191,9 +191,11 @@ def _resolve_capture_override(
     capture_content: ContentCapture | str | None,
     include_span_and_events: bool | None,
 ) -> ContentCapture | str | None:
-    """The capture mode configure_telemetry should set, or None to leave the gate
-    env-driven: `capture_content` wins over `include_span_and_events`. The bool sugar maps
-    to the wire strings set_content_capture normalizes (True -> full capture, False -> none).
+    """Resolve the capture mode `configure_telemetry` should set.
+
+    `capture_content` wins over `include_span_and_events`; returns None to leave the
+    gate env-driven. The bool sugar maps to the wire strings `set_content_capture`
+    normalizes (True -> full capture, False -> none).
     """
     if capture_content is not None:
         return capture_content

--- a/src/sdk/python/ratel_ai/telemetry.py
+++ b/src/sdk/python/ratel_ai/telemetry.py
@@ -1,5 +1,6 @@
-"""OpenTelemetry emission for the SDK funnel — the Python mirror of
-`src/sdk/ts/src/telemetry.ts` (ADR-0007).
+"""OpenTelemetry emission for the SDK funnel (ADR-0007).
+
+The Python mirror of `src/sdk/ts/src/telemetry.ts`.
 
 The catalog / capability-tool / skill / MCP paths call these helpers to open a span around
 each operation, alongside the local `record_event` stream (untouched). Span names
@@ -91,9 +92,11 @@ async def trace_execute_tool(
     args: dict[str, Any],
     run: Callable[[], Awaitable[T]],
 ) -> T:
-    """Wrap a tool invocation in a standard `execute_tool` span (`gen_ai.operation.name
-    = execute_tool`, enriched with `ratel.*`) — the OTel gen_ai tool operation, so a
-    generic backend understands it (ADR-0007). No-op pass-through when disabled.
+    """Wrap a tool invocation in a standard `execute_tool` span.
+
+    The OTel gen_ai tool operation (`gen_ai.operation.name = execute_tool`,
+    enriched with `ratel.*`), so a generic backend understands it (ADR-0007).
+    No-op pass-through when telemetry is disabled.
     """
     if not _ENABLED:
         return await run()
@@ -120,8 +123,10 @@ def trace_search(
     origin: str,
     run: Callable[[], T],
 ) -> T:
-    """Wrap a capability search (tool or skill) in a `ratel.search` span. Synchronous:
-    the native BM25 search returns inline; the hit count becomes `ratel.search.hit_count`.
+    """Wrap a capability search (tool or skill) in a `ratel.search` span.
+
+    Synchronous: the native BM25 search returns inline; the hit count becomes
+    `ratel.search.hit_count`.
     """
     if not _ENABLED:
         return run()
@@ -153,9 +158,10 @@ async def trace_upstream_register(
     transport: str,
     run: Callable[[Callable[[int], None]], Awaitable[T]],
 ) -> T:
-    """Wrap an upstream-MCP registration in a `ratel.upstream.register` span. `run`
-    receives a `report_tool_count` callback to set `ratel.upstream.tool_count` once the
-    tool list is known.
+    """Wrap an upstream-MCP registration in a `ratel.upstream.register` span.
+
+    `run` receives a `report_tool_count` callback to set
+    `ratel.upstream.tool_count` once the tool list is known.
     """
     if not _ENABLED:
         return await run(lambda _n: None)
@@ -168,8 +174,9 @@ async def trace_upstream_register(
 
 
 def record_auth_needed(server: str | None = None) -> None:
-    """Mark an upstream tool call that failed with a 401 / needs-reauthorization: a
-    short `ratel.auth.flow` span carrying `ratel.auth.outcome = needs_auth`.
+    """Mark an upstream tool call that failed with a 401 / needs-reauthorization.
+
+    Emits a short `ratel.auth.flow` span carrying `ratel.auth.outcome = needs_auth`.
     """
     if not _ENABLED:
         return
@@ -204,23 +211,41 @@ def configure_telemetry(
     capture_content: ContentCapture | str | None = None,
     include_span_and_events: bool | None = None,
 ) -> Any:
-    """Convenience wiring for the greenfield case: register a Ratel-owned OTLP exporter
-    so the spans this SDK emits are shipped to Ratel Cloud (or any OTLP endpoint).
-    Delegates to `ratel_ai_telemetry.init`, which needs the OpenTelemetry SDK — install
-    it with ``pip install 'ratel-ai[otlp]'``. A host already running its own OpenTelemetry
-    provider should skip this (the SDK's spans flow to that provider) and add
-    `ratel_span_processor` from `ratel_ai_telemetry`. Returns the provider as a shutdown
-    handle (``provider.shutdown()`` / ``provider.force_flush()``).
+    """Register a Ratel-owned OTLP exporter (convenience wiring for the greenfield case).
 
-    ``capture_content`` / ``include_span_and_events`` opt into message/tool content capture
-    in code via `set_content_capture` (an unrecognized ``capture_content`` raises a
-    ``ValueError`` before any exporter is wired); ``capture_content`` sets an exact mode,
+    Ships the spans this SDK emits to Ratel Cloud (or any OTLP endpoint) by
+    delegating to `ratel_ai_telemetry.init`, which needs the OpenTelemetry SDK —
+    install it with ``pip install 'ratel-ai[otlp]'``. A host already running its
+    own OpenTelemetry provider should skip this (the SDK's spans flow to that
+    provider) and add `ratel_span_processor` from `ratel_ai_telemetry`.
+
+    ``capture_content`` / ``include_span_and_events`` opt into message/tool content
+    capture in code via `set_content_capture`: ``capture_content`` sets an exact mode,
     ``include_span_and_events`` is bool sugar (True -> ``SPAN_AND_EVENT``, False ->
-    ``NO_CONTENT``). A provided option beats ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT``
-    (env is the fallback, as in OTel); ``capture_content`` wins over ``include_span_and_events``.
-    The returned handle's ``shutdown()`` clears the override, so tests and hot-reloads return
-    to env-driven behavior. The clear is generation-scoped: a stale handle shutting down late
-    never clobbers an override a newer configure_telemetry/set_content_capture installed.
+    ``NO_CONTENT``); ``capture_content`` wins when both are given. A provided option
+    beats ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`` (the env var is the
+    fallback when neither is given, as in OTel). The returned handle's ``shutdown()``
+    clears the override, restoring env-driven behavior; the clear is
+    generation-scoped, so a stale handle shutting down late never clobbers an
+    override a newer `configure_telemetry`/`set_content_capture` call installed.
+
+    Args:
+        api_key: Ratel Cloud API key; omit when exporting to a self-hosted endpoint.
+        endpoint: OTLP endpoint override; defaults to the Ratel Cloud collector.
+        headers: Extra headers sent with every export request.
+        service_name: ``service.name`` resource attribute; defaults per `init`.
+        capture_content: Exact content-capture mode to set (see above).
+        include_span_and_events: Boolean sugar for `capture_content` (see above).
+
+    Returns:
+        The provider, usable as a shutdown handle (``provider.shutdown()`` /
+        ``provider.force_flush()``).
+
+    Raises:
+        ModuleNotFoundError: if the OpenTelemetry exporter is not installed
+            (``pip install 'ratel-ai[otlp]'``).
+        ValueError: if `capture_content` is not a recognized mode — raised before
+            any exporter is wired, so a bad option has no side effects.
     """
     try:
         from ratel_ai_telemetry import clear_content_capture, init, set_content_capture

--- a/src/sdk/ts/native/src/lib.rs
+++ b/src/sdk/ts/native/src/lib.rs
@@ -42,23 +42,43 @@ fn build_trace_sink(config: TraceSinkConfig) -> napi::Result<BuiltTraceSink> {
     }
 }
 
+/// A tool's searchable metadata: what the registry indexes and what a search
+/// hit resolves back to. Execution lives a layer up (the SDK's `ToolCatalog`
+/// pairs each `Tool` with its executor).
 #[napi(object)]
 pub struct Tool {
+    /// Unique id, the registry key. Re-registering an existing id replaces the
+    /// entry in place. MCP-proxied tools use the `<server>__<tool>` convention.
     pub id: String,
+    /// Callable name (typically the same as `id` for local tools); indexed for
+    /// ranking both whole and split on `snake_case`/`camelCase` boundaries.
     pub name: String,
+    /// What the tool does and when to use it — the main ranking signal.
     pub description: String,
+    /// JSON Schema of the arguments. Property names and their `description`s
+    /// (nested included) are indexed for ranking.
     #[napi(ts_type = "import('json-schema').JSONSchema7")]
     pub input_schema: Value,
+    /// JSON Schema of the result; indexed the same way as `inputSchema`.
     #[napi(ts_type = "import('json-schema').JSONSchema7")]
     pub output_schema: Value,
 }
 
+/// One ranked tool from a registry search, best-first.
 #[napi(object)]
 pub struct SearchHit {
+    /// Id of the matched tool, as registered.
     pub tool_id: String,
+    /// Relevance score; higher is better, ties break by id ascending. The scale
+    /// depends on the method: raw BM25 (unbounded) for `"bm25"`, cosine
+    /// similarity for `"semantic"`, Reciprocal Rank Fusion for `"hybrid"` —
+    /// comparable within one result list, not across methods.
     pub score: f64,
 }
 
+/// Destination for the local trace stream (ADR-0007): `"noop"` discards,
+/// `"memory"` buffers envelopes for `drainTraceEvents`, `"jsonl"` appends one
+/// JSON envelope per line to `path`.
 #[napi(object)]
 pub struct TraceSinkConfig {
     /// One of "noop" | "memory" | "jsonl".
@@ -69,6 +89,10 @@ pub struct TraceSinkConfig {
     pub path: Option<String>,
 }
 
+/// Node binding over the `ratel-ai-core` tool registry: an in-process index
+/// that ranks registered tools against a natural-language query (BM25 by
+/// default; semantic/hybrid once embeddings are built). Metadata-only — the
+/// SDK's `ToolCatalog` layers executors, OTel spans, and defaults on top.
 #[napi]
 pub struct ToolRegistry {
     inner: core::ToolRegistry,
@@ -77,6 +101,7 @@ pub struct ToolRegistry {
 
 #[napi]
 impl ToolRegistry {
+    /// Create an empty registry with a no-op trace sink.
     #[napi(constructor)]
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
@@ -86,6 +111,9 @@ impl ToolRegistry {
         }
     }
 
+    /// Index a tool, or replace one in place if its id is already registered
+    /// (the corpus never holds a duplicate). Infallible and model-free; a
+    /// semantic caller embeds afterwards via `buildEmbeddings`.
     #[napi]
     pub fn register(&mut self, tool: Tool) {
         self.inner.register(core::Tool {
@@ -97,6 +125,9 @@ impl ToolRegistry {
         });
     }
 
+    /// Lexical BM25 search: up to `topK` hits, best-first with ties broken by
+    /// id. Model-free and infallible; an empty registry returns `[]`. Records
+    /// the query on the local trace stream with origin `"direct"`.
     #[napi]
     pub fn search(&self, query: String, top_k: u32) -> Vec<SearchHit> {
         self.inner
@@ -109,6 +140,10 @@ impl ToolRegistry {
             .collect()
     }
 
+    /// BM25 search with an explicit origin — `"agent"` for a call the model
+    /// synthesized (capability tools), anything else counts as `"direct"`
+    /// (host code). Origin only annotates the trace event; ranking is
+    /// identical to `search`.
     #[napi]
     pub fn search_with_origin(&self, query: String, top_k: u32, origin: String) -> Vec<SearchHit> {
         let parsed = match origin.as_str() {
@@ -170,6 +205,12 @@ impl ToolRegistry {
             .map_err(|e| napi::Error::from_reason(e.to_string()))
     }
 
+    /// Record a custom event on the local trace stream (ADR-0007). `event` is
+    /// the tagged wire shape — `{ type: "...", ... }` with snake_case fields —
+    /// and an object that doesn't parse as a known event throws
+    /// (`invalid trace event`). Higher layers use this to put their
+    /// invoke/upstream/auth lifecycle events on the same stream as the
+    /// registry's own search events.
     #[napi]
     pub fn record_event(&self, event: Value) -> napi::Result<()> {
         let event: TraceEvent = serde_json::from_value(event)
@@ -178,6 +219,9 @@ impl ToolRegistry {
         Ok(())
     }
 
+    /// Replace the trace sink; subsequent events go to the new destination,
+    /// already-recorded ones are not replayed. Throws on an unknown `kind`, a
+    /// missing `sessionId`/`path`, or a `"jsonl"` file that can't be opened.
     #[napi]
     pub fn set_trace_sink(&mut self, config: TraceSinkConfig) -> napi::Result<()> {
         let (sink, memory) = build_trace_sink(config)?;
@@ -200,10 +244,19 @@ impl ToolRegistry {
     }
 }
 
+/// A reusable playbook: instructions the agent *reads* and follows, in
+/// contrast to a `Tool` it executes. Name, description, and tags are indexed
+/// for ranking; the `body` is the dispatch payload, deliberately excluded from
+/// the index so it can't drown the description's term weights.
 #[napi(object)]
 pub struct Skill {
+    /// Unique id, the registry key. Re-registering an existing id replaces the
+    /// entry in place.
     pub id: String,
+    /// Human-readable name; indexed for ranking both whole and split on
+    /// `snake_case`/`camelCase` boundaries.
     pub name: String,
+    /// What the skill covers and when to reach for it — the main ranking signal.
     pub description: String,
     /// Author-declared labels and task phrases ("frontend", "login form");
     /// indexed for ranking. Optional (defaults to `[]`) — a minimal
@@ -215,16 +268,27 @@ pub struct Skill {
     /// Free-form, non-indexed context for higher layers — e.g.
     /// `{ stacks: ["react"] }` for the push ranker to boost by project context.
     pub metadata: Option<HashMap<String, Vec<String>>>,
+    /// The full instructions (Markdown) returned on load — the dispatch
+    /// payload, never indexed for ranking.
     /// Optional (defaults to `""`) — parity with the Python SDK's default body.
     pub body: Option<String>,
 }
 
+/// One ranked skill from a registry search, best-first — the skill twin of
+/// `SearchHit`, with the same score semantics per method.
 #[napi(object)]
 pub struct SkillHit {
+    /// Id of the matched skill, as registered.
     pub skill_id: String,
+    /// Relevance score; higher is better, ties break by id ascending. Scale
+    /// depends on the method (BM25 / cosine / RRF), as on `SearchHit.score`.
     pub score: f64,
 }
 
+/// Node binding over the `ratel-ai-core` skill registry — the skill twin of
+/// `ToolRegistry`, ranking registered skills against a natural-language query.
+/// Skill bodies are stored but never indexed; fetch them a layer up (the SDK's
+/// `SkillCatalog.invoke`).
 #[napi]
 pub struct SkillRegistry {
     inner: core::SkillRegistry,
@@ -233,6 +297,7 @@ pub struct SkillRegistry {
 
 #[napi]
 impl SkillRegistry {
+    /// Create an empty registry with a no-op trace sink.
     #[napi(constructor)]
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
@@ -242,6 +307,9 @@ impl SkillRegistry {
         }
     }
 
+    /// Index a skill, or replace one in place if its id is already registered.
+    /// Omitted optional fields default to empty (`tags`/`tools`/`metadata`)
+    /// and `""` (`body`). See `ToolRegistry.register`.
     #[napi]
     pub fn register(&mut self, skill: Skill) {
         self.inner.register(core::Skill {
@@ -255,6 +323,8 @@ impl SkillRegistry {
         });
     }
 
+    /// Lexical BM25 search over skills — see `ToolRegistry.search` for the
+    /// contract (best-first, ties by id, infallible, traced as `"direct"`).
     #[napi]
     pub fn search(&self, query: String, top_k: u32) -> Vec<SkillHit> {
         self.inner
@@ -267,6 +337,7 @@ impl SkillRegistry {
             .collect()
     }
 
+    /// BM25 search with an explicit origin — see `ToolRegistry.searchWithOrigin`.
     #[napi]
     pub fn search_with_origin(&self, query: String, top_k: u32, origin: String) -> Vec<SkillHit> {
         let parsed = match origin.as_str() {
@@ -323,6 +394,9 @@ impl SkillRegistry {
             .map_err(|e| napi::Error::from_reason(e.to_string()))
     }
 
+    /// Record a custom event on the local trace stream — see
+    /// `ToolRegistry.recordEvent`. Throws on an object that doesn't parse as a
+    /// known trace event.
     #[napi]
     pub fn record_event(&self, event: Value) -> napi::Result<()> {
         let event: TraceEvent = serde_json::from_value(event)
@@ -331,6 +405,7 @@ impl SkillRegistry {
         Ok(())
     }
 
+    /// Replace the trace sink — see `ToolRegistry.setTraceSink`.
     #[napi]
     pub fn set_trace_sink(&mut self, config: TraceSinkConfig) -> napi::Result<()> {
         let (sink, memory) = build_trace_sink(config)?;

--- a/src/sdk/ts/package.json
+++ b/src/sdk/ts/package.json
@@ -42,7 +42,8 @@
     "build:ts": "tsc",
     "build": "pnpm build:native && pnpm build:ts",
     "typecheck": "pnpm build:native && tsc --noEmit",
-    "lint": "biome check src",
+    "docs:check": "typedoc",
+    "lint": "biome check src && pnpm docs:check",
     "test": "pnpm build:native && vitest run"
   },
   "napi": {
@@ -64,6 +65,7 @@
     "@napi-rs/cli": "^3.6.0",
     "@opentelemetry/context-async-hooks": "^2.9.0",
     "@opentelemetry/sdk-trace-base": "^2.9.0",
+    "typedoc": "^0.28.20",
     "typescript": "^5.6.0",
     "vitest": "^4.1.5"
   },

--- a/src/sdk/ts/src/capabilities.ts
+++ b/src/sdk/ts/src/capabilities.ts
@@ -3,7 +3,15 @@ import { compactDescription } from "./compact.js";
 import type { SkillCatalog } from "./skill-catalog.js";
 import { recordAuthNeeded, upstreamFromToolId } from "./telemetry.js";
 
+/**
+ * Wire id (`"search_capabilities"`) of the discovery capability tool built by
+ * {@link searchCapabilitiesTool} — the name the model calls it by.
+ */
 export const SEARCH_CAPABILITIES_ID = "search_capabilities" as const;
+/**
+ * Wire id (`"invoke_tool"`) of the execution capability tool built by
+ * {@link invokeToolTool} — the name the model calls it by.
+ */
 export const INVOKE_TOOL_ID = "invoke_tool" as const;
 
 const DEFAULT_TOP_K_TOOLS = 5;
@@ -37,42 +45,105 @@ const RESULT_TOOLS_AND_SKILLS =
   "playbooks — load one's instructions via get_skill_content, then follow it). Skills have their own " +
   "result budget, so they are never crowded out by tools.";
 
+/**
+ * Descriptive metadata about one upstream MCP server behind the catalog. Fed
+ * to {@link searchCapabilitiesTool} via {@link SearchCapabilitiesOptions}: the
+ * servers are listed in the tool's description (via
+ * {@link formatUpstreamLine}), and `description`/`instructions` enrich the
+ * matching {@link CapabilityToolGroup.server} in results.
+ */
 export interface UpstreamServerInfo {
+  /**
+   * Server name; must match the `name` the server was registered under
+   * (`registerMcpServer`), i.e. the `<name>__` prefix of its tool ids.
+   */
   name: string;
+  /** One-line summary of what the server offers; compacted in the listing. */
   description?: string;
+  /** The server's own usage instructions (e.g. `McpServerHandle.serverInstructions`). */
   instructions?: string;
+  /** Number of tools the server contributes; shown in the listing when set. */
   toolCount?: number;
   /** True when the upstream rejected its boot connection with 401 / requires re-authorization. */
   needsAuth?: boolean;
 }
 
+/** Options for {@link searchCapabilitiesTool}. */
 export interface SearchCapabilitiesOptions {
+  /** Upstream MCP servers to advertise in the tool description and result groups. */
   upstreamServers?: readonly UpstreamServerInfo[];
 }
 
+/** One ranked tool in the `tools` bucket of {@link SearchCapabilitiesResult}. */
 export interface CapabilityToolHit {
+  /** Catalog id to pass to `invoke_tool` (`<server>__<tool>` for MCP-proxied tools). */
   toolId: string;
+  /**
+   * Retrieval score from the tool catalog's search (scale depends on the
+   * catalog's method — BM25 by default), or `0` when the tool was pulled in as
+   * a matched skill's declared dependency rather than by the query itself.
+   */
   score: number;
+  /** The tool's description, as registered. */
   description: string;
+  /** The tool's input JSON Schema, so the model can call it without another lookup. */
   inputSchema: Record<string, unknown>;
 }
 
+/**
+ * Tool hits grouped by upstream server. The group key is the `<server>__` id
+ * prefix (a plain, un-prefixed tool id groups under itself); `description` and
+ * `instructions` are attached when a matching {@link UpstreamServerInfo} was
+ * provided.
+ */
 export interface CapabilityToolGroup {
-  server: { name: string; description?: string; instructions?: string };
+  /** The owning server: its name, plus optional description/instructions metadata. */
+  server: {
+    /** Server name (the `<server>__` prefix of the group's tool ids). */
+    name: string;
+    /** The server's one-line summary, when known. */
+    description?: string;
+    /** The server's usage instructions, when known. */
+    instructions?: string;
+  };
+  /** The server's ranked hits, in overall result order. */
   hits: CapabilityToolHit[];
 }
 
+/** One ranked skill in the `skills` bucket of {@link SearchCapabilitiesResult}. */
 export interface CapabilitySkillHit {
+  /** Skill id to pass to `get_skill_content`. */
   skillId: string;
+  /** Retrieval score from the skill catalog's search (BM25 by default). */
   score: number;
+  /** The skill's description, compacted to ~160 chars for the listing. */
   description: string;
 }
 
+/**
+ * Result shape of the `search_capabilities` tool: two independently-ranked
+ * buckets with separate top-K budgets. Scores are comparable within a bucket,
+ * not across the two (tools and skills are indexed as different text shapes).
+ */
 export interface SearchCapabilitiesResult {
-  tools: { groups: CapabilityToolGroup[] };
+  /** Executable tool hits, grouped by upstream server. */
+  tools: {
+    /** Groups in ranking order (a server appears where its best hit ranked). */
+    groups: CapabilityToolGroup[];
+  };
+  /** Skill hits — playbooks to load via `get_skill_content`. */
   skills: CapabilitySkillHit[];
 }
 
+/**
+ * Format one upstream server as the bullet line the capability-tool
+ * descriptions embed (`- <name> — <description> (<n> tools) (auth required)`,
+ * omitting the parts that are unset). Exported for the deprecated
+ * `searchToolsTool` shim, which builds the same listing.
+ *
+ * @param s - The server to describe.
+ * @returns A single `- `-prefixed line with the description compacted.
+ */
 export function formatUpstreamLine(s: UpstreamServerInfo): string {
   let line = `- ${s.name}`;
   if (s.description) line += ` — ${compactDescription(s.description)}`;
@@ -90,10 +161,38 @@ function buildSearchDescription(hasSkills: boolean, opts?: SearchCapabilitiesOpt
 }
 
 /**
- * Unified discovery over tools AND skills. Returns two independently-ranked
- * buckets, each with its own top-K budget — so a relevant skill can never be
- * starved out of the results by a large number of matching tools (and we avoid
- * comparing BM25 scores across the two different text shapes).
+ * Build the `search_capabilities` capability tool: unified discovery over
+ * tools AND skills. Its result carries two independently-ranked buckets, each
+ * with its own top-K budget — so a relevant skill can never be starved out of
+ * the results by a large number of matching tools (and we avoid comparing BM25
+ * scores across the two different text shapes).
+ *
+ * The tool takes `{ query, topKTools?, topKSkills? }` (defaults 5 and 3;
+ * values above 50 are capped, anything else non-positive or non-integer falls
+ * back to the default) and resolves to a {@link SearchCapabilitiesResult}. A
+ * matched skill's declared tool dependencies are pulled into the `tools`
+ * bucket additively — score `0`, beyond the `topKTools` budget, deduped
+ * against query hits. The `skills` bucket (and its mention in the tool
+ * description) exists only when `skillCatalog` is non-empty at build time.
+ * Each call records a `gateway_search` event on the local trace stream.
+ *
+ * @param toolCatalog - Catalog the `tools` bucket is ranked from.
+ * @param skillCatalog - Optional catalog the `skills` bucket is ranked from.
+ * @param opts - Upstream-server metadata for the description and result groups.
+ * @returns The tool, ready to expose to the model (and to register alongside
+ *   {@link invokeToolTool}, which executes what this discovers).
+ *
+ * @example
+ * ```ts
+ * import { searchCapabilitiesTool, type SearchCapabilitiesResult } from "@ratel-ai/sdk";
+ *
+ * const discovery = searchCapabilitiesTool(toolCatalog, skillCatalog, {
+ *   upstreamServers: [{ name: "github", description: "GitHub API", toolCount: 30 }],
+ * });
+ * const result = (await discovery.execute({
+ *   query: "open a pull request",
+ * })) as SearchCapabilitiesResult;
+ * ```
  */
 export function searchCapabilitiesTool(
   toolCatalog: ToolCatalog,
@@ -262,11 +361,32 @@ export function searchCapabilitiesTool(
   };
 }
 
+/** Options for {@link invokeToolTool}. */
 export interface InvokeToolToolOptions {
   /** Notified when the underlying tool throws UnauthorizedError, with the upstream name inferred from the toolId. */
   onUnauthorized?: (upstream: string) => void | Promise<void>;
 }
 
+/**
+ * Build the `invoke_tool` capability tool: the execution counterpart to
+ * {@link searchCapabilitiesTool}. Takes `{ toolId, args }` and runs the
+ * catalog tool via {@link ToolCatalog.invoke}, returning its result.
+ *
+ * Failures come back as structured `{ error, isError: true }` results, not
+ * rejections, so the model can read and recover from them: an unknown
+ * `toolId` (with a hint to search first), a non-object `args`, or a thrown
+ * executor error. A tool that throws `UnauthorizedError` gets special
+ * handling — `opts.onUnauthorized` fires with the upstream name inferred from
+ * the `<server>__` id prefix, a `ratel.auth.flow` span records the outcome,
+ * and the result is `{ error: "needs_auth", isError: true, upstream?, hint }`.
+ * A call with `args` missing (or `null`) is tolerated by treating the
+ * remaining top-level keys as the arguments. Outcomes are recorded as
+ * `gateway_invoke` / `gateway_error` events on the local trace stream.
+ *
+ * @param catalog - Catalog whose tools this executes.
+ * @param opts - Optional auth-failure callback.
+ * @returns The tool, ready to expose to the model.
+ */
 export function invokeToolTool(
   catalog: ToolCatalog,
   opts: InvokeToolToolOptions = {},

--- a/src/sdk/ts/src/catalog.ts
+++ b/src/sdk/ts/src/catalog.ts
@@ -2,29 +2,120 @@ import { SearchTarget } from "@ratel-ai/telemetry";
 import { type SearchHit, type Tool, ToolRegistry } from "../native/index.cjs";
 import { argsSizeBytes, errorMessage, traceExecuteTool, traceSearch } from "./telemetry.js";
 
+/**
+ * The function that runs a tool. Receives the arguments object and may return
+ * either a plain value or a `Promise` — {@link ToolCatalog.invoke} awaits both,
+ * so synchronous executors need no wrapping.
+ */
 // biome-ignore lint/suspicious/noExplicitAny: tool inputs are heterogeneous across the catalog
 export type Executor = (input: any) => Promise<unknown> | unknown;
 
+/**
+ * A tool the catalog can both retrieve *and* run: the searchable metadata of a
+ * `Tool` (id, name, description, schemas) plus its {@link Executor}. The unit
+ * {@link ToolCatalog.register} accepts and {@link ToolCatalog.getExecutable}
+ * returns.
+ */
 export interface ExecutableTool extends Tool {
+  /** Runs the tool. Called by {@link ToolCatalog.invoke} with the args object. */
   execute: Executor;
 }
 
+/**
+ * Where the local trace stream (ADR-0007) goes. Distinct from the OTel spans in
+ * {@link ToolCatalog}'s docs — this is the in-process channel drained via
+ * {@link ToolCatalog.drainTraceEvents} or written to disk.
+ *
+ * - `"noop"` — discard every event (the default when no `trace` option is given).
+ * - `"memory"` — buffer envelopes in-process; read them back with
+ *   {@link ToolCatalog.drainTraceEvents}. `sessionId` is stamped on each envelope.
+ * - `"jsonl"` — append one JSON envelope per line to the file at `path`
+ *   (parent directories are created). `sessionId` is stamped on each envelope.
+ */
 export type TraceSinkConfig =
-  | { kind: "noop" }
-  | { kind: "memory"; sessionId: string }
-  | { kind: "jsonl"; sessionId: string; path: string };
+  | {
+      /** Discard every event. */
+      kind: "noop";
+    }
+  | {
+      /** Buffer envelopes in-process for `drainTraceEvents`. */
+      kind: "memory";
+      /** Session id stamped on every envelope. */
+      sessionId: string;
+    }
+  | {
+      /** Append one JSON envelope per line to `path`. */
+      kind: "jsonl";
+      /** Session id stamped on every envelope. */
+      sessionId: string;
+      /** File to append to; parent directories are created. */
+      path: string;
+    };
 
+/**
+ * Who initiated a search: `"direct"` for host code calling the SDK itself
+ * (pre-fetch helpers, benchmarks), `"agent"` for a call the model synthesized
+ * through the capability tools (`search_capabilities`). Recorded on trace
+ * events and the `ratel.origin` span attribute so consumers can separate the
+ * two paths.
+ */
 export type SearchOrigin = "direct" | "agent";
 
+/**
+ * Retrieval engine for {@link ToolCatalog.search} (and the skill catalog's
+ * `search`):
+ *
+ * - `"bm25"` — lexical ranking; model-free and infallible (the default).
+ * - `"semantic"` — cosine similarity over prebuilt embeddings.
+ * - `"hybrid"` — BM25 and semantic rankings fused with Reciprocal Rank Fusion
+ *   (ADR-0011).
+ *
+ * `"semantic"`/`"hybrid"` require the embedding cache (built eagerly at
+ * registration when they are the catalog default, or via `buildEmbeddings()`).
+ */
 export type SearchMethod = "bm25" | "semantic" | "hybrid";
 
+/** Construction options for {@link ToolCatalog}. */
 export interface ToolCatalogOptions {
+  /** Local trace stream destination (default: discard). See {@link TraceSinkConfig}. */
   trace?: TraceSinkConfig;
   /** Default retrieval method for `search` (default `"bm25"`, model-free). A
    * per-call `method` argument overrides it. */
   method?: SearchMethod;
 }
 
+/**
+ * In-process catalog of executable tools, ranked by the native Rust registry.
+ * The SDK's central surface: {@link ToolCatalog.register} tools (or ingest an
+ * MCP server's via `registerMcpServer`), {@link ToolCatalog.search} them by
+ * relevance, and {@link ToolCatalog.invoke} the chosen one. Every operation
+ * emits both an OTel span (to whatever provider is active — see telemetry.ts)
+ * and a local trace event (to the sink from {@link ToolCatalogOptions.trace}),
+ * per ADR-0007.
+ *
+ * @example
+ * ```ts
+ * import { ToolCatalog } from "@ratel-ai/sdk";
+ * import { readFile } from "node:fs/promises";
+ *
+ * const catalog = new ToolCatalog();
+ * catalog.register({
+ *   id: "read_file",
+ *   name: "read_file",
+ *   description: "Read a file from local disk and return its textual contents.",
+ *   inputSchema: {
+ *     type: "object",
+ *     properties: { path: { type: "string", description: "absolute path to the file" } },
+ *     required: ["path"],
+ *   },
+ *   outputSchema: { type: "object" },
+ *   execute: async ({ path }) => ({ contents: await readFile(path, "utf8") }),
+ * });
+ *
+ * const [hit] = catalog.search("read a file from disk", 5);
+ * const result = await catalog.invoke(hit.toolId, { path: "/tmp/notes.txt" });
+ * ```
+ */
 export class ToolCatalog {
   private readonly registry: ToolRegistry;
   private readonly executors = new Map<string, Executor>();
@@ -32,6 +123,14 @@ export class ToolCatalog {
   private readonly method: SearchMethod;
   private readonly eager: boolean;
 
+  /**
+   * Create an empty catalog.
+   *
+   * @param options - Trace sink and default retrieval method. A `"semantic"`/
+   *   `"hybrid"` default makes every subsequent `register` embed the new tool
+   *   immediately (loading the embedding model on first use); the `"bm25"`
+   *   default stays model-free.
+   */
   constructor(options: ToolCatalogOptions = {}) {
     this.registry = new ToolRegistry();
     this.method = options.method ?? "bm25";
@@ -43,6 +142,14 @@ export class ToolCatalog {
     }
   }
 
+  /**
+   * Add a tool to the catalog, or replace it in place when the id is already
+   * registered (metadata, executor, and index entry — the corpus never holds a
+   * duplicate). On a semantic/hybrid catalog this also embeds the new tool
+   * immediately, and throws if the embedding model fails to load.
+   *
+   * @param tool - The tool's searchable metadata plus its `execute` function.
+   */
   register(tool: ExecutableTool): void {
     const { execute, ...metadata } = tool;
     this.registry.register(metadata);
@@ -55,17 +162,33 @@ export class ToolCatalog {
     }
   }
 
-  /** Pre-compute embeddings for any not-yet-embedded tools. Call after a bulk
+  /**
+   * Pre-compute embeddings for any not-yet-embedded tools. Call after a bulk
    * register, or rely on the automatic per-register embedding a semantic/hybrid
-   * catalog does. No-op for a BM25 catalog's cache. */
+   * catalog does. No-op for a BM25 catalog's cache. Incremental: only tools
+   * registered since the last call are embedded. Throws if the embedding model
+   * fails to load.
+   */
   buildEmbeddings(): void {
     this.registry.buildEmbeddings();
   }
 
-  /** Search the catalog. `method` overrides the catalog default for this call.
+  /**
+   * Search the catalog. `method` overrides the catalog default for this call.
    * `"semantic"`/`"hybrid"` rank against the prebuilt embedding cache and throw
    * `EmbeddingsNotBuilt` if it isn't built; they never load the model in-search (a
-   * semantic/hybrid catalog builds embeddings eagerly at register). */
+   * semantic/hybrid catalog builds embeddings eagerly at register).
+   *
+   * @param query - Natural-language description of what the caller wants to do.
+   * @param topK - Maximum number of hits to return.
+   * @param origin - Who initiated the call (default `"direct"`); recorded on
+   *   the trace event and span, never affects ranking.
+   * @param method - Per-call override of the catalog's default retrieval method.
+   * @returns Up to `topK` hits, best-first with ties broken by tool id. The
+   *   `score` scale depends on the method: a raw BM25 relevance score, a cosine
+   *   similarity, or an RRF fusion score — comparable within one result list,
+   *   not across methods.
+   */
   search(
     query: string,
     topK: number,
@@ -77,14 +200,33 @@ export class ToolCatalog {
     );
   }
 
+  /**
+   * Whether a tool with this id is registered.
+   *
+   * @param toolId - The id to look up.
+   * @returns `true` if {@link ToolCatalog.invoke} would find an executor for it.
+   */
   has(toolId: string): boolean {
     return this.executors.has(toolId);
   }
 
+  /**
+   * Look up a tool's searchable metadata (no executor attached).
+   *
+   * @param toolId - The id to look up.
+   * @returns The metadata as registered, or `undefined` for an unknown id.
+   */
   get(toolId: string): Tool | undefined {
     return this.tools.get(toolId);
   }
 
+  /**
+   * Look up a tool with its executor reattached.
+   *
+   * @param toolId - The id to look up.
+   * @returns A copy of the registered tool including `execute`, or `undefined`
+   *   for an unknown id.
+   */
   getExecutable(toolId: string): ExecutableTool | undefined {
     const tool = this.tools.get(toolId);
     const execute = this.executors.get(toolId);
@@ -92,14 +234,45 @@ export class ToolCatalog {
     return { ...tool, execute };
   }
 
+  /**
+   * Record a custom event on the local trace stream (ADR-0007), e.g. an
+   * `upstream_register` from an ingestion layer. Delivered to the sink
+   * configured at construction; a no-op sink discards it.
+   *
+   * @param event - A tagged trace event in wire shape: `{ type: "...", ... }`
+   *   with snake_case fields. Throws if the object is not a known trace event.
+   */
   recordEvent(event: object): void {
     this.registry.recordEvent(event);
   }
 
+  /**
+   * Drain the envelopes captured by a `"memory"` trace sink, emptying its
+   * buffer.
+   *
+   * @returns The captured envelopes (`{ v, ts, session_id, type, ... }` — the
+   *   event fields are flattened alongside the envelope stamp) in record
+   *   order. Always `[]` unless the active sink is `"memory"`.
+   */
   drainTraceEvents(): unknown[] {
     return this.registry.drainTraceEvents();
   }
 
+  /**
+   * Run a registered tool's executor. Sync-absorbing: the executor may return
+   * a plain value or a `Promise` (both are awaited), and a synchronous `throw`
+   * inside it surfaces as a rejection of the returned promise — `invoke` never
+   * throws synchronously, including for an unknown `toolId` (that rejects with
+   * `unknown toolId: …`).
+   *
+   * The call is wrapped in an `execute_tool` OTel span and bracketed by
+   * `invoke_start` / `invoke_end` (or `invoke_error`, with the error message)
+   * events on the local trace stream, `took_ms` in wall-clock milliseconds.
+   *
+   * @param toolId - Id of a registered tool.
+   * @param args - Arguments object passed through to the executor unchanged.
+   * @returns Whatever the executor returns (resolved if it returned a promise).
+   */
   async invoke(toolId: string, args: Record<string, unknown>): Promise<unknown> {
     const fn = this.executors.get(toolId);
     if (!fn) {

--- a/src/sdk/ts/src/compat.ts
+++ b/src/sdk/ts/src/compat.ts
@@ -29,25 +29,40 @@ const SEARCH_TOOLS_BASE_DESCRIPTION =
 
 /** @deprecated Use `SearchCapabilitiesOptions`. */
 export interface SearchToolsToolOptions {
+  /** Upstream MCP servers to advertise in the tool description and result groups. */
   upstreamServers?: readonly UpstreamServerInfo[];
 }
 
 /** @deprecated Use `CapabilityToolHit`. */
 export interface SearchToolHit {
+  /** Catalog id to pass to `invoke_tool`. */
   toolId: string;
+  /** Retrieval score from the catalog's search (BM25 by default). */
   score: number;
+  /** The tool's description, as registered. */
   description: string;
+  /** The tool's input JSON Schema. */
   inputSchema: Record<string, unknown>;
 }
 
 /** @deprecated Use `CapabilityToolGroup`. */
 export interface SearchToolsGroup {
-  server: { name: string; description?: string; instructions?: string };
+  /** The owning server: its name, plus optional description/instructions metadata. */
+  server: {
+    /** Server name (the `<server>__` prefix of the group's tool ids). */
+    name: string;
+    /** The server's one-line summary, when known. */
+    description?: string;
+    /** The server's usage instructions, when known. */
+    instructions?: string;
+  };
+  /** The server's ranked hits, in overall result order. */
   hits: SearchToolHit[];
 }
 
 /** @deprecated Use `SearchCapabilitiesResult` (the `tools.groups` field). */
 export interface SearchToolsResult {
+  /** Tool hits grouped by upstream server, in ranking order. */
   groups: SearchToolsGroup[];
 }
 

--- a/src/sdk/ts/src/index.ts
+++ b/src/sdk/ts/src/index.ts
@@ -1,3 +1,16 @@
+/**
+ * `@ratel-ai/sdk` — TypeScript SDK for Ratel, the context engineering platform
+ * for AI agents. In-process, no infra: a native (Rust) BM25/semantic/hybrid
+ * index behind {@link ToolCatalog} and {@link SkillCatalog}, MCP ingestion via
+ * {@link registerMcpServer}, and the framework-neutral capability tools
+ * ({@link searchCapabilitiesTool}, {@link invokeToolTool},
+ * {@link getSkillContentTool}) that let a model discover and run what the
+ * catalogs hold. Everything emits OTel `ratel.*`/`gen_ai.*` spans plus a local
+ * trace stream (ADR-0007).
+ *
+ * @packageDocumentation
+ */
+
 export type { SearchHit, Skill, SkillHit, Tool } from "../native/index.cjs";
 export { SkillRegistry, ToolRegistry } from "../native/index.cjs";
 export type {

--- a/src/sdk/ts/src/mcp.ts
+++ b/src/sdk/ts/src/mcp.ts
@@ -4,17 +4,73 @@ import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { ToolCatalog } from "./catalog.js";
 import { traceUpstreamRegister } from "./telemetry.js";
 
+/** Options for {@link registerMcpServer}. */
 export interface RegisterMcpServerOptions {
+  /**
+   * Namespace for the server's tools inside the catalog: each tool is
+   * registered as `<name>__<toolName>`. Also the `server` name that trace
+   * events and result groups report for these tools.
+   */
   name: string;
+  /**
+   * An MCP client transport for the server (e.g. `StdioClientTransport`,
+   * `StreamableHTTPClientTransport`, or an `InMemoryTransport` pair in tests).
+   * {@link registerMcpServer} connects it; it must not be connected already.
+   */
   transport: Transport;
 }
 
+/** What {@link registerMcpServer} returns: the ingested ids plus lifecycle control. */
 export interface McpServerHandle {
+  /** Namespaced ids (`<name>__<toolName>`) of every tool registered, in server order. */
   toolIds: string[];
+  /**
+   * The usage instructions the server declared during the MCP initialize
+   * handshake, or `undefined` if it declared none. Useful as
+   * `UpstreamServerInfo.instructions` when building capability tools.
+   */
   serverInstructions: string | undefined;
+  /**
+   * Close the underlying MCP client connection. The proxied tools stay in the
+   * catalog but invoking them after close fails.
+   */
   close: () => Promise<void>;
 }
 
+/**
+ * Ingest an MCP server into a {@link ToolCatalog}: connect over the given
+ * transport, list its tools once (no live refresh), and register each as an
+ * {@link ToolCatalog.register | executable tool} whose executor proxies
+ * `callTool` on the live client. A missing tool description registers as `""`;
+ * a missing output schema as `{ type: "object" }`.
+ *
+ * The whole registration is one `ratel.upstream.register` OTel span and an
+ * `upstream_register` local trace event; each later invocation records
+ * `upstream_invoke` (or `upstream_error`) alongside the catalog's own events
+ * (ADR-0007). Rejects if connecting or listing tools fails.
+ *
+ * @param catalog - Catalog that receives the proxied tools.
+ * @param options - Server name (the id namespace) and transport.
+ * @returns A handle with the registered ids, the server's instructions, and
+ *   `close()`.
+ *
+ * @example
+ * ```ts
+ * import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+ * import { registerMcpServer, ToolCatalog } from "@ratel-ai/sdk";
+ *
+ * const catalog = new ToolCatalog();
+ * const github = await registerMcpServer(catalog, {
+ *   name: "github",
+ *   transport: new StdioClientTransport({ command: "github-mcp-server" }),
+ * });
+ * // github.toolIds → ["github__create_issue", "github__get_pull_request", ...]
+ * const result = await catalog.invoke("github__create_issue", {
+ *   title: "Flaky test on main",
+ * });
+ * await github.close();
+ * ```
+ */
 export async function registerMcpServer(
   catalog: ToolCatalog,
   options: RegisterMcpServerOptions,

--- a/src/sdk/ts/src/skill-catalog.ts
+++ b/src/sdk/ts/src/skill-catalog.ts
@@ -5,7 +5,9 @@ import { traceSearch, traceSkillLoad } from "./telemetry.js";
 
 export type { Skill, SkillHit };
 
+/** Construction options for {@link SkillCatalog}. */
 export interface SkillCatalogOptions {
+  /** Local trace stream destination (default: discard). See {@link TraceSinkConfig}. */
   trace?: TraceSinkConfig;
   /** Default retrieval method for `search` (default `"bm25"`). */
   method?: SearchMethod;
@@ -22,6 +24,14 @@ export class SkillCatalog {
   private readonly method: SearchMethod;
   private readonly eager: boolean;
 
+  /**
+   * Create an empty catalog.
+   *
+   * @param options - Trace sink and default retrieval method. A `"semantic"`/
+   *   `"hybrid"` default makes every subsequent `register` embed the new skill
+   *   immediately (loading the embedding model on first use); the `"bm25"`
+   *   default stays model-free.
+   */
   constructor(options: SkillCatalogOptions = {}) {
     this.registry = new SkillRegistry();
     this.method = options.method ?? "bm25";
@@ -31,6 +41,16 @@ export class SkillCatalog {
     }
   }
 
+  /**
+   * Add a skill to the catalog, or replace it in place when the id is already
+   * registered. Name, description, and tags are indexed for ranking; the
+   * `body` is not (it is the dispatch payload, fetched by
+   * {@link SkillCatalog.invoke}). On a semantic/hybrid catalog this also
+   * embeds the new skill immediately, and throws if the embedding model fails
+   * to load.
+   *
+   * @param skill - The skill to register; `id` is its lookup key.
+   */
   register(skill: Skill): void {
     this.registry.register(skill);
     this.skills.set(skill.id, skill);
@@ -44,6 +64,19 @@ export class SkillCatalog {
     this.registry.buildEmbeddings();
   }
 
+  /**
+   * Search the catalog — the skill counterpart of `ToolCatalog.search`, with
+   * the same method semantics (a `"semantic"`/`"hybrid"` call throws
+   * `EmbeddingsNotBuilt` if the embedding cache isn't built).
+   *
+   * @param query - Natural-language description of the task at hand.
+   * @param topK - Maximum number of hits to return.
+   * @param origin - Who initiated the call (default `"direct"`); recorded on
+   *   the trace event and span, never affects ranking.
+   * @param method - Per-call override of the catalog's default retrieval method.
+   * @returns Up to `topK` hits, best-first with ties broken by skill id; the
+   *   `score` scale depends on the method (BM25 / cosine / RRF).
+   */
   search(
     query: string,
     topK: number,
@@ -55,22 +88,55 @@ export class SkillCatalog {
     );
   }
 
+  /**
+   * Whether a skill with this id is registered.
+   *
+   * @param skillId - The id to look up.
+   * @returns `true` if {@link SkillCatalog.invoke} would find it.
+   */
   has(skillId: string): boolean {
     return this.skills.has(skillId);
   }
 
+  /**
+   * Look up a skill by id.
+   *
+   * @param skillId - The id to look up.
+   * @returns The skill as registered (including `body`), or `undefined` for an
+   *   unknown id.
+   */
   get(skillId: string): Skill | undefined {
     return this.skills.get(skillId);
   }
 
+  /**
+   * Number of registered skills (distinct ids). `searchCapabilitiesTool` uses
+   * this to decide whether to advertise a `skills` bucket at all.
+   *
+   * @returns The count.
+   */
   size(): number {
     return this.skills.size;
   }
 
+  /**
+   * Record a custom event on the local trace stream (ADR-0007). Same contract
+   * as `ToolCatalog.recordEvent`: the event is a tagged wire-shape object
+   * (`{ type: "...", ... }`, snake_case fields) and an unknown shape throws.
+   *
+   * @param event - The trace event to record.
+   */
   recordEvent(event: object): void {
     this.registry.recordEvent(event);
   }
 
+  /**
+   * Drain the envelopes captured by a `"memory"` trace sink, emptying its
+   * buffer. Same contract as `ToolCatalog.drainTraceEvents`.
+   *
+   * @returns The captured envelopes in record order; `[]` unless the active
+   *   sink is `"memory"`.
+   */
   drainTraceEvents(): unknown[] {
     return this.registry.drainTraceEvents();
   }
@@ -79,6 +145,9 @@ export class SkillCatalog {
    * Return a skill's body for dispatch, recording a `skill_invoke` event.
    * Throws on an unknown id — callers at the capability-tool boundary translate that
    * into a structured error for the agent.
+   *
+   * @param skillId - Id of a registered skill.
+   * @returns The skill's `body` (`""` when it was registered without one).
    */
   invoke(skillId: string): string {
     const skill = this.skills.get(skillId);

--- a/src/sdk/ts/src/skill-tools.ts
+++ b/src/sdk/ts/src/skill-tools.ts
@@ -1,12 +1,26 @@
 import type { ExecutableTool } from "./catalog.js";
 import type { SkillCatalog } from "./skill-catalog.js";
 
+/**
+ * Wire id (`"get_skill_content"`) of the skill-loading capability tool built
+ * by {@link getSkillContentTool} — the name the model calls it by.
+ */
 export const GET_SKILL_CONTENT_ID = "get_skill_content" as const;
 
 /**
- * Load a skill's full instructions by id — the counterpart to `invoke_tool`.
- * Skills are *read*, not executed: the agent discovers a skill in the `skills`
- * bucket of `search_capabilities`, then pulls its playbook into context here.
+ * Build the `get_skill_content` capability tool: load a skill's full
+ * instructions by id — the counterpart to `invoke_tool`. Skills are *read*,
+ * not executed: the agent discovers a skill in the `skills` bucket of
+ * `search_capabilities`, then pulls its playbook into context here.
+ *
+ * The tool takes `{ skillId }` and resolves to `{ body }` (the skill's
+ * Markdown) on success, or `{ error, isError: true }` for an unknown id — a
+ * structured result rather than a rejection, so the model can recover. Each
+ * load records a `ratel.skill.load` span plus a `skill_invoke` trace event
+ * (unknown ids record `gateway_error`).
+ *
+ * @param catalog - Catalog whose skills this serves.
+ * @returns The tool, ready to expose to the model.
  */
 export function getSkillContentTool(catalog: SkillCatalog): ExecutableTool {
   return {

--- a/src/sdk/ts/src/telemetry.ts
+++ b/src/sdk/ts/src/telemetry.ts
@@ -224,6 +224,7 @@ export function recordAuthNeeded(server?: string): void {
 
 /** Handle returned by {@link configureTelemetry}; `shutdown()` flushes the exporter. */
 export interface TelemetryHandle {
+  /** Flush pending spans and shut the exporter down. Call once at process exit. */
   shutdown(): Promise<void>;
 }
 

--- a/src/sdk/ts/typedoc.json
+++ b/src/sdk/ts/typedoc.json
@@ -10,7 +10,8 @@
   "intentionallyNotExported": ["native/index.d.cts:TraceSinkConfig"],
   "externalSymbolLinkMappings": {
     "@ratel-ai/telemetry": {
-      "DEFAULT_SERVICE_NAME": "https://github.com/ratel-ai/ratel/blob/main/src/telemetry/ts/src/config.ts"
+      "DEFAULT_SERVICE_NAME": "https://github.com/ratel-ai/ratel/blob/main/src/telemetry/ts/src/config.ts",
+      "contentCaptureMode": "https://github.com/ratel-ai/ratel/blob/main/src/telemetry/ts/src/config.ts"
     }
   }
 }

--- a/src/sdk/ts/typedoc.json
+++ b/src/sdk/ts/typedoc.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "readme": "none",
+  "emit": "none",
+  "validation": {
+    "notDocumented": true
+  },
+  "treatValidationWarningsAsErrors": true,
+  "intentionallyNotExported": ["native/index.d.cts:TraceSinkConfig"],
+  "externalSymbolLinkMappings": {
+    "@ratel-ai/telemetry": {
+      "DEFAULT_SERVICE_NAME": "https://github.com/ratel-ai/ratel/blob/main/src/telemetry/ts/src/config.ts"
+    }
+  }
+}

--- a/src/telemetry/core/src/lib.rs
+++ b/src/telemetry/core/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! See `README.md` and the wire contract in `../CONVENTIONS.md` for design.
 
+#![warn(missing_docs)]
+
 /// The pinned OpenTelemetry semantic-conventions version this vocabulary tracks
 /// (the `gen_ai` group). The pin is the contract; consumers read against this
 /// exact version, never "latest". Bumping it is a reviewed change with its own
@@ -96,7 +98,10 @@ pub const GEN_AI_TOOL_CALL_RESULT: &str = "gen_ai.tool.call.result";
 /// local trace `Origin` (ADR-0007).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Origin {
+    /// A direct library/SDK call — wire value `direct`.
     Direct,
+    /// A call the agent synthesized inside its loop (via the capability
+    /// tools) — wire value `agent`.
     Agent,
 }
 
@@ -114,7 +119,9 @@ impl Origin {
 /// folds capability-tool search and skill search into one span shape.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SearchTarget {
+    /// The span searched the tool catalog — wire value `tool`.
     Tool,
+    /// The span searched the skill catalog — wire value `skill`.
     Skill,
 }
 
@@ -132,9 +139,15 @@ impl SearchTarget {
 /// is the 401-driven `AuthNeeds` case (ADR-0007 `auth_needs`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthOutcome {
+    /// Existing credentials were valid; no interaction needed — wire value `ok`.
     Ok,
+    /// Credentials were refreshed without user interaction — wire value
+    /// `refreshed`.
     Refreshed,
+    /// The upstream challenged for auth (e.g. a 401); user interaction is
+    /// required — wire value `needs_auth`, the ADR-0007 `auth_needs` case.
     NeedsAuth,
+    /// The flow errored without producing credentials — wire value `failed`.
     Failed,
 }
 


### PR DESCRIPTION
## What

Backfills API-level documentation across the three published surfaces so the 0.4.0 API is self-documenting (IDE hover, docs.rs, generated typings), and adds enforcement so coverage can't regress:

- **`ratel-ai-core` + `ratel-ai-telemetry`** — `#![warn(missing_docs)]` (enforced as an error by CI's `clippy -D warnings`), a real crate-level docs.rs landing page with a compiling BM25 register→search doctest, docs on every public item: `Tool`/`Skill` fields, both registries, `SearchHit`/`SkillHit` with exact per-method score semantics (raw BM25 k1=0.9/b=0.4 per ADR-0004, cosine of L2-normalized embeddings, RRF Σ1/(60+rank)), all `TraceEvent` variants + envelope per ADR-0007, sinks with when-to-use guidance, `# Errors` sections on fallible APIs, 6 doctests.
- **`@ratel-ai/sdk`** — TSDoc with `@param`/`@returns` on the full barrel (`ToolCatalog`, `SkillCatalog`, `registerMcpServer`, capability tools and their result/option types), `@example` on the top entry points, `///` docs on all `#[napi]` items so the generated `native/index.d.cts` carries hover docs, `@packageDocumentation` barrel header. New `docs:check` (typedoc `validation.notDocumented`, warnings-as-errors) wired into `lint`.
- **`ratel-ai` (Python)** — ruff `D` (pydocstyle, google convention) enabled and green, Google-style docstrings with `Args/Returns/Raises` on the public surface, `_native.pyi` brought to parity with the PyO3 `///` docs (what IDEs actually read), deprecation notes normalized.

Doc comments, stubs, and doc-lint config only — zero behavior changes.

## Verification

- `cargo fmt --check --all` · `cargo clippy --workspace --all-targets -- -D warnings` · `cargo test --workspace` (incl. new doctests) ✅
- `pnpm -r build` · `typecheck` · `lint` (biome + typedoc gate) · `test` (90/33/11) ✅
- `ruff check .` (with `D`) · `mypy ratel_ai` · `pytest` (67) ✅
- Every documented claim was adversarially reviewed against the implementation (score semantics, error contracts, trace-event emission, clamp/default behavior); the review's confirmed findings are already folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)