### PR TITLE
Rat 385/conf embed bug performance fixes

### DIFF
--- a/src/core/CHANGELOG.md
+++ b/src/core/CHANGELOG.md
@@ -6,6 +6,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+### Changed
+
+- In-process (Candle) embedding runs one padded forward pass per batch chunk instead of one per document, speeding up embedding a corpus on a `"semantic"`/`"hybrid"` catalog. Produced vectors are bit-for-bit identical, so rankings and reproducibility are unchanged.
+
+### Fixed
+
+- Distinct embedding models now load concurrently. The process-wide embedder cache held its lock across a full model load, so a cold load of one model blocked loading — or a warm-cache hit for — another; loads now run under a per-key slot lock while same-model loads stay single-flight (one load, reported once).
+
 ## [0.5.0-rc.1] - 2026-07-16
 
 ### Added

--- a/src/core/src/embedding.rs
+++ b/src/core/src/embedding.rs
@@ -322,7 +322,7 @@ struct LoadNotices {
 type ResolvedEmbedder = (Arc<dyn Embedder>, Option<u64>, LoadNotices);
 
 fn embedder_for(model: &EmbeddingModel) -> Result<ResolvedEmbedder, EmbedderError> {
-    static CELL: OnceLock<Mutex<HashMap<String, Arc<dyn Embedder>>>> = OnceLock::new();
+    static CELL: OnceLock<Mutex<HashMap<String, LoadSlot<dyn Embedder>>>> = OnceLock::new();
     let cache = CELL.get_or_init(|| Mutex::new(HashMap::new()));
     let mut notices = LoadNotices::default();
     let (emb, load_ms) = get_or_load_keyed(cache, &model.embedder_cache_key(), || {
@@ -392,23 +392,40 @@ fn build_embedder(
     }
 }
 
-/// Get-or-load into a keyed cache with **no failure caching**: on `Err` the key
-/// stays empty so a later call retries. Returns the value plus `Some(load_ms)`
+/// A per-key load slot in a keyed cache: `None` until the value is loaded, then
+/// `Some`. Guarded by its own mutex so a `load` serializes callers of *that* key
+/// without holding the whole-map lock.
+type LoadSlot<T> = Arc<Mutex<Option<Arc<T>>>>;
+
+/// Get-or-load into a keyed cache with **no failure caching**: on `Err` the key's
+/// slot stays empty so a later call retries. Returns the value plus `Some(load_ms)`
 /// on the call that performed the load, `None` on warm reuse. Generic so the
 /// non-poisoning + once contract is unit-tested without touching the network.
+///
+/// The map lock is held only long enough to get/create the key's slot; `load`
+/// runs against that per-key slot mutex, never the map. So **different keys load
+/// concurrently** (a cold load of one model no longer blocks another), while
+/// **same-key loads stay single-flight** (concurrent cold misses share the slot,
+/// so `load` runs once and exactly one caller reports `Some(load_ms)`).
 fn get_or_load_keyed<T: ?Sized>(
-    cache: &Mutex<HashMap<String, Arc<T>>>,
+    cache: &Mutex<HashMap<String, LoadSlot<T>>>,
     key: &str,
     load: impl FnOnce() -> Result<Arc<T>, EmbedderError>,
 ) -> Result<(Arc<T>, Option<u64>), EmbedderError> {
-    let mut guard = cache.lock().expect("embedder cache mutex poisoned");
-    if let Some(existing) = guard.get(key) {
+    // Hold the map lock only to get/create this key's slot, then release it.
+    let slot = {
+        let mut guard = cache.lock().expect("embedder cache mutex poisoned");
+        Arc::clone(guard.entry(key.to_string()).or_default())
+    };
+    // Serialize per key on the slot — the map lock is NOT held across `load`.
+    let mut slot = slot.lock().expect("embedder cache slot mutex poisoned");
+    if let Some(existing) = slot.as_ref() {
         return Ok((existing.clone(), None));
     }
     let started = Instant::now();
-    let loaded = load()?;
+    let loaded = load()?; // Err leaves the slot `None`, so a later call retries.
     let took_ms = started.elapsed().as_millis() as u64;
-    guard.insert(key.to_string(), loaded.clone());
+    *slot = Some(loaded.clone());
     Ok((loaded, Some(took_ms)))
 }
 
@@ -1394,7 +1411,7 @@ mod tests {
 
     #[test]
     fn get_or_load_keyed_does_not_cache_failure_and_reports_latency_once() {
-        let cache: Mutex<HashMap<String, Arc<i32>>> = Mutex::new(HashMap::new());
+        let cache: Mutex<HashMap<String, LoadSlot<i32>>> = Mutex::new(HashMap::new());
         let boom = || {
             Err::<Arc<i32>, _>(EmbedderError::Inference {
                 source: "boom".into(),
@@ -1412,6 +1429,98 @@ mod tests {
             get_or_load_keyed(&cache, "k", || Ok::<_, EmbedderError>(Arc::new(999))).unwrap();
         assert_eq!(*v2, 7);
         assert!(ms2.is_none(), "warm reuse reports no load latency");
+    }
+
+    #[test]
+    fn distinct_key_loads_run_concurrently() {
+        use std::sync::Barrier;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::thread;
+
+        // Two loads for *different* keys must be able to run at the same time.
+        // The barrier only releases once BOTH loads have entered — so if the
+        // cache serializes distinct-key loads (map lock held across `load`), the
+        // second thread can never start and the receive below times out.
+        let cache: Arc<Mutex<HashMap<String, LoadSlot<i32>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let barrier = Arc::new(Barrier::new(2));
+        let inflight = Arc::new(AtomicUsize::new(0));
+        let (done_tx, done_rx) = mpsc::channel();
+
+        for (i, key) in ["a", "b"].into_iter().enumerate() {
+            let cache = Arc::clone(&cache);
+            let barrier = Arc::clone(&barrier);
+            let inflight = Arc::clone(&inflight);
+            let done_tx = done_tx.clone();
+            thread::spawn(move || {
+                let result = get_or_load_keyed(&cache, key, || {
+                    inflight.fetch_add(1, Ordering::SeqCst);
+                    barrier.wait(); // both distinct-key loads must be in-flight here
+                    Ok::<_, EmbedderError>(Arc::new(i as i32))
+                });
+                let _ = done_tx.send(result.map(|(v, _)| *v));
+            });
+        }
+        drop(done_tx);
+
+        let mut got = Vec::new();
+        for _ in 0..2 {
+            let value = done_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("distinct-key loads did not run concurrently (map lock held across load)");
+            got.push(value.unwrap());
+        }
+        got.sort_unstable();
+        assert_eq!(got, vec![0, 1]);
+        assert_eq!(inflight.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn same_key_load_is_single_flight() {
+        use std::sync::Barrier;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::thread;
+
+        // Many threads race the SAME key: `load` must run exactly once, and
+        // exactly one caller reports a load latency; the rest see warm reuse.
+        const THREADS: usize = 8;
+        let cache: Arc<Mutex<HashMap<String, LoadSlot<i32>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let loads = Arc::new(AtomicUsize::new(0));
+        let start = Arc::new(Barrier::new(THREADS));
+        let (tx, rx) = mpsc::channel();
+
+        for _ in 0..THREADS {
+            let cache = Arc::clone(&cache);
+            let loads = Arc::clone(&loads);
+            let start = Arc::clone(&start);
+            let tx = tx.clone();
+            thread::spawn(move || {
+                start.wait(); // maximize the race on the cold miss
+                let result = get_or_load_keyed(&cache, "shared", || {
+                    loads.fetch_add(1, Ordering::SeqCst);
+                    Ok::<_, EmbedderError>(Arc::new(42))
+                });
+                let (value, ms) = result.unwrap();
+                let _ = tx.send((*value, ms.is_some()));
+            });
+        }
+        drop(tx);
+
+        let mut reported = 0;
+        for _ in 0..THREADS {
+            let (value, loaded) = rx.recv_timeout(Duration::from_secs(5)).unwrap();
+            assert_eq!(value, 42);
+            if loaded {
+                reported += 1;
+            }
+        }
+        assert_eq!(
+            loads.load(Ordering::SeqCst),
+            1,
+            "load must run exactly once per key"
+        );
+        assert_eq!(reported, 1, "exactly one caller reports the load latency");
     }
 
     #[test]

--- a/src/core/src/embedding.rs
+++ b/src/core/src/embedding.rs
@@ -518,6 +518,12 @@ fn slow_load_ms() -> u64 {
 /// A BERT-family embedding model run in-process via Candle — the backend for the
 /// built-in default, any HuggingFace repo, and any on-disk model directory.
 /// Carries its pooling mode, asymmetric prefixes, and a resolved fingerprint.
+/// Documents per padded forward pass in [`CandleEmbedder::embed_batch_inner`]. A
+/// whole-corpus `rebuild` hands the full slice in at once, so this bounds peak
+/// activation memory; it does not affect the produced vectors (each row's output is
+/// independent of its chunk-mates).
+const EMBED_BATCH_CHUNK: usize = 32;
+
 pub(crate) struct CandleEmbedder {
     model: BertModel,
     tokenizer: Tokenizer,
@@ -802,6 +808,66 @@ impl CandleEmbedder {
         let vec = pooled.to_vec1::<f32>()?;
         Ok(l2_normalize(vec))
     }
+
+    /// Batched twin of [`Self::embed_inner`]: one padded forward pass per chunk of
+    /// documents instead of one per document. A padded (masked) key contributes
+    /// exactly zero to every real token's attention (candle adds `f32::MIN` before
+    /// softmax), and right-padding never leaks into real tokens, so each vector is
+    /// **bit-for-bit identical** to the per-document path — chunking only bounds the
+    /// activation memory a whole-corpus `rebuild` would otherwise allocate at once.
+    fn embed_batch_inner(&self, texts: &[String]) -> candle_core::Result<Vec<Vec<f32>>> {
+        let mut out = Vec::with_capacity(texts.len());
+        for chunk in texts.chunks(EMBED_BATCH_CHUNK) {
+            // Documents get the doc-side prefix, mirroring `embed_doc`.
+            let inputs: Vec<String> = if self.doc_prefix.is_empty() {
+                chunk.to_vec()
+            } else {
+                chunk
+                    .iter()
+                    .map(|t| format!("{}{}", self.doc_prefix, t))
+                    .collect()
+            };
+            let encodings = self
+                .tokenizer
+                .encode_batch(inputs, true)
+                .map_err(|e| candle_core::Error::Msg(e.to_string()))?;
+            let n = encodings.len();
+            let max_len = encodings
+                .iter()
+                .map(|e| e.get_ids().len())
+                .max()
+                .unwrap_or(0);
+            // Right-pad ids (pad id 0 — masked out, so the value is irrelevant) and
+            // the attention mask into rectangular `(n, max_len)` buffers.
+            let mut ids = vec![0u32; n * max_len];
+            let mut mask = vec![0u32; n * max_len];
+            for (row, enc) in encodings.iter().enumerate() {
+                let e_ids = enc.get_ids();
+                let e_mask = enc.get_attention_mask();
+                let base = row * max_len;
+                ids[base..base + e_ids.len()].copy_from_slice(e_ids);
+                mask[base..base + e_mask.len()].copy_from_slice(e_mask);
+            }
+            let input_ids = Tensor::from_vec(ids, (n, max_len), &self.device)?;
+            let attention_mask = Tensor::from_vec(mask, (n, max_len), &self.device)?;
+            let token_type_ids = input_ids.zeros_like()?;
+
+            // (n, max_len, hidden)
+            let sequence_output =
+                self.model
+                    .forward(&input_ids, &token_type_ids, Some(&attention_mask))?;
+            let pooled = match self.pooling {
+                // CLS pooling = each row's first token.
+                Pooling::Cls => sequence_output.narrow(1, 0, 1)?.squeeze(1)?, // (n, hidden)
+                // Mean pooling = masked average over the real tokens, per row.
+                Pooling::Mean => mean_pool_batch(&sequence_output, &attention_mask)?,
+            };
+            for row in pooled.to_vec2::<f32>()? {
+                out.push(l2_normalize(row));
+            }
+        }
+        Ok(out)
+    }
 }
 
 /// Masked mean over tokens: `Σ hidden[t]·mask[t] / Σ mask[t]`. `sequence_output`
@@ -811,6 +877,19 @@ fn mean_pool(sequence_output: &Tensor, attention_mask: &Tensor) -> candle_core::
     let summed = sequence_output.broadcast_mul(&mask)?.sum(1)?; // (1, hidden)
     let counts = mask.sum(1)?; // (1, 1)
     summed.broadcast_div(&counts)?.i(0) // (hidden,)
+}
+
+/// Masked mean over tokens for a whole batch — the row-wise twin of [`mean_pool`].
+/// `sequence_output` is `(n, seq, hidden)`, `attention_mask` is `(n, seq)`; returns
+/// `(n, hidden)`. Padded tokens (mask 0) contribute nothing and don't count.
+fn mean_pool_batch(
+    sequence_output: &Tensor,
+    attention_mask: &Tensor,
+) -> candle_core::Result<Tensor> {
+    let mask = attention_mask.to_dtype(DType::F32)?.unsqueeze(2)?; // (n, seq, 1)
+    let summed = sequence_output.broadcast_mul(&mask)?.sum(1)?; // (n, hidden)
+    let counts = mask.sum(1)?; // (n, 1)
+    summed.broadcast_div(&counts) // (n, hidden)
 }
 
 impl Embedder for CandleEmbedder {
@@ -828,6 +907,13 @@ impl Embedder for CandleEmbedder {
         } else {
             self.embed(&format!("{}{}", self.query_prefix, text))
         }
+    }
+
+    fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, EmbedderError> {
+        self.embed_batch_inner(texts)
+            .map_err(|e| EmbedderError::Inference {
+                source: e.to_string(),
+            })
     }
 
     fn fingerprint(&self) -> String {
@@ -2001,6 +2087,26 @@ mod tests {
     }
 
     #[test]
+    fn mean_pool_batch_averages_each_row_over_its_own_unmasked_tokens() {
+        let dev = Device::Cpu;
+        // (2, 2, 2): two rows, two tokens, hidden = 2.
+        let seq = Tensor::new(
+            &[[[1.0f32, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]],
+            &dev,
+        )
+        .unwrap();
+        // Row 0: both tokens count → [2, 3]. Row 1: second token padded → [5, 6].
+        let mask = Tensor::new(&[[1u32, 1], [1, 0]], &dev).unwrap();
+        assert_eq!(
+            mean_pool_batch(&seq, &mask)
+                .unwrap()
+                .to_vec2::<f32>()
+                .unwrap(),
+            vec![vec![2.0, 3.0], vec![5.0, 6.0]]
+        );
+    }
+
+    #[test]
     fn parse_pooling_config_maps_cls_mean_and_none() {
         assert_eq!(
             parse_pooling_config(br#"{"pooling_mode_cls_token": true}"#),
@@ -2059,6 +2165,56 @@ mod tests {
         assert_eq!(a, b, "same text must embed identically (determinism)");
         let norm = a.iter().map(|x| x * x).sum::<f32>().sqrt();
         assert!((norm - 1.0).abs() < 1e-3, "expected unit norm, got {norm}");
+    }
+
+    #[test]
+    #[ignore = "downloads the ~130 MB bge model; run with `cargo test -- --ignored`"]
+    fn embed_batch_matches_looping_embed_doc_cls() {
+        // The batched forward must be bit-for-bit identical to embedding each doc
+        // alone (CLS pooling, built-in bge-small). Differing lengths exercise padding;
+        // > EMBED_BATCH_CHUNK items span a chunk boundary.
+        let e = embedder_for(&EmbeddingModel::Default)
+            .expect("load embedder")
+            .0;
+        let docs: Vec<String> = (0..EMBED_BATCH_CHUNK + 5)
+            .map(|i| format!("{}read a file from disk", "word ".repeat(i % 7)))
+            .collect();
+        let batched = e.embed_batch(&docs).expect("embed_batch");
+        let looped: Vec<Vec<f32>> = docs
+            .iter()
+            .map(|d| e.embed_doc(d).expect("embed_doc"))
+            .collect();
+        assert_eq!(
+            batched, looped,
+            "batched embedding must be bit-for-bit identical to the per-doc path"
+        );
+    }
+
+    #[test]
+    #[ignore = "downloads a mean-pooled model (gte-small); run with `cargo test -- --ignored`"]
+    fn embed_batch_matches_looping_embed_doc_mean() {
+        // Same exact-equality contract on the mean-pooled path (gte-small).
+        let model = EmbeddingModel::HuggingFace {
+            repo: "thenlper/gte-small".into(),
+            revision: None,
+            query_prefix: None,
+            doc_prefix: None,
+            pooling: None,  // auto-detected → Mean
+            download: true, // ignored test: allow the fetch
+        };
+        let e = embedder_for(&model).expect("load gte-small").0;
+        let docs: Vec<String> = (0..EMBED_BATCH_CHUNK + 3)
+            .map(|i| format!("{}deploy the service", "x ".repeat(i % 5)))
+            .collect();
+        let batched = e.embed_batch(&docs).expect("embed_batch");
+        let looped: Vec<Vec<f32>> = docs
+            .iter()
+            .map(|d| e.embed_doc(d).expect("embed_doc"))
+            .collect();
+        assert_eq!(
+            batched, looped,
+            "mean-pooled batched embedding must be bit-for-bit identical to the per-doc path"
+        );
     }
 
     #[test]

--- a/src/sdk/python/.gitignore
+++ b/src/sdk/python/.gitignore
@@ -1,5 +1,6 @@
 # Virtualenv + build/test tool caches
 .venv/
+.venv*/
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/

--- a/src/sdk/python/CHANGELOG.md
+++ b/src/sdk/python/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+### Fixed
+
+- A forgotten `await` on `register()` no longer silently drops the corpus. `register()` now commits metadata **synchronously** and returns an awaitable that drives only the embedding pass, so an un-awaited call still registers the tools/skills (BM25 keeps working); and a `"semantic"`/`"hybrid"` `search_async` after an un-awaited `register()` raises an actionable "not awaited" error instead of ranking an empty corpus. Awaited usage — return value, timing, batch atomicity, off-thread embedding, error surfacing — is unchanged. (Note: `register` is now a regular method returning `Awaitable[None]`, not an `async def` coroutine function.)
+
 ## [0.5.0-rc.1] - 2026-07-16
 
 ### Changed

--- a/src/sdk/python/ratel_ai/catalog.py
+++ b/src/sdk/python/ratel_ai/catalog.py
@@ -96,6 +96,11 @@ EmbeddingSpec = Union[str, EmbeddingModelConfig]
 
 _DenseResult = TypeVar("_DenseResult")
 _REGISTRY_BUSY = "registry busy; await the active operation"
+_UNAWAITED_REGISTER = (
+    "a register() call was not awaited; its embeddings were never built — "
+    "`await catalog.register(...)` (or `registry.register(...)`) before a "
+    "semantic/hybrid search"
+)
 
 _EMBEDDING_KEYS = frozenset(
     {
@@ -311,37 +316,46 @@ class ToolRegistry:
         self._dense_gate = threading.Lock()
         self._dense_state = threading.Lock()
         self._dense_pending = 0
+        # Builds scheduled by `register` but not yet driven to completion. Bumped
+        # synchronously so a *forgotten* `await register(...)` leaves it > 0; the
+        # dense search path reads it to fail loudly instead of ranking an empty
+        # corpus. Touched only on the event-loop thread (register / `_drive` /
+        # search_async), so it needs no lock.
+        self._undriven_builds = 0
         self._dense_tasks: set[asyncio.Task[Any]] = set()
 
     @overload
-    async def register(self, item: Tool) -> None: ...
+    def register(self, item: Tool) -> Awaitable[None]: ...
 
     @overload
-    async def register(self, item: Iterable[Tool]) -> None: ...
+    def register(self, item: Iterable[Tool]) -> Awaitable[None]: ...
 
     @overload
-    async def register(
+    def register(
         self,
         item: str,
         name: str,
         description: str,
         input_schema: dict[str, Any],
         output_schema: dict[str, Any],
-    ) -> None: ...
+    ) -> Awaitable[None]: ...
 
-    async def register(
+    def register(
         self,
         item: Tool | Iterable[Tool] | str,
         name: str | None = None,
         description: str | None = None,
         input_schema: dict[str, Any] | None = None,
         output_schema: dict[str, Any] | None = None,
-    ) -> None:
+    ) -> Awaitable[None]:
         """Register one `Tool`, many `Tool`s, or a flat (id, name, …) tuple.
 
-        Stores metadata and — on a "semantic"/"hybrid" registry — embeds in one
-        batched, off-thread pass (embedding errors surface here). "bm25" registers
-        metadata only.
+        Metadata is indexed **synchronously**, the instant `register(...)` is
+        called, so a forgotten `await` can never silently drop the corpus. The
+        returned awaitable drives only the embedding pass — on a
+        "semantic"/"hybrid" registry it embeds in one batched, off-thread pass
+        (embedding errors surface when awaited); "bm25" has nothing to embed and
+        the awaitable is a no-op. Always `await` the result.
         """
         flat_args = (name, description, input_schema, output_schema)
         if isinstance(item, Tool):
@@ -359,8 +373,7 @@ class ToolRegistry:
             if not all(isinstance(tool, Tool) for tool in tools):
                 raise TypeError("register requires Tool items")
         self._register_items(tools)
-        if self._eager:
-            await self._build()
+        return self._build_tracked(bool(tools))
 
     def search(self, query: str, top_k: int) -> list[SearchHit]:
         """Run synchronous, model-free BM25 retrieval."""
@@ -391,6 +404,27 @@ class ToolRegistry:
         """Recompute and atomically replace the full embedding cache (internal)."""
         await self._run_dense(self._native._rebuild_embeddings)
 
+    def _build_tracked(self, has_items: bool) -> Awaitable[None]:
+        """Return the awaitable `register` hands back — it drives the embedding pass.
+
+        `_undriven_builds` is bumped **now** (synchronously, while `register`
+        runs), not inside the coroutine, so it stays > 0 when the coroutine is
+        never driven — that is how a forgotten `await` becomes detectable.
+        """
+        schedule = self._eager and has_items
+        if schedule:
+            self._undriven_builds += 1
+
+        async def _drive() -> None:
+            if not schedule:
+                return
+            try:
+                await self._build()
+            finally:
+                self._undriven_builds -= 1
+
+        return _drive()
+
     async def search_async(
         self,
         query: str,
@@ -403,6 +437,8 @@ class ToolRegistry:
             raise ValueError(f"unknown search method: {method}")
         if method == "bm25":
             return self.search_with_origin(query, top_k, origin)
+        if self._undriven_builds > 0:
+            raise RuntimeError(_UNAWAITED_REGISTER)
         return await self._run_dense(
             lambda: self._native._search_with_method(query, top_k, origin, method)
         )
@@ -522,15 +558,20 @@ class ToolCatalog:
         if trace is not None:
             self._registry.set_trace_sink(trace.kind, trace.session_id, trace.path)
 
-    async def register(self, tools: ExecutableTool | Iterable[ExecutableTool]) -> None:
+    def register(self, tools: ExecutableTool | Iterable[ExecutableTool]) -> Awaitable[None]:
         """Register one tool or many — the single entry point for both.
 
-        Stores metadata and the executor handler, then — on a "semantic"/"hybrid"
-        catalog — embeds the tools in one batched pass on a worker thread (so the
-        event loop is never blocked). Embedding errors (model load / endpoint /
-        auth / dimension) surface **here**, at registration. A BM25 catalog never
-        loads a model and resolves immediately. Re-registering an id replaces it
-        in place; the index never holds a duplicate.
+        Metadata and the executor handler are stored **synchronously**, the
+        instant `register(...)` is called, so a forgotten `await` can never
+        silently drop the corpus. The returned awaitable drives only the
+        embedding pass: on a "semantic"/"hybrid" catalog it embeds the batch in
+        one pass on a worker thread (the event loop is never blocked), and
+        embedding errors (model load / endpoint / auth / dimension) surface when
+        it is awaited. A BM25 catalog never loads a model and the awaitable is a
+        no-op. **Always `await` the result** — a semantic/hybrid search after an
+        un-awaited `register` raises rather than ranking an empty corpus.
+        Re-registering an id replaces it in place; the index never holds a
+        duplicate.
 
         A model or dimension change is not recovered in place — construct a new
         catalog and re-register.
@@ -542,7 +583,7 @@ class ToolCatalog:
 
         Raises:
             ValueError: if any `execute` is `None`, or a schema isn't JSON-serializable.
-            EmbedderError: on a semantic/hybrid catalog, if embedding fails.
+            EmbedderError: on a semantic/hybrid catalog, if embedding fails (when awaited).
             RuntimeError: if a dense operation already owns the registry.
         """
         batch = [tools] if isinstance(tools, ExecutableTool) else list(tools)
@@ -559,8 +600,7 @@ class ToolCatalog:
                 input_schema=tool.input_schema,
                 output_schema=tool.output_schema,
             )
-        if self._method in ("semantic", "hybrid"):
-            await self._registry._build()
+        return self._registry._build_tracked(bool(batch))
 
     def search(
         self,

--- a/src/sdk/python/ratel_ai/skill_catalog.py
+++ b/src/sdk/python/ratel_ai/skill_catalog.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import threading
 import time
-from collections.abc import Callable, Iterable
+from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
 from typing import Any, Literal, TypeVar, overload
 
@@ -18,6 +18,7 @@ from ._native import SkillHit
 from ._native import SkillRegistry as _NativeSkillRegistry
 from .catalog import (
     _REGISTRY_BUSY,
+    _UNAWAITED_REGISTER,
     EmbeddingSpec,
     SearchMethod,
     SearchOrigin,
@@ -153,16 +154,19 @@ class SkillRegistry:
         self._dense_gate = threading.Lock()
         self._dense_state = threading.Lock()
         self._dense_pending = 0
+        # See `ToolRegistry.__init__`: scheduled-but-undriven embedding builds, so
+        # a forgotten `await register(...)` is caught at the next dense search.
+        self._undriven_builds = 0
         self._dense_tasks: set[asyncio.Task[Any]] = set()
 
     @overload
-    async def register(self, item: Skill) -> None: ...
+    def register(self, item: Skill) -> Awaitable[None]: ...
 
     @overload
-    async def register(self, item: Iterable[Skill]) -> None: ...
+    def register(self, item: Iterable[Skill]) -> Awaitable[None]: ...
 
     @overload
-    async def register(
+    def register(
         self,
         item: str,
         name: str,
@@ -171,9 +175,9 @@ class SkillRegistry:
         tools: list[str],
         metadata: dict[str, list[str]],
         body: str,
-    ) -> None: ...
+    ) -> Awaitable[None]: ...
 
-    async def register(
+    def register(
         self,
         item: Skill | Iterable[Skill] | str,
         name: str | None = None,
@@ -182,12 +186,14 @@ class SkillRegistry:
         tools: list[str] | None = None,
         metadata: dict[str, list[str]] | None = None,
         body: str | None = None,
-    ) -> None:
+    ) -> Awaitable[None]:
         """Register one `Skill`, many `Skill`s, or a flat (id, name, …) tuple.
 
-        Stores metadata and — on a "semantic"/"hybrid" registry — embeds in one
-        batched, off-thread pass (embedding errors surface here). "bm25" registers
-        metadata only.
+        Metadata is indexed **synchronously** when `register(...)` is called (a
+        forgotten `await` never drops the corpus); the returned awaitable drives
+        only the embedding pass. On a "semantic"/"hybrid" registry it embeds in
+        one batched, off-thread pass (errors surface when awaited); "bm25" has
+        nothing to embed. Always `await` the result.
         """
         flat_args = (name, description, tags, tools, metadata, body)
         if isinstance(item, Skill):
@@ -205,8 +211,7 @@ class SkillRegistry:
             if not all(isinstance(skill, Skill) for skill in skills):
                 raise TypeError("register requires Skill items")
         self._register_items(skills)
-        if self._eager:
-            await self._build()
+        return self._build_tracked(bool(skills))
 
     def search(self, query: str, top_k: int) -> list[SkillHit]:
         """Run synchronous, model-free BM25 retrieval."""
@@ -237,6 +242,22 @@ class SkillRegistry:
         """Recompute and atomically replace the full embedding cache (internal)."""
         await self._run_dense(self._native._rebuild_embeddings)
 
+    def _build_tracked(self, has_items: bool) -> Awaitable[None]:
+        """The awaitable `register` returns — see `ToolRegistry._build_tracked`."""
+        schedule = self._eager and has_items
+        if schedule:
+            self._undriven_builds += 1
+
+        async def _drive() -> None:
+            if not schedule:
+                return
+            try:
+                await self._build()
+            finally:
+                self._undriven_builds -= 1
+
+        return _drive()
+
     async def search_async(
         self,
         query: str,
@@ -249,6 +270,8 @@ class SkillRegistry:
             raise ValueError(f"unknown search method: {method}")
         if method == "bm25":
             return self.search_with_origin(query, top_k, origin)
+        if self._undriven_builds > 0:
+            raise RuntimeError(_UNAWAITED_REGISTER)
         return await self._run_dense(
             lambda: self._native._search_with_method(query, top_k, origin, method)
         )
@@ -359,14 +382,16 @@ class SkillCatalog:
         if trace is not None:
             self._registry.set_trace_sink(trace.kind, trace.session_id, trace.path)
 
-    async def register(self, skills: Skill | Iterable[Skill]) -> None:
+    def register(self, skills: Skill | Iterable[Skill]) -> Awaitable[None]:
         """Register one skill or many — the single entry point for both.
 
-        Stores metadata (name/description/tags are indexed; `tools`, `metadata`,
-        `body` are stored but not indexed), then — on a "semantic"/"hybrid"
-        catalog — embeds the skills in one batched, off-thread pass. Embedding
-        errors surface **here**, at registration; a BM25 catalog never loads a
-        model. Re-registering an id replaces it in place.
+        Metadata is stored **synchronously** when `register(...)` is called
+        (name/description/tags are indexed; `tools`, `metadata`, `body` are
+        stored but not indexed), so a forgotten `await` never drops the corpus.
+        The returned awaitable drives only the embedding pass: on a
+        "semantic"/"hybrid" catalog it embeds the batch off-thread and surfaces
+        errors when awaited; a BM25 catalog never loads a model. **Always
+        `await` the result.** Re-registering an id replaces it in place.
 
         A model or dimension change is not recovered in place — construct a new
         catalog and re-register.
@@ -376,15 +401,14 @@ class SkillCatalog:
                 at once for a single embedding request.
 
         Raises:
-            EmbedderError: on a semantic/hybrid catalog, if embedding fails.
+            EmbedderError: on a semantic/hybrid catalog, if embedding fails (when awaited).
             RuntimeError: if a dense operation already owns the registry.
         """
         batch = [skills] if isinstance(skills, Skill) else list(skills)
         self._registry._register_items(batch)
         for skill in batch:
             self._skills[skill.id] = skill
-        if self._method in ("semantic", "hybrid"):
-            await self._registry._build()
+        return self._registry._build_tracked(bool(batch))
 
     def search(
         self,

--- a/src/sdk/python/tests/test_catalog.py
+++ b/src/sdk/python/tests/test_catalog.py
@@ -263,6 +263,52 @@ async def test_semantic_on_bm25_without_embeddings_raises() -> None:
         await catalog.search_async("read", 5, method="semantic")
 
 
+async def test_unawaited_register_commits_bm25_metadata_synchronously() -> None:
+    # register() indexes metadata the instant it is called — a forgotten `await`
+    # never silently drops the corpus. BM25 search finds the tool without awaiting.
+    catalog = ToolCatalog()
+    pending = catalog.register(_read_file_tool(lambda args: {}))  # deliberately not awaited
+    assert catalog.has("read_file")
+    assert catalog.search("read a file", 5)[0].tool_id == "read_file"
+    await pending  # drain the (no-op) awaitable so no coroutine is left dangling
+
+
+async def test_unawaited_semantic_register_raises_on_dense_search(
+    delayed_embedding_endpoint: str,
+) -> None:
+    # A forgotten `await` on a semantic catalog leaves the embedding pass undriven;
+    # a dense search then fails loudly with an await-specific message instead of
+    # ranking an empty corpus. Awaiting the pending build afterwards recovers.
+    catalog = ToolCatalog(
+        method="semantic",
+        embedding={"url": delayed_embedding_endpoint, "model": "test-model"},
+    )
+    pending = catalog.register(_read_file_tool(lambda args: {}))  # forgot to await
+
+    assert catalog.has("read_file")  # metadata still committed synchronously
+    with pytest.raises(RuntimeError, match="was not awaited"):
+        await catalog.search_async("read a file", 5)
+
+    await pending  # driving the build clears the guard; search then works
+    hits = await catalog.search_async("read a file", 5)
+    assert hits[0].tool_id == "read_file"
+
+
+async def test_awaited_semantic_register_leaves_no_pending_build(
+    delayed_embedding_endpoint: str,
+) -> None:
+    # The happy path is unchanged: an awaited register drives the build to
+    # completion, so the guard never fires on the next dense search.
+    catalog = ToolCatalog(
+        method="semantic",
+        embedding={"url": delayed_embedding_endpoint, "model": "test-model"},
+    )
+    await catalog.register(_read_file_tool(lambda args: {}))
+    assert catalog._registry._undriven_builds == 0
+    hits = await catalog.search_async("read a file", 5)
+    assert hits[0].tool_id == "read_file"
+
+
 async def test_delayed_endpoint_register_keeps_asyncio_responsive(
     delayed_embedding_endpoint: str,
 ) -> None:

--- a/src/sdk/python/tests/test_skill_catalog.py
+++ b/src/sdk/python/tests/test_skill_catalog.py
@@ -103,6 +103,36 @@ async def test_semantic_skill_registration_embeds_and_search_finds_hit(
     assert hits[0].skill_id == "s"
 
 
+async def test_unawaited_skill_register_commits_bm25_metadata_synchronously() -> None:
+    # Metadata is indexed the instant register() is called; a forgotten `await`
+    # never drops the corpus. BM25 search finds the skill without awaiting.
+    catalog = SkillCatalog()
+    pending = catalog.register(Skill(id="deploy", name="deploy", description="Deploy an app"))
+    assert catalog.has("deploy")
+    assert catalog.search("deploy an app", 5)[0].skill_id == "deploy"
+    await pending  # drain the no-op awaitable
+
+
+async def test_unawaited_semantic_skill_register_raises_on_dense_search(
+    delayed_embedding_endpoint: str,
+) -> None:
+    # A forgotten `await` on a semantic skill catalog is caught at the next dense
+    # search with an await-specific message; awaiting the build recovers.
+    catalog = SkillCatalog(
+        method="semantic",
+        embedding={"url": delayed_embedding_endpoint, "model": "test-model"},
+    )
+    pending = catalog.register(Skill(id="s", name="s", description="Skill"))
+
+    assert catalog.has("s")
+    with pytest.raises(RuntimeError, match="was not awaited"):
+        await catalog.search_async("skill", 5)
+
+    await pending
+    hits = await catalog.search_async("skill", 5)
+    assert hits[0].skill_id == "s"
+
+
 async def test_skill_catalog_register_accepts_an_iterable() -> None:
     catalog = SkillCatalog()
     await catalog.register(

--- a/src/sdk/ts/CHANGELOG.md
+++ b/src/sdk/ts/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+### Added
+
+- Typed embedding errors: `EmbedderError` (with a stable `code`) and its `DimensionMismatchError` subclass are thrown from `register()`/`searchAsync()` on a semantic/hybrid catalog, so callers can branch on `instanceof`/`code` instead of matching message text — parity with the Python SDK. Invalid embedding config still throws at construction.
+
 ## [0.5.0-rc.1] - 2026-07-16
 
 ### Changed

--- a/src/sdk/ts/CHANGELOG.md
+++ b/src/sdk/ts/CHANGELOG.md
@@ -10,6 +10,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 - Typed embedding errors: `EmbedderError` (with a stable `code`) and its `DimensionMismatchError` subclass are thrown from `register()`/`searchAsync()` on a semantic/hybrid catalog, so callers can branch on `instanceof`/`code` instead of matching message text — parity with the Python SDK. Invalid embedding config still throws at construction.
 
+### Fixed
+
+- A `"semantic"`/`"hybrid"` `searchAsync()` whose corpus was never embedded (the signature of a forgotten `await register(...)`) now reports an actionable "did you await register()?" hint, not just the bare "embeddings not computed" message.
+
 ## [0.5.0-rc.1] - 2026-07-16
 
 ### Changed

--- a/src/sdk/ts/README.md
+++ b/src/sdk/ts/README.md
@@ -31,6 +31,22 @@ const hits = await catalog.searchAsync("deploy the service", 5);
 
 `register()` returns a promise for every method (BM25 too); `search()` stays synchronous for BM25 only, and `searchAsync()` covers all three. To change the endpoint's model or vector dimension, construct a new catalog and re-register.
 
+Embedding failures from `register()`/`searchAsync()` are typed `EmbedderError`s (with a stable `.code` such as `"Load"`, `"NotCached"`, or `"DimensionMismatch"`); a dimension mismatch is a `DimensionMismatchError` subclass — the parity of Python's `EmbedderError`/`DimensionMismatchError`. Invalid embedding config still throws at construction.
+
+```ts
+import { EmbedderError, DimensionMismatchError } from "@ratel-ai/sdk";
+
+try {
+  await catalog.register(tools);
+} catch (err) {
+  if (err instanceof DimensionMismatchError) {
+    // the model changed under the corpus — rebuild with a fresh catalog
+  } else if (err instanceof EmbedderError) {
+    console.error(`embedding failed (${err.code}): ${err.message}`);
+  }
+}
+```
+
 ## Install
 
 ```bash

--- a/src/sdk/ts/src/catalog.test.ts
+++ b/src/sdk/ts/src/catalog.test.ts
@@ -197,6 +197,18 @@ describe("ToolCatalog search methods", () => {
     );
   });
 
+  it("enriches the not-built dense error with an await-register hint", async () => {
+    // The same failure a forgotten `await catalog.register(...)` produces on a
+    // semantic catalog: the corpus is unembedded, so a dense search enriches the
+    // core "not computed" error with an actionable await hint (original message
+    // preserved). Non-breaking: it only augments an already-failing path.
+    const catalog = new ToolCatalog();
+    await catalog.register(readFile);
+    await expect(catalog.searchAsync("read", 5, "direct", "semantic")).rejects.toThrow(
+      /without awaiting it/,
+    );
+  });
+
   it("keeps Node timers responsive during registration and query on a semantic catalog", async () => {
     const server = await startDelayedEmbeddingServer();
     try {

--- a/src/sdk/ts/src/catalog.test.ts
+++ b/src/sdk/ts/src/catalog.test.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { type ExecutableTool, ToolCatalog } from "./index.js";
+import { EmbedderError, type ExecutableTool, ToolCatalog } from "./index.js";
 import { startDelayedEmbeddingServer } from "./test-support/delayed-embedding-server.js";
 
 async function expectTimerBefore<T>(operation: Promise<T>): Promise<T> {
@@ -175,6 +175,21 @@ describe("ToolCatalog search methods", () => {
     // Metadata registration happens before the embedding pass inside `register`,
     // so it persists even though the embed itself failed.
     expect(catalog.has("read_file")).toBe(true);
+  });
+
+  it("surfaces a load failure as a typed EmbedderError with a stable code", async () => {
+    const catalog = new ToolCatalog({
+      method: "semantic",
+      embedding: { local: "/definitely/missing/ratel-embedding-model" },
+    });
+    const error = await catalog.register(readFile).then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+    expect(error).toBeInstanceOf(EmbedderError);
+    expect((error as EmbedderError).code).toBe("Load");
+    // Original message preserved so message-based matchers keep working.
+    expect((error as EmbedderError).message).toMatch(/failed to load embedding model/);
   });
 
   it("keeps dense search behind the asynchronous API", () => {

--- a/src/sdk/ts/src/catalog.ts
+++ b/src/sdk/ts/src/catalog.ts
@@ -237,6 +237,10 @@ export class ToolCatalog {
    * @param tools - A single tool or a readonly array of tools; each
    *   `execute` must be set. Pass the whole batch at once for a single
    *   embedding request — separate `register` calls embed separately.
+   * @throws {@link EmbedderError} on a `"semantic"`/`"hybrid"` catalog when
+   *   embedding fails (model load / endpoint / auth / dimension) — a
+   *   {@link DimensionMismatchError} for a vector-width change. A missing
+   *   `execute` handler throws a plain `Error`.
    */
   async register(tools: ExecutableTool | readonly ExecutableTool[]): Promise<void> {
     const batch = Array.isArray(tools) ? tools : [tools];

--- a/src/sdk/ts/src/catalog.type-test.ts
+++ b/src/sdk/ts/src/catalog.type-test.ts
@@ -1,4 +1,6 @@
 import {
+  DimensionMismatchError,
+  EmbedderError,
   type EmbeddingSpec,
   type Skill,
   SkillCatalog,
@@ -111,3 +113,11 @@ new SkillCatalog().registerMany;
 new SkillCatalog().buildEmbeddings;
 // @ts-expect-error rebuildEmbeddings removed from SkillCatalog
 new SkillCatalog().rebuildEmbeddings;
+
+// Typed embedding errors: DimensionMismatchError is an EmbedderError, both are Errors,
+// and every EmbedderError carries a string `code` (parity with Python's hierarchy).
+const embedderError: EmbedderError = new DimensionMismatchError("x");
+const asError: Error = embedderError;
+const code: string = new EmbedderError("x", "Load").code;
+void asError;
+void code;

--- a/src/sdk/ts/src/errors.test.ts
+++ b/src/sdk/ts/src/errors.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { mapEmbedderError } from "./errors.js";
+import { DimensionMismatchError, EmbedderError } from "./index.js";
+
+describe("mapEmbedderError", () => {
+  // Each core `EmbedderError` display signature → its typed class + code.
+  const cases: Array<[string, string, string]> = [
+    ["Load", "failed to load embedding model /x: missing model.safetensors (hint: …)", "Load"],
+    [
+      "Download",
+      "failed to download embedding model bge: connection refused (hint: …)",
+      "Download",
+    ],
+    [
+      "CacheUnwritable",
+      "embedding model cache is not writable: permission denied (hint: …)",
+      "CacheUnwritable",
+    ],
+    ["Inference", "embedding failed: tokenizer error (hint: …)", "Inference"],
+    [
+      "ModelMismatch",
+      "embedding model mismatch: cache was built with A, active model is B (hint: …)",
+      "ModelMismatch",
+    ],
+    [
+      "NotCached",
+      "embedding model bge-base is not in the local HuggingFace cache — download it first (hint: …)",
+      "NotCached",
+    ],
+  ];
+
+  for (const [name, message, code] of cases) {
+    it(`maps a ${name} error to EmbedderError with code "${code}"`, () => {
+      const mapped = mapEmbedderError(new Error(message));
+      expect(mapped).toBeInstanceOf(EmbedderError);
+      expect(mapped).not.toBeInstanceOf(DimensionMismatchError);
+      expect((mapped as EmbedderError).code).toBe(code);
+      expect((mapped as EmbedderError).message).toBe(message); // message preserved verbatim
+    });
+  }
+
+  it("maps a dimension mismatch to DimensionMismatchError (a subclass of EmbedderError)", () => {
+    const message = "embedding dimension mismatch for bge: expected 384, got 768 (hint: …)";
+    const mapped = mapEmbedderError(new Error(message));
+    expect(mapped).toBeInstanceOf(DimensionMismatchError);
+    expect(mapped).toBeInstanceOf(EmbedderError);
+    expect((mapped as DimensionMismatchError).code).toBe("DimensionMismatch");
+    expect((mapped as DimensionMismatchError).message).toBe(message);
+  });
+
+  it("appends the await-register hint to a not-built error, keeping the original text", () => {
+    const message = "embeddings are not computed for semantic search (hint: …)";
+    const mapped = mapEmbedderError(new Error(message)) as EmbedderError;
+    expect(mapped).toBeInstanceOf(EmbedderError);
+    expect(mapped.code).toBe("EmbeddingsNotBuilt");
+    expect(mapped.message).toContain("not computed for semantic"); // existing matcher
+    expect(mapped.message).toContain("without awaiting it"); // added hint
+  });
+
+  it("passes non-embedding errors through unchanged", () => {
+    for (const message of [
+      "registry busy; await the active operation before registering more items",
+      "tool registry lock poisoned",
+      "semantic and hybrid search are asynchronous; use searchWithMethodAsync()",
+      "embedding 'local' must not be blank (hint: …)", // construction-time config error
+    ]) {
+      const original = new Error(message);
+      expect(mapEmbedderError(original)).toBe(original); // same reference, untouched
+    }
+    const notError = { message: "failed to load embedding model x" };
+    expect(mapEmbedderError(notError)).toBe(notError);
+  });
+});

--- a/src/sdk/ts/src/errors.ts
+++ b/src/sdk/ts/src/errors.ts
@@ -1,0 +1,96 @@
+/**
+ * Typed embedding errors — the TypeScript twin of the Python SDK's
+ * `EmbedderError` / `DimensionMismatchError` (`ratel_ai/exceptions.py`).
+ *
+ * The native binding surfaces every failure as a plain {@link Error} whose
+ * message is the core `EmbedderError` display string. {@link mapEmbedderError}
+ * recognizes the embedding failures among them (by their stable message
+ * signatures) and re-raises them as these typed classes so callers can branch on
+ * `instanceof` / `code` instead of matching message text. Non-embedding errors
+ * (registry-busy, lock-poison, the sync "use searchAsync" guard, and
+ * construction-time config errors) are passed through unchanged.
+ */
+
+/**
+ * An embedding model failed to load, download, or run — the base class for every
+ * dense-retrieval failure raised from `register` / `searchAsync` on a
+ * `"semantic"`/`"hybrid"` catalog. Mirrors Python's `EmbedderError`.
+ */
+export class EmbedderError extends Error {
+  /**
+   * Stable machine-readable discriminant — one of `"Load"`, `"Download"`,
+   * `"NotCached"`, `"ModelMismatch"`, `"DimensionMismatch"`,
+   * `"EmbeddingsNotBuilt"`, `"Inference"`, or `"CacheUnwritable"`. Prefer this (or
+   * `instanceof`) over parsing {@link Error.message}.
+   */
+  readonly code: string;
+
+  /**
+   * @param message - The underlying failure description (the core error text).
+   * @param code - The stable {@link EmbedderError.code} discriminant.
+   */
+  constructor(message: string, code: string) {
+    super(message);
+    this.name = "EmbedderError";
+    this.code = code;
+  }
+}
+
+/**
+ * A vector's dimension did not match the embedding cache's — the model changed
+ * under an existing corpus. A subclass of {@link EmbedderError} (so
+ * `instanceof EmbedderError` still catches it), mirroring Python's
+ * `DimensionMismatchError`. Its {@link EmbedderError.code} is `"DimensionMismatch"`.
+ */
+export class DimensionMismatchError extends EmbedderError {
+  /**
+   * @param message - The underlying dimension-mismatch description.
+   */
+  constructor(message: string) {
+    super(message, "DimensionMismatch");
+    this.name = "DimensionMismatchError";
+  }
+}
+
+/** Appended to a "not built" error — the signature of a forgotten `await register(...)`. */
+const AWAIT_REGISTER_HINT =
+  " — if you called register(...) without awaiting it, the embedding pass was " +
+  "skipped; `await catalog.register(...)` (or `registry.register(...)`) before a " +
+  "semantic/hybrid search";
+
+/**
+ * Classify a native error message by matching the core `EmbedderError` display
+ * signatures. Returns the stable code, or `undefined` when the message is not an
+ * embedding failure (so the caller passes it through untouched).
+ */
+function embedderCode(message: string): string | undefined {
+  if (message.includes("embedding dimension mismatch")) return "DimensionMismatch";
+  if (message.includes("embedding model mismatch")) return "ModelMismatch";
+  if (message.includes("is not in the local HuggingFace cache")) return "NotCached";
+  if (message.includes("not computed for semantic search")) return "EmbeddingsNotBuilt";
+  if (message.startsWith("failed to load embedding model")) return "Load";
+  if (message.startsWith("failed to download embedding model")) return "Download";
+  if (message.startsWith("embedding model cache is not writable")) return "CacheUnwritable";
+  if (message.startsWith("embedding failed:")) return "Inference";
+  return undefined;
+}
+
+/**
+ * Re-raise a native embedding failure as a typed {@link EmbedderError} /
+ * {@link DimensionMismatchError}, preserving the original message (and appending
+ * the await-register hint to a "not built" error). Any error that is not a
+ * recognized embedding failure is returned unchanged.
+ *
+ * @param error - The error thrown by the native binding.
+ * @returns The typed embedding error, or `error` unchanged when it is not one.
+ */
+export function mapEmbedderError(error: unknown): unknown {
+  if (!(error instanceof Error)) return error;
+  const code = embedderCode(error.message);
+  if (code === undefined) return error;
+  const message =
+    code === "EmbeddingsNotBuilt" ? error.message + AWAIT_REGISTER_HINT : error.message;
+  return code === "DimensionMismatch"
+    ? new DimensionMismatchError(message)
+    : new EmbedderError(message, code);
+}

--- a/src/sdk/ts/src/index.ts
+++ b/src/sdk/ts/src/index.ts
@@ -48,6 +48,7 @@ export type {
   SearchToolsToolOptions,
 } from "./compat.js";
 export { SEARCH_TOOLS_ID, searchToolsTool } from "./compat.js";
+export { DimensionMismatchError, EmbedderError } from "./errors.js";
 export type { McpServerHandle, RegisterMcpServerOptions } from "./mcp.js";
 export { registerMcpServer } from "./mcp.js";
 export { SkillRegistry, ToolRegistry } from "./registry.js";

--- a/src/sdk/ts/src/registry.ts
+++ b/src/sdk/ts/src/registry.ts
@@ -8,6 +8,7 @@ import {
   type Tool,
 } from "../native/index.cjs";
 import type { EmbeddingSpec, SearchMethod, SearchOrigin, TraceSinkConfig } from "./catalog.js";
+import { mapEmbedderError } from "./errors.js";
 
 /** Normalize the public string|object form into the native config the binding
  * expects (a string is the local-path `spec`, validated in core). */
@@ -16,27 +17,6 @@ function toNativeEmbedding(
 ): NativeEmbeddingConfig | undefined {
   if (embedding === undefined) return undefined;
   return typeof embedding === "string" ? { spec: embedding } : embedding;
-}
-
-/**
- * Append an await-oriented hint when a dense search fails because the corpus
- * was never embedded — the signature of a forgotten `await register(...)`.
- *
- * On a `"semantic"`/`"hybrid"` catalog the embedding pass runs inside `register`;
- * an un-awaited `register(...)` skips it, and the next dense search hits the
- * core's "not computed for semantic" error. We enrich only that already-failing
- * error (the original message is preserved, so existing matchers still match)
- * and pass every other error through untouched — this never turns a passing
- * call into a failure.
- */
-function augmentNotBuilt(error: unknown): unknown {
-  const message = error instanceof Error ? error.message : String(error);
-  if (!message.includes("not computed for semantic")) return error;
-  return new Error(
-    `${message} — if you called register(...) without awaiting it, the embedding ` +
-      "pass was skipped; `await catalog.register(...)` (or `registry.register(...)`) " +
-      "before a semantic/hybrid search",
-  );
 }
 
 /**
@@ -99,8 +79,11 @@ export class ToolRegistry {
    * @internal
    */
   async buildDense(): Promise<void> {
-    if (this.eager) {
+    if (!this.eager) return;
+    try {
       await this.native.buildEmbeddings();
+    } catch (error) {
+      throw mapEmbedderError(error);
     }
   }
 
@@ -141,7 +124,7 @@ export class ToolRegistry {
     try {
       return await this.native.searchWithMethodAsync(query, topK, origin, method);
     } catch (error) {
-      throw augmentNotBuilt(error);
+      throw mapEmbedderError(error);
     }
   }
 
@@ -214,8 +197,11 @@ export class SkillRegistry {
    * @internal
    */
   async buildDense(): Promise<void> {
-    if (this.eager) {
+    if (!this.eager) return;
+    try {
       await this.native.buildEmbeddings();
+    } catch (error) {
+      throw mapEmbedderError(error);
     }
   }
 
@@ -249,7 +235,7 @@ export class SkillRegistry {
     try {
       return await this.native.searchWithMethodAsync(query, topK, origin, method);
     } catch (error) {
-      throw augmentNotBuilt(error);
+      throw mapEmbedderError(error);
     }
   }
 

--- a/src/sdk/ts/src/registry.ts
+++ b/src/sdk/ts/src/registry.ts
@@ -19,6 +19,27 @@ function toNativeEmbedding(
 }
 
 /**
+ * Append an await-oriented hint when a dense search fails because the corpus
+ * was never embedded — the signature of a forgotten `await register(...)`.
+ *
+ * On a `"semantic"`/`"hybrid"` catalog the embedding pass runs inside `register`;
+ * an un-awaited `register(...)` skips it, and the next dense search hits the
+ * core's "not computed for semantic" error. We enrich only that already-failing
+ * error (the original message is preserved, so existing matchers still match)
+ * and pass every other error through untouched — this never turns a passing
+ * call into a failure.
+ */
+function augmentNotBuilt(error: unknown): unknown {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!message.includes("not computed for semantic")) return error;
+  return new Error(
+    `${message} — if you called register(...) without awaiting it, the embedding ` +
+      "pass was skipped; `await catalog.register(...)` (or `registry.register(...)`) " +
+      "before a semantic/hybrid search",
+  );
+}
+
+/**
  * Typed facade over the native tool registry: metadata-only indexing and
  * retrieval, with the SDK's public embedding config and an async, batch-aware
  * `register`. {@link ToolCatalog} layers executors, OTel spans, and defaults
@@ -111,13 +132,17 @@ export class ToolRegistry {
   }
 
   /** Search on a libuv worker; supports `"bm25"`, `"semantic"`, and `"hybrid"`. */
-  searchWithMethodAsync(
+  async searchWithMethodAsync(
     query: string,
     topK: number,
     origin: SearchOrigin,
     method: SearchMethod,
   ): Promise<SearchHit[]> {
-    return this.native.searchWithMethodAsync(query, topK, origin, method);
+    try {
+      return await this.native.searchWithMethodAsync(query, topK, origin, method);
+    } catch (error) {
+      throw augmentNotBuilt(error);
+    }
   }
 
   /**
@@ -215,13 +240,17 @@ export class SkillRegistry {
   }
 
   /** Search on a libuv worker — see `ToolRegistry.searchWithMethodAsync`. */
-  searchWithMethodAsync(
+  async searchWithMethodAsync(
     query: string,
     topK: number,
     origin: SearchOrigin,
     method: SearchMethod,
   ): Promise<SkillHit[]> {
-    return this.native.searchWithMethodAsync(query, topK, origin, method);
+    try {
+      return await this.native.searchWithMethodAsync(query, topK, origin, method);
+    } catch (error) {
+      throw augmentNotBuilt(error);
+    }
   }
 
   /** Record a custom event on the local trace stream (ADR-0007). */


### PR DESCRIPTION
### Summary

Four follow-up fixes to the configurable-embedding-models work shipped in 0.5.0-rc.1, surfaced by a post-release review (RAT-385). One real DX bug, one concurrency bug, one DX-parity feature, and one perf win. All are additive or behavior-preserving for correctly-written code; each was verified end-to-end.

**Changes**

1. Forgotten-await register() no longer silently drops the corpus (fix, Python SDK + TS hint)
register() became async in 0.5.0-rc.1; a forgotten await registered nothing in Python (the coroutine body never ran) and only surfaced later as empty search results — it bit our own examples/e2e. Python register() now commits metadata synchronously (returns an awaitable that drives only the embedding pass), and a semantic/hybrid search_async after an un-awaited register() raises an actionable error instead of ranking an empty corpus. TS already committed metadata synchronously; its dense "not-built" error now carries the same await hint.
Awaited usage is unchanged. register is now a method returning Awaitable[None] rather than an async def.

2. Distinct embedding models load concurrently (fix, core)
The process-wide embedder cache held its lock across a full model load (HF download + BERT load), so a cold load of one model blocked loading — or a warm hit for — another. The cache now holds its lock only to fetch a per-key slot; loads run under that slot. Same-model loads stay single-flight (one load, reported once); retry-on-failure and load telemetry are unchanged.

3. Typed embedding errors in the TS SDK (feat, TS SDK)
The TS binding flattened every embedding failure to a plain Error. Adds exported EmbedderError (with a stable .code) and its DimensionMismatchError subclass — parity with the Python SDK — so callers branch on instanceof/code instead of matching message text. Pure-TS mapping; messages preserved; invalid config still throws at construction.

4. Batched in-process embedding (perf, core)
CandleEmbedder embedded one document per forward pass. It now runs one padded forward per chunk, cutting the time to embed a corpus (and every process-start re-embed). Produced vectors are bit-for-bit identical to the per-document path, so rankings and reproducibility are unchanged.

**Compatibility**

- No public API removed; correct (awaited) code is unaffected.
- New TS exports: EmbedderErro(additive).
- Behavior changes are all intended and positive: metadata now commits at register()
call time (Python); distinct mbedding failures are typed (TS). No change to ranking, vector reproducibility, retry, or telemetry semantics.
- No changes to core retrievalconventions, or MCP ingestion.

**Testing**

- core cargo test: 111 passed, #[ignore] test assertsembed_batch is bit-for-bit equal to looping embed_doc on the real bge-small model (exact
equality, no epsilon) — verifi
- sdk-ts pnpm test: 152 passed (typed-error unit + integration tests added); typecheck,
biome, and typedoc docs:check
- sdk-py pytest: 129 passed on Python 3.11 and 3.14 (incl. the async-cancellation
tests); ruff + mypy clean (12-erved).
- Ran the offline embedding demo across all four changes: semantic scores identical to
before (proving #4's bit-identgraceful-error paths intact.

**CHANGELOGs**

[Unreleased] entries added for), and sdk-ts (#1 hint; #3landed earlier). No version bump — these graduate to a version section at release.