### PR TITLE
docs(README): add Discord badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
     <a href="https://pypi.org/project/ratel-ai/"><img src="https://img.shields.io/pypi/v/ratel-ai?label=PyPI&color=3775a9" alt="PyPI" /></a>
     <a href="https://crates.io/crates/ratel-ai-core"><img src="https://img.shields.io/crates/v/ratel-ai-core?label=crates.io&color=e57300" alt="crates.io" /></a>
     <a href="https://github.com/ratel-ai/ratel/stargazers"><img src="https://img.shields.io/github/stars/ratel-ai/ratel?style=social" alt="GitHub stars" /></a>
+    <a href="https://discord.gg/75vAPdjYqT"><img src="https://img.shields.io/discord/1478702964003705015?label=Discord&logo=discord&logoColor=white&color=5865F2" alt="Discord" /></a>
     <a href="#license"><img src="https://img.shields.io/badge/license-Apache--2.0%20%26%20MIT-blue" alt="license" /></a>
   </p>
 </div>


### PR DESCRIPTION
Adds a Discord badge to the README badge row, linking to the community invite (`discord.gg/75vAPdjYqT`) with live member count via server ID.

Note: shields.io reads the count through the Discord server widget, so the server must have Widget enabled or the badge renders as invalid.