### PR TITLE
feat: add @ratel-ai/mastra-adapter (OSI-16)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ name: Release
 #     The telemetry helpers release independently (one registry each; otlp is the
 #     npm exporter split from the vocabulary); tag the same commit to ship together.
 #   mastra-v* -> @ratel-ai/mastra on npm (framework adapter, peers the SDK)
+#   vercel-ai-sdk-v* -> @ratel-ai/vercel-ai-sdk on npm (framework adapter, peers the SDK)
 
 on:
   push:
@@ -27,6 +28,7 @@ on:
       - 'telemetry-py-v*'
       - 'telemetry-ts-otlp-v*'
       - 'mastra-v*'
+      - 'vercel-ai-sdk-v*'
   workflow_dispatch:
     inputs:
       tag:
@@ -650,6 +652,70 @@ jobs:
             (cd src/adapters/ts-mastra && npm publish --provenance --access public --tag "$DIST_TAG" $DRY_RUN)
           fi
 
+  publish-vercel-ai-sdk:
+    name: Publish @ratel-ai/vercel-ai-sdk to npm
+    needs: [tag-version-check]
+    if: needs.tag-version-check.outputs.unit == 'vercel-ai-sdk'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+      - name: Verify npm CLI version
+        shell: bash
+        run: |
+          set -e
+          npm --version
+          # Trusted Publishers requires npm CLI 11.5.1+
+          node -e "const v = require('child_process').execSync('npm --version').toString().trim(); const [maj, min, patch] = v.split('.').map(Number); if (maj < 11 || (maj === 11 && (min < 5 || (min === 5 && patch < 1)))) { console.error('npm CLI ' + v + ' < 11.5.1 (required for Trusted Publishers)'); process.exit(1); } console.log('npm ' + v + ' OK');"
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      # Build the adapter and its @ratel-ai/sdk workspace dependency (topo order).
+      - name: Build TS
+        run: pnpm --filter "@ratel-ai/vercel-ai-sdk..." run build
+      # npm keeps `workspace:` specifiers verbatim, so pin the @ratel-ai/sdk peer to
+      # the concrete co-released version before publishing (ephemeral CI edit; not
+      # committed). Keeps the npm-OIDC dir publish + provenance identical to the
+      # other units rather than switching to `pnpm publish`.
+      - name: Pin the @ratel-ai/sdk peer dependency for publish
+        shell: bash
+        run: |
+          set -e
+          sdk_ver=$(node -p "require('./src/sdk/ts/package.json').version")
+          SDK_VER="$sdk_ver" node -e "const fs=require('fs'); const f='./src/adapters/ts-vercel-ai-sdk/package.json'; const p=require(f); p.peerDependencies['@ratel-ai/sdk']='^'+process.env.SDK_VER; fs.writeFileSync(f, JSON.stringify(p, null, 2) + '\n')"
+          echo "pinned @ratel-ai/sdk -> $(node -p "require('./src/adapters/ts-vercel-ai-sdk/package.json').peerDependencies['@ratel-ai/sdk']")"
+      # Preflight dry-run BEFORE the real (immutable) publish, mirroring the SDK job.
+      - name: Preflight — dry-run npm publish
+        shell: bash
+        env:
+          DIST_TAG: ${{ needs.tag-version-check.outputs.dist_tag }}
+        run: (cd src/adapters/ts-vercel-ai-sdk && npm publish --access public --tag "$DIST_TAG" --dry-run)
+      - name: Publish
+        shell: bash
+        env:
+          DRY_RUN: ${{ inputs.dry_run && '--dry-run' || '' }}
+          DIST_TAG: ${{ needs.tag-version-check.outputs.dist_tag }}
+        run: |
+          set -e
+          name=$(node -p "require('./src/adapters/ts-vercel-ai-sdk/package.json').name")
+          ver=$(node -p "require('./src/adapters/ts-vercel-ai-sdk/package.json').version")
+          # Idempotent: skip if this exact name@version is already live (npm is immutable).
+          if [ -z "$DRY_RUN" ] && [ "$(npm view "$name@$ver" version 2>/dev/null)" = "$ver" ]; then
+            echo "::notice::$name@$ver already published — skipping"
+          else
+            (cd src/adapters/ts-vercel-ai-sdk && npm publish --provenance --access public --tag "$DIST_TAG" $DRY_RUN)
+          fi
+
   github-release:
     name: GitHub Release
     needs:
@@ -662,6 +728,7 @@ jobs:
       - publish-telemetry-core
       - publish-telemetry-ts-otlp
       - publish-mastra
+      - publish-vercel-ai-sdk
     # Exactly one unit's publish job runs; the rest are skipped. Run when the tag
     # was pushed and that one job succeeded. Every unit is single-registry now, so
     # any one publish job succeeding is enough.
@@ -675,7 +742,8 @@ jobs:
               || needs.publish-telemetry-py.result == 'success'
               || needs.publish-telemetry-core.result == 'success'
               || needs.publish-telemetry-ts-otlp.result == 'success'
-              || needs.publish-mastra.result == 'success') }}
+              || needs.publish-mastra.result == 'success'
+              || needs.publish-vercel-ai-sdk.result == 'success') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ name: Release
 #   telemetry-ts-otlp-v* -> @ratel-ai/telemetry-otlp on npm (the init() exporter)
 #     The telemetry helpers release independently (one registry each; otlp is the
 #     npm exporter split from the vocabulary); tag the same commit to ship together.
-#   mastra-adapter-v* -> @ratel-ai/mastra-adapter on npm (framework adapter, peers the SDK)
+#   mastra-v* -> @ratel-ai/mastra on npm (framework adapter, peers the SDK)
 
 on:
   push:
@@ -26,7 +26,7 @@ on:
       - 'telemetry-ts-v*'
       - 'telemetry-py-v*'
       - 'telemetry-ts-otlp-v*'
-      - 'mastra-adapter-v*'
+      - 'mastra-v*'
   workflow_dispatch:
     inputs:
       tag:
@@ -586,10 +586,10 @@ jobs:
             (cd src/telemetry/ts-otlp && npm publish --provenance --access public --tag "$DIST_TAG" $DRY_RUN)
           fi
 
-  publish-mastra-adapter:
-    name: Publish @ratel-ai/mastra-adapter to npm
+  publish-mastra:
+    name: Publish @ratel-ai/mastra to npm
     needs: [tag-version-check]
-    if: needs.tag-version-check.outputs.unit == 'mastra-adapter'
+    if: needs.tag-version-check.outputs.unit == 'mastra'
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -616,7 +616,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       # Build the adapter and its @ratel-ai/sdk workspace dependency (topo order).
       - name: Build TS
-        run: pnpm --filter "@ratel-ai/mastra-adapter..." run build
+        run: pnpm --filter "@ratel-ai/mastra..." run build
       # npm keeps `workspace:` specifiers verbatim, so pin the @ratel-ai/sdk peer to
       # the concrete co-released version before publishing (ephemeral CI edit; not
       # committed). Keeps the npm-OIDC dir publish + provenance identical to the
@@ -661,7 +661,7 @@ jobs:
       - publish-telemetry-py
       - publish-telemetry-core
       - publish-telemetry-ts-otlp
-      - publish-mastra-adapter
+      - publish-mastra
     # Exactly one unit's publish job runs; the rest are skipped. Run when the tag
     # was pushed and that one job succeeded. Every unit is single-registry now, so
     # any one publish job succeeding is enough.
@@ -675,7 +675,7 @@ jobs:
               || needs.publish-telemetry-py.result == 'success'
               || needs.publish-telemetry-core.result == 'success'
               || needs.publish-telemetry-ts-otlp.result == 'success'
-              || needs.publish-mastra-adapter.result == 'success') }}
+              || needs.publish-mastra.result == 'success') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ name: Release
 #   telemetry-ts-otlp-v* -> @ratel-ai/telemetry-otlp on npm (the init() exporter)
 #     The telemetry helpers release independently (one registry each; otlp is the
 #     npm exporter split from the vocabulary); tag the same commit to ship together.
+#   mastra-adapter-v* -> @ratel-ai/mastra-adapter on npm (framework adapter, peers the SDK)
 
 on:
   push:
@@ -25,6 +26,7 @@ on:
       - 'telemetry-ts-v*'
       - 'telemetry-py-v*'
       - 'telemetry-ts-otlp-v*'
+      - 'mastra-adapter-v*'
   workflow_dispatch:
     inputs:
       tag:
@@ -584,6 +586,70 @@ jobs:
             (cd src/telemetry/ts-otlp && npm publish --provenance --access public --tag "$DIST_TAG" $DRY_RUN)
           fi
 
+  publish-mastra-adapter:
+    name: Publish @ratel-ai/mastra-adapter to npm
+    needs: [tag-version-check]
+    if: needs.tag-version-check.outputs.unit == 'mastra-adapter'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+      - name: Verify npm CLI version
+        shell: bash
+        run: |
+          set -e
+          npm --version
+          # Trusted Publishers requires npm CLI 11.5.1+
+          node -e "const v = require('child_process').execSync('npm --version').toString().trim(); const [maj, min, patch] = v.split('.').map(Number); if (maj < 11 || (maj === 11 && (min < 5 || (min === 5 && patch < 1)))) { console.error('npm CLI ' + v + ' < 11.5.1 (required for Trusted Publishers)'); process.exit(1); } console.log('npm ' + v + ' OK');"
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      # Build the adapter and its @ratel-ai/sdk workspace dependency (topo order).
+      - name: Build TS
+        run: pnpm --filter "@ratel-ai/mastra-adapter..." run build
+      # npm keeps `workspace:` specifiers verbatim, so pin the @ratel-ai/sdk peer to
+      # the concrete co-released version before publishing (ephemeral CI edit; not
+      # committed). Keeps the npm-OIDC dir publish + provenance identical to the
+      # other units rather than switching to `pnpm publish`.
+      - name: Pin the @ratel-ai/sdk peer dependency for publish
+        shell: bash
+        run: |
+          set -e
+          sdk_ver=$(node -p "require('./src/sdk/ts/package.json').version")
+          SDK_VER="$sdk_ver" node -e "const fs=require('fs'); const f='./src/adapters/ts-mastra/package.json'; const p=require(f); p.peerDependencies['@ratel-ai/sdk']='^'+process.env.SDK_VER; fs.writeFileSync(f, JSON.stringify(p, null, 2) + '\n')"
+          echo "pinned @ratel-ai/sdk -> $(node -p "require('./src/adapters/ts-mastra/package.json').peerDependencies['@ratel-ai/sdk']")"
+      # Preflight dry-run BEFORE the real (immutable) publish, mirroring the SDK job.
+      - name: Preflight — dry-run npm publish
+        shell: bash
+        env:
+          DIST_TAG: ${{ needs.tag-version-check.outputs.dist_tag }}
+        run: (cd src/adapters/ts-mastra && npm publish --access public --tag "$DIST_TAG" --dry-run)
+      - name: Publish
+        shell: bash
+        env:
+          DRY_RUN: ${{ inputs.dry_run && '--dry-run' || '' }}
+          DIST_TAG: ${{ needs.tag-version-check.outputs.dist_tag }}
+        run: |
+          set -e
+          name=$(node -p "require('./src/adapters/ts-mastra/package.json').name")
+          ver=$(node -p "require('./src/adapters/ts-mastra/package.json').version")
+          # Idempotent: skip if this exact name@version is already live (npm is immutable).
+          if [ -z "$DRY_RUN" ] && [ "$(npm view "$name@$ver" version 2>/dev/null)" = "$ver" ]; then
+            echo "::notice::$name@$ver already published — skipping"
+          else
+            (cd src/adapters/ts-mastra && npm publish --provenance --access public --tag "$DIST_TAG" $DRY_RUN)
+          fi
+
   github-release:
     name: GitHub Release
     needs:
@@ -595,6 +661,7 @@ jobs:
       - publish-telemetry-py
       - publish-telemetry-core
       - publish-telemetry-ts-otlp
+      - publish-mastra-adapter
     # Exactly one unit's publish job runs; the rest are skipped. Run when the tag
     # was pushed and that one job succeeded. Every unit is single-registry now, so
     # any one publish job succeeding is enough.
@@ -607,7 +674,8 @@ jobs:
               || needs.publish-telemetry-ts.result == 'success'
               || needs.publish-telemetry-py.result == 'success'
               || needs.publish-telemetry-core.result == 'success'
-              || needs.publish-telemetry-ts-otlp.result == 'success') }}
+              || needs.publish-telemetry-ts-otlp.result == 'success'
+              || needs.publish-mastra-adapter.result == 'success') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -47,7 +47,7 @@ jobs:
       # Example wiring (Mastra) — parity with the AI SDK row. Drives the real Mastra
       # Agent loop with Mastra's built-in mock model (no API key), asserting the
       # adapter's capability-tool funnel + recall processor reach the model prompt.
-      # @ratel-ai/mastra-adapter is already built by `pnpm -r build` above.
+      # @ratel-ai/mastra is already built by `pnpm -r build` above.
       # See examples/mastra/test/agent.test.ts.
       - name: Test the Mastra example wiring
         run: pnpm --filter @ratel-ai/example-mastra exec tsx test/agent.test.ts

--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -44,6 +44,13 @@ jobs:
       # See examples/ai-sdk/test/agent.test.ts.
       - name: Test the AI SDK example wiring
         run: pnpm --filter @ratel-ai/example-ai-sdk exec tsx test/agent.test.ts
+      # Example wiring (Mastra) — parity with the AI SDK row. Drives the real Mastra
+      # Agent loop with Mastra's built-in mock model (no API key), asserting the
+      # adapter's capability-tool funnel + recall processor reach the model prompt.
+      # @ratel-ai/mastra-adapter is already built by `pnpm -r build` above.
+      # See examples/mastra/test/agent.test.ts.
+      - name: Test the Mastra example wiring
+        run: pnpm --filter @ratel-ai/example-mastra exec tsx test/agent.test.ts
       # Telemetry example — runs offline (console exporter), emitting a ratel.search
       # + execute_tool trace through the OTel SDK, so it verifies the `ratel.*` vocab
       # end-to-end. @ratel-ai/telemetry and @ratel-ai/telemetry-otlp (the example imports

--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -44,13 +44,29 @@ jobs:
       # See examples/ai-sdk/test/agent.test.ts.
       - name: Test the AI SDK example wiring
         run: pnpm --filter @ratel-ai/example-ai-sdk exec tsx test/agent.test.ts
-      # Example wiring (Mastra) — parity with the AI SDK row. Drives the real Mastra
-      # Agent loop with Mastra's built-in mock model (no API key), asserting the
-      # adapter's capability-tool funnel + recall processor reach the model prompt.
+      # Example wiring (Mastra) — parity with the AI SDK row. Drives a real 1.51
+      # Agent loop with Mastra's built-in mock model (no API key).
       # @ratel-ai/mastra is already built by `pnpm -r build` above.
       # See examples/mastra/test/agent.test.ts.
       - name: Test the Mastra example wiring
         run: pnpm --filter @ratel-ai/example-mastra exec tsx test/agent.test.ts
+      # Re-run the adapter at the customer's 1.31 line and its declared floor after
+      # all 1.51 workspace consumers are done. `--no-lockfile` keeps these ephemeral
+      # CI substitutions out of the lock.
+      - name: Install customer-line Mastra
+        run: pnpm --filter @ratel-ai/mastra add --save-dev --save-exact @mastra/core@1.31.0 --no-lockfile
+      - name: Test Mastra 1.31
+        run: |
+          pnpm --filter @ratel-ai/mastra build
+          pnpm --filter @ratel-ai/mastra typecheck
+          pnpm --filter @ratel-ai/mastra test
+      - name: Install minimum supported Mastra
+        run: pnpm --filter @ratel-ai/mastra add --save-dev --save-exact @mastra/core@1.11.0 --no-lockfile
+      - name: Test minimum supported Mastra
+        run: |
+          pnpm --filter @ratel-ai/mastra build
+          pnpm --filter @ratel-ai/mastra typecheck
+          pnpm --filter @ratel-ai/mastra test
       # Telemetry example — runs offline (console exporter), emitting a ratel.search
       # + execute_tool trace through the OTel SDK, so it verifies the `ratel.*` vocab
       # end-to-end. @ratel-ai/telemetry and @ratel-ai/telemetry-otlp (the example imports

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Core is a Rust lib (`ratel-ai-core`); language SDKs bundle it. In-process, no in
 ```
 src/core/           Rust core (ratel-ai-core engine)
 src/sdk/            language SDKs
-src/adapters/       framework adapter packages (ai-sdk, ...)
+src/adapters/       framework adapter packages (ai-sdk, mastra, ...)
 src/telemetry/      OTel telemetry conventions + helper packages
 protocol/           catalog source wire contract (pull-sync + auth)
 docs/               ADRs and other docs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "ratel-sdk-ts-native"
-version = "0.5.0"
+version = "0.5.1-rc.1"
 dependencies = [
  "napi",
  "napi-build",

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ src/
 ├── sdk/ts/            # @ratel-ai/sdk — TypeScript SDK (NAPI-bound)
 ├── sdk/python/        # ratel-ai — Python SDK (PyO3-bound)
 ├── adapters/ts-vercel-ai-sdk/ # @ratel-ai/vercel-ai-sdk — Vercel AI SDK adapter
+├── adapters/ts-mastra/ # @ratel-ai/mastra-adapter — Mastra adapter
 └── telemetry/         # OTel conventions + helper packages
 protocol/              # catalog-source wire contract
 examples/              # End-to-end SDK examples

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ src/
 ├── sdk/ts/            # @ratel-ai/sdk — TypeScript SDK (NAPI-bound)
 ├── sdk/python/        # ratel-ai — Python SDK (PyO3-bound)
 ├── adapters/ts-vercel-ai-sdk/ # @ratel-ai/vercel-ai-sdk — Vercel AI SDK adapter
-├── adapters/ts-mastra/ # @ratel-ai/mastra-adapter — Mastra adapter
+├── adapters/ts-mastra/ # @ratel-ai/mastra — Mastra adapter
 └── telemetry/         # OTel conventions + helper packages
 protocol/              # catalog-source wire contract
 examples/              # End-to-end SDK examples

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,7 +19,7 @@ each unit carries its own version in its own manifest and ships on its own caden
 | `telemetry-py` | `telemetry-py-v*` | `ratel-ai-telemetry` on PyPI | `src/telemetry/python/pyproject.toml` |
 | `telemetry-ts-otlp` | `telemetry-ts-otlp-v*` | `@ratel-ai/telemetry-otlp` on npm | `src/telemetry/ts-otlp/package.json` |
 | `vercel-ai-sdk` | `vercel-ai-sdk-v*` | `@ratel-ai/vercel-ai-sdk` on npm | `src/adapters/ts-vercel-ai-sdk/package.json` |
-| `mastra-adapter` | `mastra-adapter-v*` | `@ratel-ai/mastra-adapter` on npm | `src/adapters/ts-mastra/package.json` |
+| `mastra` | `mastra-v*` | `@ratel-ai/mastra` on npm | `src/adapters/ts-mastra/package.json` |
 
 The units are registered once, in [`scripts/release-units.mjs`](scripts/release-units.mjs)
 — the single source of truth that the tag gate, the `releasable` helper, the changelog
@@ -48,8 +48,8 @@ to release them in one run. `telemetry-ts-otlp` (`@ratel-ai/telemetry-otlp` → 
 time. All four are pure-language, so the manual helper builds them locally (no prebuilt
 artifacts).
 
-The **framework adapters** (`vercel-ai-sdk` → `@ratel-ai/vercel-ai-sdk`, `mastra-adapter` →
-`@ratel-ai/mastra-adapter`; more to come) are npm-only, pure-language units that peer-depend on
+The **framework adapters** (`vercel-ai-sdk` → `@ratel-ai/vercel-ai-sdk`, `mastra` →
+`@ratel-ai/mastra`; more to come) are npm-only, pure-language units that peer-depend on
 `@ratel-ai/sdk` via `workspace:^`. Like `telemetry-ts-otlp`, the manual helper builds and
 `pnpm pack`s them locally (the pack rewrites the `workspace:` peer to a concrete range); they
 need no prebuilt artifact.
@@ -59,7 +59,7 @@ need no prebuilt artifact.
 ## How the release pipeline is wired
 
 - **`release.yml`** — fires on any `core-v*` / `sdk-ts-v*` / `sdk-py-v*` / `telemetry-core-v*` /
-  `telemetry-ts-v*` / `telemetry-py-v*` / `telemetry-ts-otlp-v*` / `mastra-adapter-v*` tag push (and
+  `telemetry-ts-v*` / `telemetry-py-v*` / `telemetry-ts-otlp-v*` / `mastra-v*` tag push (and
   supports `workflow_dispatch` with `dry_run: true` for rehearsal). Its first job,
   `tag-version-check`, runs [`scripts/check-release-tag.mjs`](scripts/check-release-tag.mjs) to
   route the tag to its unit and verify **only that unit's** manifests + CHANGELOG carry the
@@ -134,8 +134,8 @@ rstagi with a one-member team. Run the E2E locally per `e2e/README.md`.
   `ratel-ai-core` crate, and the `ratel-ai` PyPI project — each pointing at this repo /
   `release.yml` / the `release` environment. **The 4 telemetry names
   (`@ratel-ai/telemetry` + `@ratel-ai/telemetry-otlp` on npm, `ratel-ai-telemetry` on PyPI +
-  crates.io) and the `@ratel-ai/mastra-adapter` name are not yet registered** — they are added
-  at their first-time bootstrap, taking the total 8 → 12 (telemetry) → 13 (mastra-adapter).
+  crates.io) and the `@ratel-ai/mastra` name are not yet registered** — they are added
+  at their first-time bootstrap, taking the total 8 → 12 (telemetry) → 13 (mastra).
   `@ratel-ai/vercel-ai-sdk` exists on npm but remains outside this count until its workflow
   job and Trusted Publisher are configured.
 - A `release` GitHub Environment exists whose **deployment tag policy allows the unit
@@ -143,7 +143,7 @@ rstagi with a one-member team. Run the E2E locally per `e2e/README.md`.
   unchanged (it's what binds the Trusted Publishers); only its tag policy lists the prefixes.
   A tag not matched by the policy hangs the publish job at the deploy gate. **Add
   `telemetry-core-v*`, `telemetry-ts-v*`, `telemetry-py-v*`, `telemetry-ts-otlp-v*` to the policy
-  before cutting the first telemetry release, and `mastra-adapter-v*` before the first CI-driven
+  before cutting the first telemetry release, and `mastra-v*` before the first CI-driven
   adapter release** (still pending).
 
 ### Per-release flow (one unit at a time)
@@ -224,7 +224,7 @@ Publishers can't be configured for a package that doesn't exist yet. Do this per
    - `sdk-ts` → `build-binaries.yml` (produces the `release-tarballs` artifact).
    - `sdk-py` → `python-binaries.yml` (produces `wheels-*` + sdist).
    - `core` needs no prebuilt artifact — it publishes straight from the repo.
-   - `telemetry-core` / `telemetry-ts` / `telemetry-py` / `telemetry-ts-otlp` / `mastra-adapter` /
+   - `telemetry-core` / `telemetry-ts` / `telemetry-py` / `telemetry-ts-otlp` / `mastra` /
      `vercel-ai-sdk` need no prebuilt artifact — they are pure-language, so `publish-rc.sh`
      builds the crate, npm packages, wheel/sdist, or packed adapter locally.
 2. Log in locally: `npm login` (npm requires 2FA on the publishing account for a first-publish
@@ -238,12 +238,12 @@ Publishers can't be configured for a package that doesn't exist yet. Do this per
    subpackages → loader for `sdk-ts`, `twine upload --skip-existing` for `sdk-py`, `cargo
    publish` for `core`, the locally-built npm / npm / wheel / crate for `telemetry-ts` /
    `telemetry-ts-otlp` / `telemetry-py` / `telemetry-core`, and the pnpm-packed npm tarballs
-   for `mastra-adapter` + `vercel-ai-sdk`.
+   for `mastra` + `vercel-ai-sdk`.
    It's idempotent (skips anything already on the registry), so a partial failure is safe to
    resume. First-publish from a laptop ships **without provenance** (that requires GH Actions
    OIDC); that's expected for the bootstrap.
 4. Configure Trusted Publishers on each registry name (npm web UI for the 6 SDK packages +
-   `@ratel-ai/telemetry` + `@ratel-ai/telemetry-otlp` + `@ratel-ai/mastra-adapter` +
+   `@ratel-ai/telemetry` + `@ratel-ai/telemetry-otlp` + `@ratel-ai/mastra` +
    `@ratel-ai/vercel-ai-sdk`, crates.io for `ratel-ai-core` + `ratel-ai-telemetry`, PyPI for
    `ratel-ai` + `ratel-ai-telemetry`) pointing at `release.yml` in this repo, `release` environment.
 5. Bump to the next version (e.g. `-rc.2`), tag `<unit>-v…`, push — `release.yml` should now

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,8 +3,7 @@
 How a new version of a Ratel package is published. Read end-to-end before cutting a release.
 
 Ratel releases **per unit** (ADR-0008): nine independently-versioned release units, each on
-its own tag prefix, routed through one `release.yml` (except `vercel-ai-sdk`, which is
-manual-publish-only for now — see its note below). There is no workspace-shared version —
+its own tag prefix, routed through one `release.yml`. There is no workspace-shared version —
 each unit carries its own version in its own manifest and ships on its own cadence.
 
 ## Release units
@@ -25,13 +24,12 @@ The units are registered once, in [`scripts/release-units.mjs`](scripts/release-
 — the single source of truth that the tag gate, the `releasable` helper, the changelog
 drafter, and the manual publish helper all read. Adding a future unit is a one-place change.
 
-The `vercel-ai-sdk` framework adapter is registered here so the tag gate, `releasable`, and
-`publish-rc.sh` recognise it, but it is **not yet wired into `release.yml`'s triggers or a
-Trusted Publisher**. It has already been bootstrapped on npm; publish every adapter version
-manually with `scripts/publish-rc.sh --unit vercel-ai-sdk --tag <rc|latest>` after pushing its
-version tag. Then verify the exact published version with `verify-install.yml`. Add its
-`vercel-ai-sdk-v*` trigger to `release.yml`, the `release` environment's tag policy, and a
-Trusted Publisher before moving it onto the OIDC path.
+The `vercel-ai-sdk` framework adapter is wired into `release.yml`'s triggers and its own
+`publish-vercel-ai-sdk` job (pure-TS, built + `pnpm pack`ed locally, like the telemetry npm
+units), publishing over OIDC via a Trusted Publisher. Its npm name was bootstrapped by a manual
+first-publish (`scripts/publish-rc.sh --unit vercel-ai-sdk`) before the Trusted Publisher could
+exist. The `release` environment's tag policy must allow `vercel-ai-sdk-v*`, or the publish job
+hangs at the deploy gate.
 
 The `sdk-ts` unit is internally lockstep: the loader `@ratel-ai/sdk`, its five per-OS native
 packages (`@ratel-ai/sdk-darwin-arm64`, `-darwin-x64`, `-linux-x64-gnu`, `-linux-arm64-gnu`,
@@ -59,7 +57,8 @@ need no prebuilt artifact.
 ## How the release pipeline is wired
 
 - **`release.yml`** — fires on any `core-v*` / `sdk-ts-v*` / `sdk-py-v*` / `telemetry-core-v*` /
-  `telemetry-ts-v*` / `telemetry-py-v*` / `telemetry-ts-otlp-v*` / `mastra-v*` tag push (and
+  `telemetry-ts-v*` / `telemetry-py-v*` / `telemetry-ts-otlp-v*` / `mastra-v*` /
+  `vercel-ai-sdk-v*` tag push (and
   supports `workflow_dispatch` with `dry_run: true` for rehearsal). Its first job,
   `tag-version-check`, runs [`scripts/check-release-tag.mjs`](scripts/check-release-tag.mjs) to
   route the tag to its unit and verify **only that unit's** manifests + CHANGELOG carry the
@@ -130,21 +129,19 @@ rstagi with a one-member team. Run the E2E locally per `e2e/README.md`.
 
 - `@ratel-ai` npm org exists; the publishing account is a member with `developer`+ role; 2FA enabled.
 - `ratel-ai-core` (crates.io) and `ratel-ai` (PyPI) names are registered.
-- Trusted Publishers are configured on all **8** registry names — the 6 npm packages, the
-  `ratel-ai-core` crate, and the `ratel-ai` PyPI project — each pointing at this repo /
-  `release.yml` / the `release` environment. **The 4 telemetry names
+- Trusted Publishers are configured on the 6 SDK npm packages, the `ratel-ai-core` crate, the
+  `ratel-ai` PyPI project, and the `@ratel-ai/vercel-ai-sdk` npm name — each pointing at this
+  repo / `release.yml` / the `release` environment. **The 4 telemetry names
   (`@ratel-ai/telemetry` + `@ratel-ai/telemetry-otlp` on npm, `ratel-ai-telemetry` on PyPI +
-  crates.io) and the `@ratel-ai/mastra` name are not yet registered** — they are added
-  at their first-time bootstrap, taking the total 8 → 12 (telemetry) → 13 (mastra).
-  `@ratel-ai/vercel-ai-sdk` exists on npm but remains outside this count until its workflow
-  job and Trusted Publisher are configured.
+  crates.io) and the `@ratel-ai/mastra` npm name are not yet registered** — they are added at
+  their first-time bootstrap.
 - A `release` GitHub Environment exists whose **deployment tag policy allows the unit
   prefixes** — `core-v*`, `sdk-ts-v*`, `sdk-py-v*`. Keep the environment *name* `release`
   unchanged (it's what binds the Trusted Publishers); only its tag policy lists the prefixes.
   A tag not matched by the policy hangs the publish job at the deploy gate. **Add
   `telemetry-core-v*`, `telemetry-ts-v*`, `telemetry-py-v*`, `telemetry-ts-otlp-v*` to the policy
-  before cutting the first telemetry release, and `mastra-v*` before the first CI-driven
-  adapter release** (still pending).
+  before cutting the first telemetry release, and `mastra-v*` + `vercel-ai-sdk-v*` before their
+  first CI-driven adapter release.**
 
 ### Per-release flow (one unit at a time)
 
@@ -176,19 +173,14 @@ rstagi with a one-member team. Run the E2E locally per `e2e/README.md`.
      (for a `vercel-ai-sdk` release)
 5. **(Optional dry-run, workflow-wired units only)** `workflow_dispatch` `release.yml` with
    the tag (e.g. `sdk-py-v0.2.1-rc.1`) and `dry_run: true` to validate the auth + publish path
-   without consuming a version number. Skip this for `vercel-ai-sdk` while it remains
-   manual-publish-only.
+   without consuming a version number.
 6. **Commit, tag, push:**
    ```
    git commit -am "release: <unit>-vX.Y.Z"
    git tag <unit>-vX.Y.Z          # e.g. sdk-py-v0.2.1-rc.1
    git push origin main <unit>-vX.Y.Z
    ```
-7. **Publish:**
-   - `vercel-ai-sdk`: run `scripts/publish-rc.sh --unit vercel-ai-sdk --tag rc` for an RC,
-     or `--tag latest` for a GA. It builds and packs the adapter locally; do not wait for
-     `release.yml`, which has no adapter publish job yet.
-   - Every other unit: watch `release.yml` to completion and inspect the GitHub Release.
+7. **Publish:** watch `release.yml` to completion and inspect the GitHub Release.
 8. **Verify the install:** run `verify-install.yml` for the unit + version
    (`gh workflow run verify-install.yml -f unit=$UNIT -f version=X.Y.Z`).
 9. **For RCs:** iterate (`-rc.2`, `-rc.3`, …) until happy, then bump to the un-suffixed

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 How a new version of a Ratel package is published. Read end-to-end before cutting a release.
 
-Ratel releases **per unit** (ADR-0008): eight independently-versioned release units, each on
+Ratel releases **per unit** (ADR-0008): nine independently-versioned release units, each on
 its own tag prefix, routed through one `release.yml` (except `vercel-ai-sdk`, which is
 manual-publish-only for now — see its note below). There is no workspace-shared version —
 each unit carries its own version in its own manifest and ships on its own cadence.
@@ -19,6 +19,7 @@ each unit carries its own version in its own manifest and ships on its own caden
 | `telemetry-py` | `telemetry-py-v*` | `ratel-ai-telemetry` on PyPI | `src/telemetry/python/pyproject.toml` |
 | `telemetry-ts-otlp` | `telemetry-ts-otlp-v*` | `@ratel-ai/telemetry-otlp` on npm | `src/telemetry/ts-otlp/package.json` |
 | `vercel-ai-sdk` | `vercel-ai-sdk-v*` | `@ratel-ai/vercel-ai-sdk` on npm | `src/adapters/ts-vercel-ai-sdk/package.json` |
+| `mastra-adapter` | `mastra-adapter-v*` | `@ratel-ai/mastra-adapter` on npm | `src/adapters/ts-mastra/package.json` |
 
 The units are registered once, in [`scripts/release-units.mjs`](scripts/release-units.mjs)
 — the single source of truth that the tag gate, the `releasable` helper, the changelog
@@ -47,12 +48,18 @@ to release them in one run. `telemetry-ts-otlp` (`@ratel-ai/telemetry-otlp` → 
 time. All four are pure-language, so the manual helper builds them locally (no prebuilt
 artifacts).
 
+The **framework adapters** (`vercel-ai-sdk` → `@ratel-ai/vercel-ai-sdk`, `mastra-adapter` →
+`@ratel-ai/mastra-adapter`; more to come) are npm-only, pure-language units that peer-depend on
+`@ratel-ai/sdk` via `workspace:^`. Like `telemetry-ts-otlp`, the manual helper builds and
+`pnpm pack`s them locally (the pack rewrites the `workspace:` peer to a concrete range); they
+need no prebuilt artifact.
+
 `@ratel-ai/mcp-server` ships from a sibling repo, [ratel-ai/ratel-mcp](https://github.com/ratel-ai/ratel-mcp), on its own cadence.
 
 ## How the release pipeline is wired
 
 - **`release.yml`** — fires on any `core-v*` / `sdk-ts-v*` / `sdk-py-v*` / `telemetry-core-v*` /
-  `telemetry-ts-v*` / `telemetry-py-v*` / `telemetry-ts-otlp-v*` tag push (and
+  `telemetry-ts-v*` / `telemetry-py-v*` / `telemetry-ts-otlp-v*` / `mastra-adapter-v*` tag push (and
   supports `workflow_dispatch` with `dry_run: true` for rehearsal). Its first job,
   `tag-version-check`, runs [`scripts/check-release-tag.mjs`](scripts/check-release-tag.mjs) to
   route the tag to its unit and verify **only that unit's** manifests + CHANGELOG carry the
@@ -127,15 +134,17 @@ rstagi with a one-member team. Run the E2E locally per `e2e/README.md`.
   `ratel-ai-core` crate, and the `ratel-ai` PyPI project — each pointing at this repo /
   `release.yml` / the `release` environment. **The 4 telemetry names
   (`@ratel-ai/telemetry` + `@ratel-ai/telemetry-otlp` on npm, `ratel-ai-telemetry` on PyPI +
-  crates.io) are not yet registered** — they are added at their first-time bootstrap, taking
-  the total 8 → 12. `@ratel-ai/vercel-ai-sdk` exists on npm but remains outside this count
-  until its workflow job and Trusted Publisher are configured.
+  crates.io) and the `@ratel-ai/mastra-adapter` name are not yet registered** — they are added
+  at their first-time bootstrap, taking the total 8 → 12 (telemetry) → 13 (mastra-adapter).
+  `@ratel-ai/vercel-ai-sdk` exists on npm but remains outside this count until its workflow
+  job and Trusted Publisher are configured.
 - A `release` GitHub Environment exists whose **deployment tag policy allows the unit
   prefixes** — `core-v*`, `sdk-ts-v*`, `sdk-py-v*`. Keep the environment *name* `release`
   unchanged (it's what binds the Trusted Publishers); only its tag policy lists the prefixes.
   A tag not matched by the policy hangs the publish job at the deploy gate. **Add
   `telemetry-core-v*`, `telemetry-ts-v*`, `telemetry-py-v*`, `telemetry-ts-otlp-v*` to the policy
-  before cutting the first telemetry release** (still pending).
+  before cutting the first telemetry release, and `mastra-adapter-v*` before the first CI-driven
+  adapter release** (still pending).
 
 ### Per-release flow (one unit at a time)
 
@@ -215,7 +224,7 @@ Publishers can't be configured for a package that doesn't exist yet. Do this per
    - `sdk-ts` → `build-binaries.yml` (produces the `release-tarballs` artifact).
    - `sdk-py` → `python-binaries.yml` (produces `wheels-*` + sdist).
    - `core` needs no prebuilt artifact — it publishes straight from the repo.
-   - `telemetry-core` / `telemetry-ts` / `telemetry-py` / `telemetry-ts-otlp` /
+   - `telemetry-core` / `telemetry-ts` / `telemetry-py` / `telemetry-ts-otlp` / `mastra-adapter` /
      `vercel-ai-sdk` need no prebuilt artifact — they are pure-language, so `publish-rc.sh`
      builds the crate, npm packages, wheel/sdist, or packed adapter locally.
 2. Log in locally: `npm login` (npm requires 2FA on the publishing account for a first-publish
@@ -224,18 +233,18 @@ Publishers can't be configured for a package that doesn't exist yet. Do this per
    units together need all three registries (`telemetry-ts` + `telemetry-ts-otlp` → npm,
    `telemetry-py` → PyPI, `telemetry-core` → crates.io); also `pip install build twine`.
 3. Run `scripts/publish-rc.sh --unit <unit> --from-run <run-id>` (omit `--from-run` for
-   `core`, the telemetry units, and `vercel-ai-sdk`). It reads the unit's version from its
+   `core`, the telemetry units, and the adapter units). It reads the unit's version from its
    manifest, finds the tarballs/wheels in the run's artifacts, and publishes — npm
    subpackages → loader for `sdk-ts`, `twine upload --skip-existing` for `sdk-py`, `cargo
    publish` for `core`, the locally-built npm / npm / wheel / crate for `telemetry-ts` /
-   `telemetry-ts-otlp` / `telemetry-py` / `telemetry-core`, and the pnpm-packed npm tarball
-   for `vercel-ai-sdk`.
+   `telemetry-ts-otlp` / `telemetry-py` / `telemetry-core`, and the pnpm-packed npm tarballs
+   for `mastra-adapter` + `vercel-ai-sdk`.
    It's idempotent (skips anything already on the registry), so a partial failure is safe to
    resume. First-publish from a laptop ships **without provenance** (that requires GH Actions
    OIDC); that's expected for the bootstrap.
 4. Configure Trusted Publishers on each registry name (npm web UI for the 6 SDK packages +
-   `@ratel-ai/telemetry` + `@ratel-ai/telemetry-otlp` + `@ratel-ai/vercel-ai-sdk`, crates.io
-   for `ratel-ai-core` + `ratel-ai-telemetry`, PyPI for `ratel-ai` +
-   `ratel-ai-telemetry`) pointing at `release.yml` in this repo, `release` environment.
+   `@ratel-ai/telemetry` + `@ratel-ai/telemetry-otlp` + `@ratel-ai/mastra-adapter` +
+   `@ratel-ai/vercel-ai-sdk`, crates.io for `ratel-ai-core` + `ratel-ai-telemetry`, PyPI for
+   `ratel-ai` + `ratel-ai-telemetry`) pointing at `release.yml` in this repo, `release` environment.
 5. Bump to the next version (e.g. `-rc.2`), tag `<unit>-v…`, push — `release.yml` should now
    publish via OIDC with no token errors, validating the trust relationship.

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,7 @@ Runnable demos of Ratel wired into real agent frameworks and protocol surfaces. 
 
 ```
 ai-sdk/           Ratel + Vercel AI SDK — top-K filtering + capability tools in ToolLoopAgent.generate
+mastra/           Ratel + Mastra — capability tools + per-turn recall processor via @ratel-ai/mastra-adapter
 mcp-chat/         Interactive REPL against an MCP-backed agent (Vercel AI SDK + OpenAI)
 pydantic-ai/      Ratel + Pydantic AI (Python) — top-K filtering + capability tools in the agent loop
 telemetry-ts/     Ratel telemetry — emit ratel.* spans via the OpenTelemetry JS SDK

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ Runnable demos of Ratel wired into real agent frameworks and protocol surfaces. 
 
 ```
 ai-sdk/           Ratel + Vercel AI SDK — top-K filtering + capability tools in ToolLoopAgent.generate
-mastra/           Ratel + Mastra — capability tools + per-turn recall processor via @ratel-ai/mastra-adapter
+mastra/           Ratel + Mastra — capability tools + per-turn recall processor via @ratel-ai/mastra
 mcp-chat/         Interactive REPL against an MCP-backed agent (Vercel AI SDK + OpenAI)
 pydantic-ai/      Ratel + Pydantic AI (Python) — top-K filtering + capability tools in the agent loop
 telemetry-ts/     Ratel telemetry — emit ratel.* spans via the OpenTelemetry JS SDK

--- a/examples/mastra/README.md
+++ b/examples/mastra/README.md
@@ -1,6 +1,6 @@
 # `examples/mastra` — Ratel + Mastra
 
-Demonstrates the Ratel SDK wired into [Mastra](https://mastra.ai) through [`@ratel-ai/mastra`](../../src/adapters/ts-mastra/README.md). App tools are registered as native Mastra `createTool`s on an adapted view (`ratel(config).adaptTo(mastra())`); the Agent is handed only the three capability tools (`view.expose()`), and `view.recallProcessor()` injects a ranked `search_capabilities` result for each user turn. See [Capability tools](https://docs.ratel.sh/docs/capability-tools) and [Framework integrations](https://docs.ratel.sh/docs/framework-integrations) for the protocol and reusable wiring pattern.
+Demonstrates the Ratel SDK wired into [Mastra](https://mastra.ai) through [`@ratel-ai/mastra`](../../src/adapters/ts-mastra/README.md). App tools are registered as native Mastra `createTool`s on an adapted view (`ratel(config).adaptTo(mastra())`); the Agent is handed only the three capability tools (`view.modelTools()`), and `view.recallProcessor()` injects a ranked `search_capabilities` result for each user turn. See [Capability tools](https://docs.ratel.sh/docs/capability-tools) and [Framework integrations](https://docs.ratel.sh/docs/framework-integrations) for the protocol and reusable wiring pattern.
 
 ## Setup
 
@@ -20,7 +20,7 @@ The model is a [Mastra model-router](https://mastra.ai/en/docs/getting-started/m
 
 ```
 src/tools.ts        the app's Mastra createTool tools (stubs)
-src/agent.ts        buildView (ratel().adaptTo(mastra()) + register) and runAgent (Agent + expose + recallProcessor)
+src/agent.ts        buildView (ratel().adaptTo(mastra()) + register) and runAgent (Agent + modelTools + recallProcessor)
 src/index.ts        entry — parse argv, run, print (diagnostic mode without a key)
 test/agent.test.ts  model-free test of the capability-tool + recall path (Mastra's mock model)
 ```

--- a/examples/mastra/README.md
+++ b/examples/mastra/README.md
@@ -1,0 +1,32 @@
+# `examples/mastra` — Ratel + Mastra
+
+Demonstrates the Ratel SDK wired into [Mastra](https://mastra.ai) through [`@ratel-ai/mastra-adapter`](../../src/adapters/ts-mastra/README.md). App tools are registered as native Mastra `createTool`s on an adapted view (`ratel(config).adaptTo(mastra())`); the Agent is handed only the three capability tools (`view.expose()`), and `view.recallProcessor()` injects a ranked `search_capabilities` result for each user turn. See [Capability tools](https://docs.ratel.sh/docs/capability-tools) and [Framework integrations](https://docs.ratel.sh/docs/framework-integrations) for the protocol and reusable wiring pattern.
+
+## Setup
+
+```bash
+export OPENAI_API_KEY=sk-...
+pnpm install
+pnpm -F @ratel-ai/example-mastra start
+# or with a custom prompt:
+pnpm -F @ratel-ai/example-mastra start "send an email to alice@example.com saying ship it"
+```
+
+Without a model API key the script runs in diagnostic mode — it prints Ratel's initial BM25 ranking for the prompt and exits before any model call.
+
+The model is a [Mastra model-router](https://mastra.ai/en/docs/getting-started/model-providers) id (default `openai/gpt-4o-mini`), so there is no provider SDK dependency — the router resolves the key from the environment. Override with `MASTRA_MODEL=anthropic/claude-haiku-4-5` (and set the matching key).
+
+## Layout
+
+```
+src/tools.ts        the app's Mastra createTool tools (stubs)
+src/agent.ts        buildView (ratel().adaptTo(mastra()) + register) and runAgent (Agent + expose + recallProcessor)
+src/index.ts        entry — parse argv, run, print (diagnostic mode without a key)
+test/agent.test.ts  model-free test of the capability-tool + recall path (Mastra's mock model)
+```
+
+The Agent never sees the six app tools directly — only `search_capabilities` / `invoke_tool` / `get_skill_content`. It discovers a tool by searching, then runs it through `invoke_tool`.
+
+## Why it's a separate workspace package
+
+Examples don't ship in `@ratel-ai/mastra-adapter` — keeping them out of the published artifact keeps the public API surface narrow. The example pulls `@mastra/core` only here.

--- a/examples/mastra/README.md
+++ b/examples/mastra/README.md
@@ -1,6 +1,6 @@
 # `examples/mastra` — Ratel + Mastra
 
-Demonstrates the Ratel SDK wired into [Mastra](https://mastra.ai) through [`@ratel-ai/mastra-adapter`](../../src/adapters/ts-mastra/README.md). App tools are registered as native Mastra `createTool`s on an adapted view (`ratel(config).adaptTo(mastra())`); the Agent is handed only the three capability tools (`view.expose()`), and `view.recallProcessor()` injects a ranked `search_capabilities` result for each user turn. See [Capability tools](https://docs.ratel.sh/docs/capability-tools) and [Framework integrations](https://docs.ratel.sh/docs/framework-integrations) for the protocol and reusable wiring pattern.
+Demonstrates the Ratel SDK wired into [Mastra](https://mastra.ai) through [`@ratel-ai/mastra`](../../src/adapters/ts-mastra/README.md). App tools are registered as native Mastra `createTool`s on an adapted view (`ratel(config).adaptTo(mastra())`); the Agent is handed only the three capability tools (`view.expose()`), and `view.recallProcessor()` injects a ranked `search_capabilities` result for each user turn. See [Capability tools](https://docs.ratel.sh/docs/capability-tools) and [Framework integrations](https://docs.ratel.sh/docs/framework-integrations) for the protocol and reusable wiring pattern.
 
 ## Setup
 
@@ -29,4 +29,4 @@ The Agent never sees the six app tools directly — only `search_capabilities` /
 
 ## Why it's a separate workspace package
 
-Examples don't ship in `@ratel-ai/mastra-adapter` — keeping them out of the published artifact keeps the public API surface narrow. The example pulls `@mastra/core` only here.
+Examples don't ship in `@ratel-ai/mastra` — keeping them out of the published artifact keeps the public API surface narrow. The example pulls `@mastra/core` only here.

--- a/examples/mastra/package.json
+++ b/examples/mastra/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@ratel-ai/example-mastra",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "pnpm -F @ratel-ai/sdk build && pnpm -F @ratel-ai/mastra-adapter build && tsx src/index.ts",
+    "typecheck": "tsc",
+    "test:integration": "pnpm -F @ratel-ai/sdk build && pnpm -F @ratel-ai/mastra-adapter build && tsx test/agent.test.ts"
+  },
+  "dependencies": {
+    "@mastra/core": "^1.51.0",
+    "@ratel-ai/mastra-adapter": "workspace:*",
+    "@ratel-ai/sdk": "workspace:*",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "tsx": "^4.20.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/examples/mastra/package.json
+++ b/examples/mastra/package.json
@@ -4,13 +4,13 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "pnpm -F @ratel-ai/sdk build && pnpm -F @ratel-ai/mastra-adapter build && tsx src/index.ts",
+    "start": "pnpm -F @ratel-ai/sdk build && pnpm -F @ratel-ai/mastra build && tsx src/index.ts",
     "typecheck": "tsc",
-    "test:integration": "pnpm -F @ratel-ai/sdk build && pnpm -F @ratel-ai/mastra-adapter build && tsx test/agent.test.ts"
+    "test:integration": "pnpm -F @ratel-ai/sdk build && pnpm -F @ratel-ai/mastra build && tsx test/agent.test.ts"
   },
   "dependencies": {
     "@mastra/core": "^1.51.0",
-    "@ratel-ai/mastra-adapter": "workspace:*",
+    "@ratel-ai/mastra": "workspace:*",
     "@ratel-ai/sdk": "workspace:*",
     "zod": "^4.0.0"
   },

--- a/examples/mastra/src/agent.ts
+++ b/examples/mastra/src/agent.ts
@@ -1,0 +1,42 @@
+import { Agent } from "@mastra/core/agent";
+import type { MastraModelConfig } from "@mastra/core/llm";
+import { mastra } from "@ratel-ai/mastra-adapter";
+import { ratel, type RatelConfig } from "@ratel-ai/sdk";
+import { tools } from "./tools.js";
+
+export type AgentResult = {
+  text: string;
+  /** The model-facing tools — Ratel's three capability tools, not the app's six. */
+  exposedTools: string[];
+};
+
+/** A Ratel core adapted to Mastra with the example's tools registered. */
+export function buildView(config?: RatelConfig) {
+  const view = ratel(config).adaptTo(mastra());
+  view.tools.register(tools);
+  return view;
+}
+
+/**
+ * Wire the adapted view into a Mastra Agent and run one turn. The Agent only ever
+ * sees the three capability tools (`view.expose()`); `recallProcessor()` injects a
+ * ranked `search_capabilities` result for the prompt before the model runs.
+ */
+export async function runAgent(args: {
+  prompt: string;
+  model: MastraModelConfig;
+  view: ReturnType<typeof buildView>;
+}): Promise<AgentResult> {
+  const agent = new Agent({
+    id: "ratel-mastra-example",
+    name: "ratel-mastra-example",
+    instructions:
+      "You are a coding assistant. Your tools are hidden behind `search_capabilities` — " +
+      "call it to find the right tool, then `invoke_tool` to run it. Answer once the task is done.",
+    model: args.model,
+    tools: args.view.expose(),
+    inputProcessors: [args.view.recallProcessor()],
+  });
+  const result = await agent.generate(args.prompt);
+  return { text: result.text, exposedTools: Object.keys(args.view.expose()) };
+}

--- a/examples/mastra/src/agent.ts
+++ b/examples/mastra/src/agent.ts
@@ -1,6 +1,6 @@
 import { Agent } from "@mastra/core/agent";
 import type { MastraModelConfig } from "@mastra/core/llm";
-import { mastra } from "@ratel-ai/mastra-adapter";
+import { mastra } from "@ratel-ai/mastra";
 import { ratel, type RatelConfig } from "@ratel-ai/sdk";
 import { tools } from "./tools.js";
 

--- a/examples/mastra/src/agent.ts
+++ b/examples/mastra/src/agent.ts
@@ -19,7 +19,7 @@ export function buildView(config?: RatelConfig) {
 
 /**
  * Wire the adapted view into a Mastra Agent and run one turn. The Agent only ever
- * sees the three capability tools (`view.expose()`); `recallProcessor()` injects a
+ * sees the three capability tools (`view.modelTools()`); `recallProcessor()` injects a
  * ranked `search_capabilities` result for the prompt before the model runs.
  */
 export async function runAgent(args: {
@@ -34,9 +34,9 @@ export async function runAgent(args: {
       "You are a coding assistant. Your tools are hidden behind `search_capabilities` — " +
       "call it to find the right tool, then `invoke_tool` to run it. Answer once the task is done.",
     model: args.model,
-    tools: args.view.expose(),
+    tools: args.view.modelTools(),
     inputProcessors: [args.view.recallProcessor()],
   });
   const result = await agent.generate(args.prompt);
-  return { text: result.text, exposedTools: Object.keys(args.view.expose()) };
+  return { text: result.text, exposedTools: Object.keys(args.view.modelTools()) };
 }

--- a/examples/mastra/src/index.ts
+++ b/examples/mastra/src/index.ts
@@ -1,0 +1,29 @@
+import { buildView, runAgent } from "./agent.js";
+import { tools } from "./tools.js";
+
+const prompt =
+  process.argv.slice(2).join(" ") || "read the file at /tmp/notes.md and summarize its TODOs";
+// A Mastra model-router id: no provider SDK dependency, resolves the key from env
+// (e.g. OPENAI_API_KEY for an `openai/*` id). Override with MASTRA_MODEL.
+const modelId = process.env.MASTRA_MODEL ?? "openai/gpt-4o-mini";
+
+const view = buildView({ method: "bm25" });
+
+console.log(`prompt: "${prompt}"`);
+console.log(`catalog: ${Object.keys(tools).length} app tools behind 3 capability tools`);
+
+if (!process.env.OPENAI_API_KEY && !process.env.ANTHROPIC_API_KEY) {
+  const hits = view.tools.catalog.search(prompt, 3, "direct");
+  console.log("\n(diagnostic mode — no model API key set, skipping the model call)");
+  console.log(`initial top-3 (Ratel BM25): ${hits.map((h) => h.toolId).join(", ") || "(none)"}`);
+  console.log("always-present: search_capabilities, invoke_tool, get_skill_content");
+  process.exit(0);
+}
+
+console.log(`model: ${modelId}\n`);
+
+const result = await runAgent({ prompt, model: modelId, view });
+
+console.log(`exposed tools: ${result.exposedTools.join(", ")}`);
+console.log("\nmodel output:");
+console.log(result.text || "(no final text — agent stopped after tool execution)");

--- a/examples/mastra/src/tools.ts
+++ b/examples/mastra/src/tools.ts
@@ -1,0 +1,54 @@
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+
+// A handful of stub Mastra tools (native `createTool` shape). They register into
+// Ratel's shared catalog through the adapter and stay hidden behind the three
+// capability tools until the model searches for them.
+export const tools = {
+  read_file: createTool({
+    id: "read_file",
+    description: "Read a file from local disk and return its textual contents.",
+    inputSchema: z.object({ path: z.string().describe("absolute path to the file") }),
+    execute: async ({ path }) => ({ contents: `(stub) contents of ${path}` }),
+  }),
+  write_file: createTool({
+    id: "write_file",
+    description: "Write textual contents to a file on local disk.",
+    inputSchema: z.object({
+      path: z.string().describe("absolute path to the file"),
+      contents: z.string().describe("bytes to write"),
+    }),
+    execute: async ({ path }) => ({ ok: true, path }),
+  }),
+  search_files: createTool({
+    id: "search_files",
+    description: "Grep across files in a directory using a regular expression.",
+    inputSchema: z.object({
+      root: z.string().describe("directory to scan recursively"),
+      pattern: z.string().describe("regular expression to match"),
+    }),
+    execute: async ({ root, pattern }) => ({ matches: [{ path: `${root}/example.ts`, line: 42, match: pattern }] }),
+  }),
+  run_command: createTool({
+    id: "run_command",
+    description: "Execute a shell command and capture stdout, stderr, and exit code.",
+    inputSchema: z.object({ command: z.string().describe("command line to run") }),
+    execute: async ({ command }) => ({ stdout: `(stub) ran ${command}`, stderr: "", exitCode: 0 }),
+  }),
+  send_email: createTool({
+    id: "send_email",
+    description: "Send an email to a recipient via SMTP.",
+    inputSchema: z.object({
+      to: z.string().describe("recipient email address"),
+      subject: z.string(),
+      body: z.string(),
+    }),
+    execute: async ({ to }) => ({ messageId: "msg-stub", to }),
+  }),
+  query_database: createTool({
+    id: "query_database",
+    description: "Run a SQL query against the application database.",
+    inputSchema: z.object({ sql: z.string().describe("SQL statement to execute") }),
+    execute: async ({ sql }) => ({ rows: [], sql }),
+  }),
+};

--- a/examples/mastra/test/agent.test.ts
+++ b/examples/mastra/test/agent.test.ts
@@ -1,0 +1,50 @@
+// Framework-integration test for the Mastra wiring (the analogue of
+// examples/ai-sdk/test/agent.test.ts). Drives the real Mastra `Agent` loop with
+// Mastra's built-in mock model — no API key, no network — so it exercises the
+// parts that break on SDK/Mastra drift but the SDK-level e2e can't see:
+//   - the adapter's expose() feeding the Agent exactly the three capability tools
+//   - recallProcessor() injecting the synthetic search_capabilities pair into the
+//     prompt the model actually receives
+//
+// Run: `tsx test/agent.test.ts` (the `example` CI job builds @ratel-ai/sdk and the
+// adapter first). Mastra ships the mock as JS with no type declarations; this file
+// is not part of the package's `tsc` include, so the plain import is fine.
+import assert from "node:assert/strict";
+
+import { createMockModel } from "@mastra/core/test-utils/llm-mock";
+import { SEARCH_CAPABILITIES_ID } from "@ratel-ai/sdk";
+
+import { buildView, runAgent } from "../src/agent.js";
+
+async function main() {
+  const view = buildView({ method: "bm25" });
+  const prompts = [];
+  const model = createMockModel({
+    mockText: "done: read the file",
+    spyGenerate: (props) => prompts.push(JSON.stringify(props.prompt)),
+  });
+
+  const result = await runAgent({ prompt: "read a file from local disk", model, view });
+
+  // The model sees exactly Ratel's three capability tools, not the six app tools.
+  assert.deepEqual(
+    result.exposedTools.slice().sort(),
+    ["get_skill_content", "invoke_tool", "search_capabilities"],
+    `unexpected exposed tools: ${result.exposedTools.join(", ")}`,
+  );
+  // The loop ran to a final answer.
+  assert.ok(result.text.includes("done"), `unexpected final text: ${result.text}`);
+  // The mock was driven exactly once and the recall pair rode into its prompt.
+  assert.equal(prompts.length, 1, "model was not called exactly once");
+  assert.ok(prompts[0].includes(SEARCH_CAPABILITIES_ID), "recall pair not in the model prompt");
+  assert.ok(prompts[0].includes("read a file"), "recall query not in the model prompt");
+
+  console.log(
+    `PASS (mastra example): text=${JSON.stringify(result.text)}, exposed=[${result.exposedTools.join(", ")}]`,
+  );
+}
+
+main().catch((err) => {
+  console.error("FAIL (mastra example):", err);
+  process.exit(1);
+});

--- a/examples/mastra/test/agent.test.ts
+++ b/examples/mastra/test/agent.test.ts
@@ -2,7 +2,7 @@
 // examples/ai-sdk/test/agent.test.ts). Drives the real Mastra `Agent` loop with
 // Mastra's built-in mock model — no API key, no network — so it exercises the
 // parts that break on SDK/Mastra drift but the SDK-level e2e can't see:
-//   - the adapter's expose() feeding the Agent exactly the three capability tools
+//   - the adapter's modelTools() feeding the Agent exactly the three capability tools
 //   - recallProcessor() injecting the synthetic search_capabilities pair into the
 //     prompt the model actually receives
 //

--- a/examples/mastra/tsconfig.json
+++ b/examples/mastra/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ importers:
       '@mastra/core':
         specifier: ^1.51.0
         version: 1.51.0(ai@7.0.33(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
-      '@ratel-ai/mastra-adapter':
+      '@ratel-ai/mastra':
         specifier: workspace:*
         version: link:../../src/adapters/ts-mastra
       '@ratel-ai/sdk':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,31 @@ importers:
         specifier: ^5.6.0
         version: 5.9.3
 
+  examples/mastra:
+    dependencies:
+      '@mastra/core':
+        specifier: ^1.51.0
+        version: 1.51.0(ai@7.0.33(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
+      '@ratel-ai/mastra-adapter':
+        specifier: workspace:*
+        version: link:../../src/adapters/ts-mastra
+      '@ratel-ai/sdk':
+        specifier: workspace:*
+        version: link:../../src/sdk/ts
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.12.2
+      tsx:
+        specifier: ^4.20.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+
   examples/mcp-chat:
     dependencies:
       '@ai-sdk/openai':
@@ -95,6 +120,27 @@ importers:
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
+
+  src/adapters/ts-mastra:
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.4.13
+        version: 2.4.13
+      '@mastra/core':
+        specifier: 1.51.0
+        version: 1.51.0(ai@7.0.33(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
+      '@ratel-ai/sdk':
+        specifier: workspace:^
+        version: link:../../sdk/ts
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
   src/adapters/ts-vercel-ai-sdk:
     devDependencies:
@@ -217,6 +263,21 @@ importers:
 
 packages:
 
+  '@a2a-js/sdk@0.3.14':
+    resolution: {integrity: sha512-F6Ew1AtPzCLhTn8h9yiqTe7DiDf6XVrSnq9V1YqSl9eWqPm6anMveTiKdCSb/76cW0YiJc24rNaUrVezFFHbqQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.10.2
+      '@grpc/grpc-js': ^1.11.0
+      express: ^4.21.2 || ^5.1.0
+    peerDependenciesMeta:
+      '@bufbuild/protobuf':
+        optional: true
+      '@grpc/grpc-js':
+        optional: true
+      express:
+        optional: true
+
   '@ai-sdk/gateway@3.0.107':
     resolution: {integrity: sha512-JwODLcuTe8rWXJwQcNPE5fiadjCOKHxNGtL5pHqEhFQSuWs6x47oVRkLs/Zw6eUhTsuXiZbyJ3QJHVIyLKX5hg==}
     engines: {node: '>=18'}
@@ -235,8 +296,26 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@2.2.8':
+    resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
+
+  '@ai-sdk/provider-utils@3.0.28':
+    resolution: {integrity: sha512-bXlX1WX7E50a2N+AJW+1a/x63m52aPhm+6xYe5THxWrx9vW9NR7E2Ay+1G1ndlCdMdYKo2Fnsd7kBhuyQPaphw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@4.0.25':
     resolution: {integrity: sha512-yjGPZPiJm79ZOYk0anXn2LkVqUFgStZqEOdyoynhkaAg+yOCuv6PJwf+1gUW0eSIUnYEboT2TPbPX/bxZpx4gw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.38':
+    resolution: {integrity: sha512-/HHGmtKllqjg1OLc023v9w9kK3laW7Z6TzfZukYQWCsGBbzB9p60zTvvpXFVcs44NZBVXL3viOa1HRKUbeee8g==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -247,13 +326,37 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@5.0.7':
+    resolution: {integrity: sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@1.1.3':
+    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@2.0.3':
+    resolution: {integrity: sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==}
+    engines: {node: '>=18'}
+
   '@ai-sdk/provider@3.0.10':
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.14':
+    resolution: {integrity: sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@4.0.3':
     resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
     engines: {node: '>=22'}
+
+  '@ai-sdk/ui-utils@1.2.11':
+    resolution: {integrity: sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
 
   '@biomejs/biome@2.4.13':
     resolution: {integrity: sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==}
@@ -620,8 +723,32 @@ packages:
       '@types/node':
         optional: true
 
+  '@isaacs/ttlcache@2.1.5':
+    resolution: {integrity: sha512-VwGZqqjAWPICTmxUZnbpEfO60LhPWzquik+bmyXGY7pYRn6diEvCI5i6Ca+J6o2y4vS73HrpuMTo2dOvUevH8w==}
+    engines: {node: '>=12'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@lukeed/csprng@1.1.0':
+    resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
+    engines: {node: '>=8'}
+
+  '@lukeed/uuid@2.0.1':
+    resolution: {integrity: sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==}
+    engines: {node: '>=8'}
+
+  '@mastra/core@1.51.0':
+    resolution: {integrity: sha512-MmY2/cA97y8KSJ9w/GlMRKTBNsglO1XHI5zv8oVcYQhGr6AFZ/jnAbKzjIEEBrofRca7TXYYvg6YeZCCY4fBvg==}
+    engines: {node: '>=22.13.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
+  '@mastra/schema-compat@1.3.4':
+    resolution: {integrity: sha512-2ObUsd21KIVelQy+eKPxJvnMxtmKnWacsIkZovhEYjVcQX9OYTDQ+u4E4RboIJZvurJnFx++/ujQLFznUaEYMg==}
+    engines: {node: '>=22.13.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -1123,6 +1250,12 @@ packages:
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
+  '@posthog/core@1.43.1':
+    resolution: {integrity: sha512-hGM8f5sp3we6Em/RQHXbmyYm554hUx9+9jhf92ZQgDS4/xW72KHyZiO9wcFye+qAx2cJAOhOCDIznmO1FV8IbA==}
+
+  '@posthog/types@1.397.0':
+    resolution: {integrity: sha512-Pa7FtsBo3V0XrhY4y8Xquwp8U07syuZ2IGQdlsRyxhz0yejQLceFjI58UssCXE5zDCDj3km5l7H3ufD6rHChCg==}
+
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1221,6 +1354,9 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
   '@shikijs/engine-oniguruma@3.23.0':
     resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
 
@@ -1236,6 +1372,18 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
+
+  '@sindresorhus/slugify@2.2.1':
+    resolution: {integrity: sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==}
+    engines: {node: '>=12'}
+
+  '@sindresorhus/transliterate@1.6.0':
+    resolution: {integrity: sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==}
+    engines: {node: '>=12'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1244,6 +1392,9 @@ packages:
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -1256,6 +1407,12 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
@@ -1299,6 +1456,9 @@ packages:
   '@workflow/serde@4.1.0':
     resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
 
+  '@workflow/serde@4.1.0-beta.2':
+    resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -1326,12 +1486,18 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -1360,12 +1526,30 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  chat@4.34.0:
+    resolution: {integrity: sha512-g3c9ANavtCX7BwHcB5c3lWKIUm+8Oo7qlbgQ7/ni1rmVLLeCQa7FiMfeIyEyTAd/4HlRQu5jcS4EPdb0VyhUDQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      ai: ^6.0.182 || ^7.0.0
+      zod: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      ai:
+        optional: true
+      zod:
+        optional: true
 
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
@@ -1402,6 +1586,10 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  croner@10.0.1:
+    resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
+    engines: {node: '>=18.0'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1415,13 +1603,27 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1472,6 +1674,15 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -1487,6 +1698,10 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1500,6 +1715,13 @@ packages:
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
+
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
@@ -1519,6 +1741,9 @@ packages:
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1527,6 +1752,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -1556,12 +1785,20 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
+
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -1579,9 +1816,17 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
+
+  ignore@7.0.6:
+    resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
+    engines: {node: '>= 4'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -1594,8 +1839,28 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
+  is-network-error@1.3.2:
+    resolution: {integrity: sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==}
+    engines: {node: '>=16'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1603,8 +1868,19 @@ packages:
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
+  jpeg-js@0.4.4:
+    resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
+
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+    hasBin: true
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  json-schema-to-zod@2.8.1:
+    resolution: {integrity: sha512-fRr1mHgZ7hboLKBUdR428gd9dIHUFGivUqOeiDcSmyXkNZCtB1uGaZLvsjZ4GaN5pwBIs+TGIOf6s+Rp5/R/zA==}
     hasBin: true
 
   json-schema-traverse@1.0.0:
@@ -1618,6 +1894,10 @@ packages:
 
   json-with-bigint@3.5.8:
     resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1696,6 +1976,13 @@ packages:
   linkify-it@5.0.2:
     resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
 
@@ -1706,9 +1993,45 @@ packages:
     resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
     hasBin: true
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
@@ -1720,6 +2043,90 @@ packages:
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
@@ -1749,6 +2156,10 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -1767,6 +2178,18 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  p-map@7.0.5:
+    resolution: {integrity: sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==}
+    engines: {node: '>=18'}
+
+  p-retry@7.1.1:
+    resolution: {integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==}
+    engines: {node: '>=20'}
+
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -1774,6 +2197,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
@@ -1796,6 +2223,19 @@ packages:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-node@5.45.2:
+    resolution: {integrity: sha512-QhHw/xL0ntMG/DzqA/qdiKu8JY8ChK5Obm8m1nMJor5sjJ7+pfVJSx1yAynC7iUAJfJ9V+OhBNhDCyi5IFWC0Q==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
+
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -1816,12 +2256,28 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  remend@1.3.0:
+    resolution: {integrity: sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw==}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
   rolldown@1.0.0-rc.17:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
@@ -1834,6 +2290,13 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
+  secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -1886,6 +2349,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -1895,6 +2361,14 @@ packages:
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
+
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1914,6 +2388,12 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tokenx@1.3.0:
+    resolution: {integrity: sha512-NLdXTEZkKiO0gZuLtMoZKjCXTREXeZZt8nnnNeyoXtNZAfG/GKGSbQtLU5STspc0rMSwcA+UJfWZkbNU01iKmQ==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1948,6 +2428,25 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
@@ -1955,9 +2454,19 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
@@ -2056,20 +2565,57 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xxhash-wasm@1.1.0:
+    resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
+
+  zod-from-json-schema@0.0.5:
+    resolution: {integrity: sha512-zYEoo86M1qpA1Pq6329oSyHLS785z/mTwfr9V1Xf/ZLhuuBGaMlDGu/pDVGVUe4H4oa1EFgWZT53DP0U3oT9CQ==}
+
+  zod-from-json-schema@0.5.6:
+    resolution: {integrity: sha512-U33AJ7ZWS6y9XNSzMWcdy8hRAvZmWhTtpYJu0SXPT5AArbc9nq2ur7Magzmn5RF9KBV4b3FP0nCpmqqlfXlR9w==}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
       zod: ^3.25.28 || ^4
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
 snapshots:
+
+  '@a2a-js/sdk@0.3.14(express@5.2.1)':
+    dependencies:
+      uuid: 11.1.1
+    optionalDependencies:
+      express: 5.2.1
 
   '@ai-sdk/gateway@3.0.107(zod@4.4.3)':
     dependencies:
@@ -2091,9 +2637,30 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.25(zod@4.4.3)
       zod: 4.4.3
 
+  '@ai-sdk/provider-utils@2.2.8(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      nanoid: 3.3.11
+      secure-json-parse: 2.7.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@3.0.28(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.4.3
+
   '@ai-sdk/provider-utils@4.0.25(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@4.0.38(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.8
       zod: 4.4.3
@@ -2106,13 +2673,40 @@ snapshots:
       eventsource-parser: 3.0.8
       zod: 4.4.3
 
+  '@ai-sdk/provider-utils@5.0.7(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.4.3
+
+  '@ai-sdk/provider@1.1.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@2.0.3':
+    dependencies:
+      json-schema: 0.4.0
+
   '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.14':
     dependencies:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@4.0.3':
     dependencies:
       json-schema: 0.4.0
+
+  '@ai-sdk/ui-utils@1.2.11(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
 
   '@biomejs/biome@2.4.13':
     optionalDependencies:
@@ -2374,7 +2968,69 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.12.2
 
+  '@isaacs/ttlcache@2.1.5': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@lukeed/csprng@1.1.0': {}
+
+  '@lukeed/uuid@2.0.1':
+    dependencies:
+      '@lukeed/csprng': 1.1.0
+
+  '@mastra/core@1.51.0(ai@7.0.33(zod@4.4.3))(express@5.2.1)(zod@4.4.3)':
+    dependencies:
+      '@a2a-js/sdk': 0.3.14(express@5.2.1)
+      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.28(zod@4.4.3)'
+      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.38(zod@4.4.3)'
+      '@ai-sdk/provider-utils-v7': '@ai-sdk/provider-utils@5.0.7(zod@4.4.3)'
+      '@ai-sdk/provider-v5': '@ai-sdk/provider@2.0.3'
+      '@ai-sdk/provider-v6': '@ai-sdk/provider@3.0.14'
+      '@ai-sdk/provider-v7': '@ai-sdk/provider@4.0.3'
+      '@ai-sdk/ui-utils-v5': '@ai-sdk/ui-utils@1.2.11(zod@4.4.3)'
+      '@isaacs/ttlcache': 2.1.5
+      '@lukeed/uuid': 2.0.1
+      '@mastra/schema-compat': 1.3.4(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@sindresorhus/slugify': 2.2.1
+      '@standard-schema/spec': 1.1.0
+      ajv: 8.20.0
+      chat: 4.34.0(ai@7.0.33(zod@4.4.3))(zod@4.4.3)
+      croner: 10.0.1
+      dotenv: 17.4.2
+      execa: 9.6.1
+      fastq: 1.20.1
+      gray-matter: 4.0.3
+      ignore: 7.0.6
+      jpeg-js: 0.4.4
+      json-schema: 0.4.0
+      lru-cache: 11.5.2
+      p-map: 7.0.5
+      p-retry: 7.1.1
+      picomatch: 4.0.4
+      posthog-node: 5.45.2
+      tokenx: 1.3.0
+      ws: 8.21.1
+      xxhash-wasm: 1.1.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@bufbuild/protobuf'
+      - '@cfworker/json-schema'
+      - '@grpc/grpc-js'
+      - ai
+      - bufferutil
+      - express
+      - rxjs
+      - supports-color
+      - utf-8-validate
+
+  '@mastra/schema-compat@1.3.4(zod@4.4.3)':
+    dependencies:
+      json-schema-to-zod: 2.8.1
+      zod: 4.4.3
+      zod-from-json-schema: 0.5.6
+      zod-from-json-schema-v3: zod-from-json-schema@0.0.5
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
@@ -2815,6 +3471,12 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
+  '@posthog/core@1.43.1':
+    dependencies:
+      '@posthog/types': 1.397.0
+
+  '@posthog/types@1.397.0': {}
+
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
 
@@ -2866,6 +3528,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
+  '@sec-ant/readable-stream@0.4.1': {}
+
   '@shikijs/engine-oniguruma@3.23.0':
     dependencies:
       '@shikijs/types': 3.23.0
@@ -2886,6 +3550,17 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@sindresorhus/slugify@2.2.1':
+    dependencies:
+      '@sindresorhus/transliterate': 1.6.0
+      escape-string-regexp: 5.0.0
+
+  '@sindresorhus/transliterate@1.6.0':
+    dependencies:
+      escape-string-regexp: 5.0.0
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.1':
@@ -2898,6 +3573,10 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
@@ -2907,6 +3586,12 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@24.12.2':
     dependencies:
@@ -2959,6 +3644,8 @@ snapshots:
 
   '@workflow/serde@4.1.0': {}
 
+  '@workflow/serde@4.1.0-beta.2': {}
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -2990,9 +3677,15 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
 
   assertion-error@2.0.1: {}
+
+  bail@2.0.2: {}
 
   balanced-match@4.0.4: {}
 
@@ -3028,9 +3721,28 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
 
+  character-entities@2.0.2: {}
+
   chardet@2.1.1: {}
+
+  chat@4.34.0(ai@7.0.33(zod@4.4.3))(zod@4.4.3):
+    dependencies:
+      '@workflow/serde': 4.1.0-beta.2
+      mdast-util-to-string: 4.0.0
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      remend: 1.3.0
+      unified: 11.0.5
+    optionalDependencies:
+      ai: 7.0.33(zod@4.4.3)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   cli-width@4.1.0: {}
 
@@ -3055,6 +3767,8 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
+  croner@10.0.1: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -3065,9 +3779,21 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
+  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3126,6 +3852,10 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  escape-string-regexp@5.0.0: {}
+
+  esprima@4.0.1: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -3137,6 +3867,21 @@ snapshots:
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.0.8
+
+  execa@9.6.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.1.2
 
   expect-type@1.3.0: {}
 
@@ -3178,6 +3923,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
+  extend@3.0.2: {}
+
   fast-content-type-parse@3.0.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -3194,9 +3945,17 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
 
   finalhandler@2.1.1:
     dependencies:
@@ -3236,11 +3995,23 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
+
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
   gopd@1.2.0: {}
+
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.15.0
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
 
   has-symbols@1.1.0: {}
 
@@ -3258,9 +4029,13 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  human-signals@8.0.1: {}
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
+
+  ignore@7.0.6: {}
 
   inherits@2.0.4: {}
 
@@ -3268,15 +4043,34 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  is-extendable@0.1.1: {}
+
+  is-network-error@1.3.2: {}
+
+  is-plain-obj@4.1.0: {}
+
   is-promise@4.0.0: {}
+
+  is-stream@4.0.1: {}
+
+  is-unicode-supported@2.1.0: {}
 
   isexe@2.0.0: {}
 
   jose@6.2.3: {}
 
+  jpeg-js@0.4.4: {}
+
+  js-yaml@3.15.0:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  json-schema-to-zod@2.8.1: {}
 
   json-schema-traverse@1.0.0: {}
 
@@ -3285,6 +4079,8 @@ snapshots:
   json-schema@0.4.0: {}
 
   json-with-bigint@3.5.8: {}
+
+  kind-of@6.0.3: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -3339,6 +4135,10 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
+  longest-streak@3.1.0: {}
+
+  lru-cache@11.5.2: {}
+
   lunr@2.3.9: {}
 
   magic-string@0.30.21:
@@ -3354,13 +4154,308 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
+  markdown-table@3.0.4: {}
+
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
 
   mdurl@2.0.0: {}
 
   media-typer@1.1.0: {}
 
   merge-descriptors@2.0.0: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   mime-db@1.54.0: {}
 
@@ -3380,6 +4475,11 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -3394,9 +4494,19 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  p-map@7.0.5: {}
+
+  p-retry@7.1.1:
+    dependencies:
+      is-network-error: 1.3.2
+
+  parse-ms@4.0.0: {}
+
   parseurl@1.3.3: {}
 
   path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
 
   path-to-regexp@8.4.2: {}
 
@@ -3413,6 +4523,14 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  posthog-node@5.45.2:
+    dependencies:
+      '@posthog/core': 1.43.1
+
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
 
   proxy-addr@2.0.7:
     dependencies:
@@ -3434,9 +4552,39 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
+  remend@1.3.0: {}
+
   require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  reusify@1.1.0: {}
 
   rolldown@1.0.0-rc.17:
     dependencies:
@@ -3470,6 +4618,13 @@ snapshots:
       - supports-color
 
   safer-buffer@2.1.2: {}
+
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
+  secure-json-parse@2.7.0: {}
 
   semver@7.7.4: {}
 
@@ -3540,11 +4695,17 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  sprintf-js@1.0.3: {}
+
   stackback@0.0.2: {}
 
   statuses@2.0.2: {}
 
   std-env@4.1.0: {}
+
+  strip-bom-string@1.0.0: {}
+
+  strip-final-newline@4.0.0: {}
 
   tinybench@2.9.0: {}
 
@@ -3558,6 +4719,10 @@ snapshots:
   tinyrainbow@3.1.0: {}
 
   toidentifier@1.0.1: {}
+
+  tokenx@1.3.0: {}
+
+  trough@2.2.0: {}
 
   tslib@2.8.1:
     optional: true
@@ -3592,11 +4757,54 @@ snapshots:
 
   undici-types@7.16.0: {}
 
+  unicorn-magic@0.3.0: {}
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   universal-user-agent@7.0.3: {}
 
   unpipe@1.0.0: {}
 
+  uuid@11.1.1: {}
+
   vary@1.1.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
@@ -3651,10 +4859,28 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  ws@8.21.1: {}
+
+  xxhash-wasm@1.1.0: {}
+
   yaml@2.9.0: {}
+
+  yoctocolors@2.1.2: {}
+
+  zod-from-json-schema@0.0.5:
+    dependencies:
+      zod: 3.25.76
+
+  zod-from-json-schema@0.5.6:
+    dependencies:
+      zod: 4.4.3
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
 
+  zod@3.25.76: {}
+
   zod@4.4.3: {}
+
+  zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - 'src/sdk/ts'
   - 'src/adapters/ts-vercel-ai-sdk'
+  - 'src/adapters/ts-mastra'
   - 'src/telemetry/ts'
   - 'src/telemetry/ts-otlp'
   - 'examples/*'

--- a/scripts/check-release-tag.test.mjs
+++ b/scripts/check-release-tag.test.mjs
@@ -48,6 +48,9 @@ function makeRepo(version = "0.2.0", pyVersion = version) {
   // vercel-ai-sdk: the Vercel AI SDK framework adapter — an independent npm unit.
   write("src/adapters/ts-vercel-ai-sdk/package.json", json("@ratel-ai/vercel-ai-sdk"));
   write("src/adapters/ts-vercel-ai-sdk/CHANGELOG.md", changelog(version));
+  // mastra: the Mastra framework adapter — an independent npm unit.
+  write("src/adapters/ts-mastra/package.json", json("@ratel-ai/mastra"));
+  write("src/adapters/ts-mastra/CHANGELOG.md", changelog(version));
 
   return { root, write, cleanup: () => rmSync(root, { recursive: true, force: true }) };
 }
@@ -62,6 +65,7 @@ test("parseTag splits prefix and version for every unit", () => {
   assert.deepEqual(parseTag("telemetry-py-v0.2.0-rc.2"), { unit: "telemetry-py", version: "0.2.0-rc.2" });
   assert.deepEqual(parseTag("telemetry-ts-otlp-v0.1.0-rc.3"), { unit: "telemetry-ts-otlp", version: "0.1.0-rc.3" });
   assert.deepEqual(parseTag("vercel-ai-sdk-v0.1.0-rc.1"), { unit: "vercel-ai-sdk", version: "0.1.0-rc.1" });
+  assert.deepEqual(parseTag("mastra-v0.1.0-rc.1"), { unit: "mastra", version: "0.1.0-rc.1" });
 });
 
 test("parseTag rejects the old lockstep tag and unknown prefixes", () => {
@@ -78,6 +82,19 @@ test("vercel-ai-sdk rc tag passes when the adapter package + its changelog match
     const r = checkReleaseTag("vercel-ai-sdk-v0.1.0-rc.1", { root: repo.root });
     assert.equal(r.ok, true, r.errors.join("; "));
     assert.equal(r.unit, "vercel-ai-sdk");
+    assert.equal(r.version, "0.1.0-rc.1");
+    assert.equal(r.distTag, "rc");
+  } finally {
+    repo.cleanup();
+  }
+});
+
+test("mastra rc tag passes when the adapter package + its changelog match", () => {
+  const repo = makeRepo("0.1.0-rc.1");
+  try {
+    const r = checkReleaseTag("mastra-v0.1.0-rc.1", { root: repo.root });
+    assert.equal(r.ok, true, r.errors.join("; "));
+    assert.equal(r.unit, "mastra");
     assert.equal(r.version, "0.1.0-rc.1");
     assert.equal(r.distTag, "rc");
   } finally {

--- a/scripts/publish-rc.sh
+++ b/scripts/publish-rc.sh
@@ -15,7 +15,7 @@
 #   telemetry-py   -> ratel-ai-telemetry on PyPI           (twine upload, built locally)
 #   telemetry-ts-otlp -> @ratel-ai/telemetry-otlp on npm      (npm publish, pnpm-packed locally)
 #   vercel-ai-sdk  -> @ratel-ai/vercel-ai-sdk on npm       (npm publish, pnpm-packed locally)
-#   mastra-adapter -> @ratel-ai/mastra-adapter on npm      (npm publish, pnpm-packed locally)
+#   mastra -> @ratel-ai/mastra on npm      (npm publish, pnpm-packed locally)
 # Each unit's version is read from its own manifest via scripts/release-units.mjs
 # (the single source of truth) — units are NOT assumed to share a version.
 #
@@ -33,7 +33,7 @@
 # Options:
 #   --unit <id>        core | sdk-ts | sdk-py | telemetry-core | telemetry-ts |
 #                      telemetry-py | telemetry-ts-otlp | vercel-ai-sdk |
-#                      mastra-adapter.
+#                      mastra.
 #                      Repeatable. Default: all.
 #   --from-run <id>    Download all artifacts from the given GH Actions run
 #                      (requires `gh auth login`); tarballs/wheels are found within.
@@ -358,18 +358,18 @@ publish_telemetry_core() {
   echo "==> telemetry-core publish complete"; echo
 }
 
-# ---------- mastra-adapter: @ratel-ai/mastra-adapter on npm, packed locally ----------
+# ---------- mastra: @ratel-ai/mastra on npm, packed locally ----------
 # Pure-language framework adapter with a `workspace:^` peer on @ratel-ai/sdk.
 # `pnpm pack` rewrites that specifier to the concrete co-installed version in the
 # tarball, so a plain `npm publish <tarball>` (bootstrap: no OIDC, no provenance)
 # ships a valid manifest — same shape as telemetry-ts-otlp.
-publish_mastra_adapter() {
-  local version; version="$(resolve_version mastra-adapter)"
-  echo "===== mastra-adapter @ $version (npm) ====="
-  echo "----- @ratel-ai/mastra-adapter@$version (npm) -----"
+publish_mastra() {
+  local version; version="$(resolve_version mastra)"
+  echo "===== mastra @ $version (npm) ====="
+  echo "----- @ratel-ai/mastra@$version (npm) -----"
   local status
   status="$(curl -sS -o /dev/null -w '%{http_code}' \
-    "https://registry.npmjs.org/@ratel-ai%2Fmastra-adapter/${version}" || echo 000)"
+    "https://registry.npmjs.org/@ratel-ai%2Fmastra/${version}" || echo 000)"
   if [[ "$status" == "200" ]]; then
     echo "    already published, skipping npm"; echo; return 0
   fi
@@ -377,7 +377,7 @@ publish_mastra_adapter() {
     echo "error: not logged in to npm. run 'npm login' first." >&2; exit 1
   fi
   # Build the adapter and its @ratel-ai/sdk workspace dependency (topo order).
-  ( cd "$REPO_ROOT" && pnpm --filter "@ratel-ai/mastra-adapter..." run build )
+  ( cd "$REPO_ROOT" && pnpm --filter "@ratel-ai/mastra..." run build )
   local tgz
   tgz="$( cd "$REPO_ROOT/src/adapters/ts-mastra" && pnpm pack --pack-destination "$(mktemp -d)" | tail -1 )"
   if [[ $DRY_RUN -eq 1 ]]; then
@@ -385,7 +385,7 @@ publish_mastra_adapter() {
   else
     publish_one_npm "$tgz" || exit 1
   fi
-  echo "==> mastra-adapter publish complete"; echo
+  echo "==> mastra publish complete"; echo
 }
 
 # Publish in a stable order regardless of --unit argument order.
@@ -397,7 +397,7 @@ selected telemetry-ts   && publish_telemetry_ts
 selected telemetry-ts-otlp && publish_telemetry_ts_otlp
 selected telemetry-py   && publish_telemetry_py
 selected vercel-ai-sdk  && publish_vercel_ai_sdk
-selected mastra-adapter && publish_mastra_adapter
+selected mastra && publish_mastra
 
 echo "==> done"
 echo

--- a/scripts/publish-rc.sh
+++ b/scripts/publish-rc.sh
@@ -15,6 +15,7 @@
 #   telemetry-py   -> ratel-ai-telemetry on PyPI           (twine upload, built locally)
 #   telemetry-ts-otlp -> @ratel-ai/telemetry-otlp on npm      (npm publish, pnpm-packed locally)
 #   vercel-ai-sdk  -> @ratel-ai/vercel-ai-sdk on npm       (npm publish, pnpm-packed locally)
+#   mastra-adapter -> @ratel-ai/mastra-adapter on npm      (npm publish, pnpm-packed locally)
 # Each unit's version is read from its own manifest via scripts/release-units.mjs
 # (the single source of truth) — units are NOT assumed to share a version.
 #
@@ -31,7 +32,8 @@
 #
 # Options:
 #   --unit <id>        core | sdk-ts | sdk-py | telemetry-core | telemetry-ts |
-#                      telemetry-py | telemetry-ts-otlp | vercel-ai-sdk.
+#                      telemetry-py | telemetry-ts-otlp | vercel-ai-sdk |
+#                      mastra-adapter.
 #                      Repeatable. Default: all.
 #   --from-run <id>    Download all artifacts from the given GH Actions run
 #                      (requires `gh auth login`); tarballs/wheels are found within.
@@ -356,6 +358,36 @@ publish_telemetry_core() {
   echo "==> telemetry-core publish complete"; echo
 }
 
+# ---------- mastra-adapter: @ratel-ai/mastra-adapter on npm, packed locally ----------
+# Pure-language framework adapter with a `workspace:^` peer on @ratel-ai/sdk.
+# `pnpm pack` rewrites that specifier to the concrete co-installed version in the
+# tarball, so a plain `npm publish <tarball>` (bootstrap: no OIDC, no provenance)
+# ships a valid manifest — same shape as telemetry-ts-otlp.
+publish_mastra_adapter() {
+  local version; version="$(resolve_version mastra-adapter)"
+  echo "===== mastra-adapter @ $version (npm) ====="
+  echo "----- @ratel-ai/mastra-adapter@$version (npm) -----"
+  local status
+  status="$(curl -sS -o /dev/null -w '%{http_code}' \
+    "https://registry.npmjs.org/@ratel-ai%2Fmastra-adapter/${version}" || echo 000)"
+  if [[ "$status" == "200" ]]; then
+    echo "    already published, skipping npm"; echo; return 0
+  fi
+  if [[ $DRY_RUN -eq 0 ]] && ! npm whoami >/dev/null 2>&1; then
+    echo "error: not logged in to npm. run 'npm login' first." >&2; exit 1
+  fi
+  # Build the adapter and its @ratel-ai/sdk workspace dependency (topo order).
+  ( cd "$REPO_ROOT" && pnpm --filter "@ratel-ai/mastra-adapter..." run build )
+  local tgz
+  tgz="$( cd "$REPO_ROOT/src/adapters/ts-mastra" && pnpm pack --pack-destination "$(mktemp -d)" | tail -1 )"
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "    [dry-run] npm publish $tgz --access public --tag $TAG --provenance=false"
+  else
+    publish_one_npm "$tgz" || exit 1
+  fi
+  echo "==> mastra-adapter publish complete"; echo
+}
+
 # Publish in a stable order regardless of --unit argument order.
 selected core           && publish_core
 selected sdk-ts         && publish_sdk_ts
@@ -365,6 +397,7 @@ selected telemetry-ts   && publish_telemetry_ts
 selected telemetry-ts-otlp && publish_telemetry_ts_otlp
 selected telemetry-py   && publish_telemetry_py
 selected vercel-ai-sdk  && publish_vercel_ai_sdk
+selected mastra-adapter && publish_mastra_adapter
 
 echo "==> done"
 echo

--- a/scripts/release-units.mjs
+++ b/scripts/release-units.mjs
@@ -137,15 +137,15 @@ export const UNITS = {
       includePaths: ["src/adapters/ts-vercel-ai-sdk/**"],
     },
   },
-  "mastra-adapter": {
-    tagPrefix: "mastra-adapter-v",
-    label: "@ratel-ai/mastra-adapter → npm",
+  "mastra": {
+    tagPrefix: "mastra-v",
+    label: "@ratel-ai/mastra → npm",
     versionManifest: { path: "src/adapters/ts-mastra/package.json", kind: "json" },
     manifests: [{ path: "src/adapters/ts-mastra/package.json", kind: "json" }],
     changelogs: ["src/adapters/ts-mastra/CHANGELOG.md"],
     srcPaths: ["src/adapters/ts-mastra"],
     changelog: {
-      name: "@ratel-ai/mastra-adapter",
+      name: "@ratel-ai/mastra",
       includePaths: ["src/adapters/ts-mastra/**"],
     },
   },

--- a/scripts/release-units.mjs
+++ b/scripts/release-units.mjs
@@ -122,9 +122,9 @@ export const UNITS = {
       includePaths: ["src/telemetry/ts-otlp/**"],
     },
   },
-  // The Vercel AI SDK framework adapter — an independent npm-only unit. Pure TS
-  // with a workspace:^ dep on @ratel-ai/sdk, so publish-rc.sh `pnpm pack`s it
-  // (rewriting that dep to a real range) and `npm publish`es the tarball.
+  // Framework adapters: npm-only, pure-language packages that peer-depend on
+  // @ratel-ai/sdk via `workspace:^` (rewritten to a concrete range at pack time,
+  // like telemetry-ts-otlp). Each ships independently on its own tag prefix.
   "vercel-ai-sdk": {
     tagPrefix: "vercel-ai-sdk-v",
     label: "@ratel-ai/vercel-ai-sdk → npm",
@@ -135,6 +135,18 @@ export const UNITS = {
     changelog: {
       name: "@ratel-ai/vercel-ai-sdk",
       includePaths: ["src/adapters/ts-vercel-ai-sdk/**"],
+    },
+  },
+  "mastra-adapter": {
+    tagPrefix: "mastra-adapter-v",
+    label: "@ratel-ai/mastra-adapter → npm",
+    versionManifest: { path: "src/adapters/ts-mastra/package.json", kind: "json" },
+    manifests: [{ path: "src/adapters/ts-mastra/package.json", kind: "json" }],
+    changelogs: ["src/adapters/ts-mastra/CHANGELOG.md"],
+    srcPaths: ["src/adapters/ts-mastra"],
+    changelog: {
+      name: "@ratel-ai/mastra-adapter",
+      includePaths: ["src/adapters/ts-mastra/**"],
     },
   },
 };

--- a/src/adapters/README.md
+++ b/src/adapters/README.md
@@ -7,7 +7,7 @@ Directories are language-prefixed (`ts-*`, `py-*`) since a framework gets one ad
 ## Layout
 
 - `ts-vercel-ai-sdk/` — [`@ratel-ai/vercel-ai-sdk`](ts-vercel-ai-sdk/README.md): the [Vercel AI SDK](https://sdk.vercel.ai) (`ai@^5 || ^6 || ^7`) adapter.
-- `ts-mastra/` — [`@ratel-ai/mastra-adapter`](ts-mastra/README.md): the [Mastra](https://mastra.ai) (`@mastra/core`) adapter.
+- `ts-mastra/` — [`@ratel-ai/mastra`](ts-mastra/README.md): the [Mastra](https://mastra.ai) (`@mastra/core`) adapter.
 
 ## Build & test
 

--- a/src/adapters/README.md
+++ b/src/adapters/README.md
@@ -7,6 +7,7 @@ Directories are language-prefixed (`ts-*`, `py-*`) since a framework gets one ad
 ## Layout
 
 - `ts-vercel-ai-sdk/` — [`@ratel-ai/vercel-ai-sdk`](ts-vercel-ai-sdk/README.md): the [Vercel AI SDK](https://sdk.vercel.ai) (`ai@^5 || ^6 || ^7`) adapter.
+- `ts-mastra/` — [`@ratel-ai/mastra-adapter`](ts-mastra/README.md): the [Mastra](https://mastra.ai) (`@mastra/core`) adapter.
 
 ## Build & test
 

--- a/src/adapters/ts-mastra/CHANGELOG.md
+++ b/src/adapters/ts-mastra/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to `@ratel-ai/mastra-adapter` are documented here.
+All notable changes to `@ratel-ai/mastra` are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this package adheres to [Semantic Versioning](https://semver.org/).
 
@@ -8,4 +8,4 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ### Added
 
-- Initial release: `@ratel-ai/mastra-adapter`, the [Mastra](https://mastra.ai) (`@mastra/core`) adapter for Ratel. `ratel(config).adaptTo(mastra())` speaks Mastra's native `Tool` (from `createTool`) and `MastraDBMessage` shapes through the framework-adapter SPI (ADR-0013): the `ingest` / `expose` / `recallMessages` codecs plus a per-turn recall idiom — `recallProcessor()`, a Mastra `Processor` you drop into an Agent's `inputProcessors`. `ingest` reads Mastra's normalized input schema (so zod 3, zod 4, and raw JSON Schema tools all work); `expose` wraps the three capability tools as genuine `createTool` results; `recallMessages` encodes the synthetic `search_capabilities` call+result as one assistant message (`content.format: 2`, a single resolved `tool-invocation` part). Peers `@mastra/core@^1.51.0`, `zod@^3.25.0 || ^4.0.0`, and `@ratel-ai/sdk` with zero runtime dependencies; passes the `@ratel-ai/sdk/testkit` conformance battery (21 cases).
+- Initial release: `@ratel-ai/mastra`, the [Mastra](https://mastra.ai) (`@mastra/core`) adapter for Ratel. (Supersedes the pre-release `@ratel-ai/mastra-adapter@0.1.0-rc.1`, published under the old name before the rename.) `ratel(config).adaptTo(mastra())` speaks Mastra's native `Tool` (from `createTool`) and `MastraDBMessage` shapes through the framework-adapter SPI (ADR-0013): the `ingest` / `expose` / `recallMessages` codecs plus a per-turn recall idiom — `recallProcessor()`, a Mastra `Processor` you drop into an Agent's `inputProcessors`. `ingest` reads Mastra's normalized input schema (so zod 3, zod 4, and raw JSON Schema tools all work); `expose` wraps the three capability tools as genuine `createTool` results; `recallMessages` encodes the synthetic `search_capabilities` call+result as one assistant message (`content.format: 2`, a single resolved `tool-invocation` part). Peers `@mastra/core@^1.51.0`, `zod@^3.25.0 || ^4.0.0`, and `@ratel-ai/sdk` with zero runtime dependencies; passes the `@ratel-ai/sdk/testkit` conformance battery (21 cases).

--- a/src/adapters/ts-mastra/CHANGELOG.md
+++ b/src/adapters/ts-mastra/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `@ratel-ai/mastra` are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this package adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.1.0-rc.2] - 2026-07-21
+
+### Changed
+
+- Follow the SDK's model-facing `expose()` → `modelTools()` rename at the call sites (the adapter's `expose` SPI codec is unchanged). Rebased onto the current adapter SPI and built against `@ratel-ai/sdk@0.5.1-rc.0`.
+
 ## [0.1.0-rc.1] - 2026-07-18
 
 ### Added

--- a/src/adapters/ts-mastra/CHANGELOG.md
+++ b/src/adapters/ts-mastra/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to `@ratel-ai/mastra-adapter` are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this package adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- Initial release: `@ratel-ai/mastra-adapter`, the [Mastra](https://mastra.ai) (`@mastra/core`) adapter for Ratel. `ratel(config).adaptTo(mastra())` speaks Mastra's native `Tool` (from `createTool`) and `MastraDBMessage` shapes through the framework-adapter SPI (ADR-0013): the `ingest` / `expose` / `recallMessages` codecs plus a per-turn recall idiom — `recallProcessor()`, a Mastra `Processor` you drop into an Agent's `inputProcessors`. `ingest` reads Mastra's normalized input schema (so zod 3, zod 4, and raw JSON Schema tools all work); `expose` wraps the three capability tools as genuine `createTool` results; `recallMessages` encodes the synthetic `search_capabilities` call+result as one assistant message (`content.format: 2`, a single resolved `tool-invocation` part). Peers `@mastra/core@^1.51.0`, `zod@^3.25.0 || ^4.0.0`, and `@ratel-ai/sdk` with zero runtime dependencies; passes the `@ratel-ai/sdk/testkit` conformance battery (21 cases).

--- a/src/adapters/ts-mastra/CHANGELOG.md
+++ b/src/adapters/ts-mastra/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `@ratel-ai/mastra` are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this package adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Lower the supported `@mastra/core` floor from 1.51.0 to 1.11.0. The adapter now owns the no-op observer and validation-error guard locally instead of importing helpers added in later Mastra releases; CI runs its build, full suite, and type tests against 1.11.0, 1.31.0, and 1.51.0. Align the declared Node.js floor with Mastra at 22.13.0.
+
 ## [0.1.0-rc.2] - 2026-07-21
 
 ### Changed

--- a/src/adapters/ts-mastra/CHANGELOG.md
+++ b/src/adapters/ts-mastra/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.1.0-rc.3] - 2026-07-21
+
 ### Changed
 
 - Lower the supported `@mastra/core` floor from 1.51.0 to 1.11.0. The adapter now owns the no-op observer and validation-error guard locally instead of importing helpers added in later Mastra releases; CI runs its build, full suite, and type tests against 1.11.0, 1.31.0, and 1.51.0. Align the declared Node.js floor with Mastra at 22.13.0.

--- a/src/adapters/ts-mastra/CHANGELOG.md
+++ b/src/adapters/ts-mastra/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `@ratel-ai/mastra-adapter` are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this package adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.1.0-rc.1] - 2026-07-18
 
 ### Added
 

--- a/src/adapters/ts-mastra/CHANGELOG.md
+++ b/src/adapters/ts-mastra/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.1.0-rc.4] - 2026-07-21
+
 ### Fixed
 
 - Preserve Mastra's complete live `ToolExecutionContext` through `invoke_tool`, including `requestContext`, workspace, agent thread/resource metadata, `mastra`, and `abortSignal`. Required `requestContextSchema` values now validate against the caller's real context, and concurrent invocations remain isolated. Direct `ToolCatalog.invoke` calls still use the documented context-free fallback. This requires the paired `@ratel-ai/sdk` release containing opaque invocation-context forwarding.

--- a/src/adapters/ts-mastra/CHANGELOG.md
+++ b/src/adapters/ts-mastra/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve Mastra's complete live `ToolExecutionContext` through `invoke_tool`, including `requestContext`, workspace, agent thread/resource metadata, `mastra`, and `abortSignal`. Required `requestContextSchema` values now validate against the caller's real context, and concurrent invocations remain isolated. Direct `ToolCatalog.invoke` calls still use the documented context-free fallback. This requires the paired `@ratel-ai/sdk` release containing opaque invocation-context forwarding.
+
 ## [0.1.0-rc.3] - 2026-07-21
 
 ### Changed

--- a/src/adapters/ts-mastra/LICENSE.md
+++ b/src/adapters/ts-mastra/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Agentified
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/adapters/ts-mastra/README.md
+++ b/src/adapters/ts-mastra/README.md
@@ -1,0 +1,81 @@
+# `@ratel-ai/mastra-adapter`
+
+The [Mastra](https://mastra.ai) (`@mastra/core`) adapter for [Ratel](https://github.com/ratel-ai/ratel). `ratel(config).adaptTo(mastra())` layers a framework-shaped view over the framework-neutral core (ADR-0013), so a Mastra agent registers its own `createTool()`s, hands the model Ratel's capability funnel, and gets per-turn recall — all in Mastra's native `Tool` and `MastraDBMessage` shapes, with no glue in app code.
+
+Ratel keeps the model's tool list small and stable: instead of advertising every tool, it exposes three capability tools (`search_capabilities` / `invoke_tool` / `get_skill_content`) and injects a ranked, per-turn `search_capabilities` result for the current user message. The core owns all state and every guard (reserved ids, top-K clamp, first-registration-wins, recall-id counter); the adapter is just three codecs plus one recall idiom.
+
+## Usage
+
+```ts
+import { Agent } from "@mastra/core/agent";
+import { createTool } from "@mastra/core/tools";
+import { mastra } from "@ratel-ai/mastra-adapter";
+import { ratel } from "@ratel-ai/sdk";
+import { z } from "zod";
+
+const r = ratel({ method: "hybrid", recallTopK: 5 }).adaptTo(mastra());
+
+// Register the app's Mastra tools into the shared catalog (any time, also after
+// expose()). Tools without an `execute` (client/provider-executed) pass through eagerly.
+r.tools.register({
+  weather: createTool({
+    id: "weather",
+    description: "Get the weather in a location",
+    inputSchema: z.object({ location: z.string() }),
+    execute: async ({ location }) => ({ location, tempF: 72 }),
+  }),
+});
+
+const agent = new Agent({
+  name: "assistant",
+  instructions: "Help the user with their tasks.",
+  model: "openai/gpt-4o-mini",
+  // The three capability tools in Mastra shape. Take the set ONCE per agent and
+  // reuse it: it never changes across turns, so the prompt cache survives.
+  tools: r.expose(),
+  // Rank the catalog for each user turn and inject the synthetic search_capabilities
+  // call+result before the model runs (recall mode).
+  inputProcessors: [r.recallProcessor()],
+});
+
+const result = await agent.generate("what's the weather in Paris?");
+console.log(result.text);
+```
+
+Standalone (framework-free) use of the same core is also fine — `r` is `ratel(config)` before `.adaptTo`, exposing native `ExecutableTool`s. See [`@ratel-ai/sdk`](../../sdk/ts/README.md).
+
+## The `recallProcessor()` idiom
+
+`r.recallProcessor()` returns a fresh Mastra [`Processor`](https://mastra.ai/en/docs/agents/input-processors) each call (so several agents each get their own). It implements `processInput`, which Mastra runs **once at the start of every generation** — i.e. once per user turn. On each turn it:
+
+1. reads the last message's text iff that message is the user's turn (multi-part text joins with newlines);
+2. ranks the catalog with the core's `recall(query)`;
+3. if there are hits, appends the synthetic `search_capabilities` call+result to the messages the model sees.
+
+It is a no-op — spending no recall-id — when the last message is not a user turn, the user text is empty, or nothing matched. Because `processInput` runs once per generation (not per step), the pair is injected once and is **not** re-injected during the agent's tool-call loop.
+
+## Limitations
+
+- **Single-message recall encoding.** A `MastraDBMessage` has no `tool` role: a completed call+result is one assistant message with `content.format: 2` and a single resolved `tool-invocation` part. The recall pair is therefore encoded as **one** assistant message (Mastra renders it to the model as an assistant tool-call followed by a tool result).
+- **Fabricated execution context for catalog-invoked tools.** When the model runs one of your tools through `invoke_tool`, the catalog calls its `execute(args, context)` with a *minimal fabricated* context (`{ observe }` no-op; `mastra` / `agent` / `workflow` / `abortSignal` absent, `requestContext` a fresh empty one). A tool that reads those sees the fakes; tools that read only their input args are unaffected. Mastra re-validates the args against the tool's schema on this call; invalid args (or a required `requestContextSchema` the fabricated context can't satisfy) surface as a thrown error, which the capability funnel reports as a failed call.
+- **Any Mastra tool schema works.** `ingest` reads Mastra's *already-normalized* input schema, so tools built with zod 3, zod 4, or a raw JSON Schema all catalog correctly — the adapter never re-converts schemas itself. (`zod` is a peer only because the exposed capability tools carry hand-written zod schemas.)
+- **Persist the conversation across turns.** Recall fires only when the last message is the user's turn. Standard Mastra memory hygiene applies; if you rebuild the message history per call, keep the user turn last so recall can find it.
+
+## Package shape
+
+- Package name: `@ratel-ai/mastra-adapter`
+- Pure TypeScript, **zero runtime dependencies** — the adapter is glue. `@mastra/core@^1.51.0`, `zod@^3.25.0 || ^4.0.0` (matching Mastra's own zod peer), and `@ratel-ai/sdk` are peers the host already installs.
+- MIT ([ADR-0009](../../../docs/adr/0009-licensing.md)); member of the pnpm workspace; `publishConfig` provenance on.
+
+## Build & test
+
+From the repo root (the SDK is built first by `pnpm -r build`, which the tests import):
+
+```bash
+pnpm --filter @ratel-ai/mastra-adapter build
+pnpm --filter @ratel-ai/mastra-adapter typecheck
+pnpm --filter @ratel-ai/mastra-adapter lint
+pnpm --filter @ratel-ai/mastra-adapter test
+```
+
+The suite covers the three codecs, the recall processor (including id economy on the no-op paths), a mock-model integration test that drives the real Mastra `Agent` loop, a compile-only type-test locking the `@mastra/core` surface, and the `@ratel-ai/sdk/testkit` conformance battery (21 cases, 0 skipped).

--- a/src/adapters/ts-mastra/README.md
+++ b/src/adapters/ts-mastra/README.md
@@ -64,8 +64,15 @@ It is a no-op — spending no recall-id — when the last message is not a user 
 ## Package shape
 
 - Package name: `@ratel-ai/mastra`
-- Pure TypeScript, **zero runtime dependencies** — the adapter is glue. `@mastra/core@^1.51.0`, `zod@^3.25.0 || ^4.0.0` (matching Mastra's own zod peer), and `@ratel-ai/sdk` are peers the host already installs.
+- Pure TypeScript, **zero runtime dependencies** — the adapter is glue. `@mastra/core@>=1.11.0 <2`, `zod@^3.25.0 || ^4.0.0` (matching Mastra's own zod peer), and `@ratel-ai/sdk` are peers the host already installs.
+- Requires Node.js 22.13 or newer, matching Mastra's own requirement.
 - MIT ([ADR-0009](../../../docs/adr/0009-licensing.md)); member of the pnpm workspace; `publishConfig` provenance on.
+
+## Mastra compatibility
+
+The supported range is `@mastra/core@>=1.11.0 <2`. Version 1.11 is the floor because it is the first 1.x release where `createTool()` normalizes zod and raw JSON schemas to the Standard Schema surface that `ingest` reads.
+
+There is no runtime version detection. The adapter stays on the common public tool, message, and processor shapes and owns two tiny compatibility details locally: the no-op observer context and the structural validation-error check. This avoids imports that Mastra only exported later (`isValidationError` in 1.18 and `noopObserve` in 1.37) while preserving their behavior. CI runs the adapter build, suite, and type tests against exact 1.11.0, 1.31.0, and 1.51.0; the worked Mastra example also drives a real 1.51 Agent loop.
 
 ## Build & test
 
@@ -78,4 +85,4 @@ pnpm --filter @ratel-ai/mastra lint
 pnpm --filter @ratel-ai/mastra test
 ```
 
-The suite covers the three codecs, the recall processor (including id economy on the no-op paths), a mock-model integration test that drives the real Mastra `Agent` loop, a compile-only type-test locking the `@mastra/core` surface, and the `@ratel-ai/sdk/testkit` conformance battery (21 cases, 0 skipped).
+The suite covers the three codecs, the recall processor (including id economy on the no-op paths), a mock-model integration test that drives the real Mastra `Agent` loop, a compile-only type-test locking the supported `@mastra/core` surface, and the `@ratel-ai/sdk/testkit` conformance battery (22 cases, 0 skipped). CI repeats it against the minimum Mastra release.

--- a/src/adapters/ts-mastra/README.md
+++ b/src/adapters/ts-mastra/README.md
@@ -1,4 +1,4 @@
-# `@ratel-ai/mastra-adapter`
+# `@ratel-ai/mastra`
 
 The [Mastra](https://mastra.ai) (`@mastra/core`) adapter for [Ratel](https://github.com/ratel-ai/ratel). `ratel(config).adaptTo(mastra())` layers a framework-shaped view over the framework-neutral core (ADR-0013), so a Mastra agent registers its own `createTool()`s, hands the model Ratel's capability funnel, and gets per-turn recall — all in Mastra's native `Tool` and `MastraDBMessage` shapes, with no glue in app code.
 
@@ -9,7 +9,7 @@ Ratel keeps the model's tool list small and stable: instead of advertising every
 ```ts
 import { Agent } from "@mastra/core/agent";
 import { createTool } from "@mastra/core/tools";
-import { mastra } from "@ratel-ai/mastra-adapter";
+import { mastra } from "@ratel-ai/mastra";
 import { ratel } from "@ratel-ai/sdk";
 import { z } from "zod";
 
@@ -63,7 +63,7 @@ It is a no-op — spending no recall-id — when the last message is not a user 
 
 ## Package shape
 
-- Package name: `@ratel-ai/mastra-adapter`
+- Package name: `@ratel-ai/mastra`
 - Pure TypeScript, **zero runtime dependencies** — the adapter is glue. `@mastra/core@^1.51.0`, `zod@^3.25.0 || ^4.0.0` (matching Mastra's own zod peer), and `@ratel-ai/sdk` are peers the host already installs.
 - MIT ([ADR-0009](../../../docs/adr/0009-licensing.md)); member of the pnpm workspace; `publishConfig` provenance on.
 
@@ -72,10 +72,10 @@ It is a no-op — spending no recall-id — when the last message is not a user 
 From the repo root (the SDK is built first by `pnpm -r build`, which the tests import):
 
 ```bash
-pnpm --filter @ratel-ai/mastra-adapter build
-pnpm --filter @ratel-ai/mastra-adapter typecheck
-pnpm --filter @ratel-ai/mastra-adapter lint
-pnpm --filter @ratel-ai/mastra-adapter test
+pnpm --filter @ratel-ai/mastra build
+pnpm --filter @ratel-ai/mastra typecheck
+pnpm --filter @ratel-ai/mastra lint
+pnpm --filter @ratel-ai/mastra test
 ```
 
 The suite covers the three codecs, the recall processor (including id economy on the no-op paths), a mock-model integration test that drives the real Mastra `Agent` loop, a compile-only type-test locking the `@mastra/core` surface, and the `@ratel-ai/sdk/testkit` conformance battery (21 cases, 0 skipped).

--- a/src/adapters/ts-mastra/README.md
+++ b/src/adapters/ts-mastra/README.md
@@ -16,7 +16,7 @@ import { z } from "zod";
 const r = ratel({ method: "hybrid", recallTopK: 5 }).adaptTo(mastra());
 
 // Register the app's Mastra tools into the shared catalog (any time, also after
-// expose()). Tools without an `execute` (client/provider-executed) pass through eagerly.
+// modelTools()). Tools without an `execute` (client/provider-executed) pass through eagerly.
 r.tools.register({
   weather: createTool({
     id: "weather",
@@ -32,7 +32,7 @@ const agent = new Agent({
   model: "openai/gpt-4o-mini",
   // The three capability tools in Mastra shape. Take the set ONCE per agent and
   // reuse it: it never changes across turns, so the prompt cache survives.
-  tools: r.expose(),
+  tools: r.modelTools(),
   // Rank the catalog for each user turn and inject the synthetic search_capabilities
   // call+result before the model runs (recall mode).
   inputProcessors: [r.recallProcessor()],

--- a/src/adapters/ts-mastra/README.md
+++ b/src/adapters/ts-mastra/README.md
@@ -57,7 +57,7 @@ It is a no-op — spending no recall-id — when the last message is not a user 
 ## Limitations
 
 - **Single-message recall encoding.** A `MastraDBMessage` has no `tool` role: a completed call+result is one assistant message with `content.format: 2` and a single resolved `tool-invocation` part. The recall pair is therefore encoded as **one** assistant message (Mastra renders it to the model as an assistant tool-call followed by a tool result).
-- **Fabricated execution context for catalog-invoked tools.** When the model runs one of your tools through `invoke_tool`, the catalog calls its `execute(args, context)` with a *minimal fabricated* context (`{ observe }` no-op; `mastra` / `agent` / `workflow` / `abortSignal` absent, `requestContext` a fresh empty one). A tool that reads those sees the fakes; tools that read only their input args are unaffected. Mastra re-validates the args against the tool's schema on this call; invalid args (or a required `requestContextSchema` the fabricated context can't satisfy) surface as a thrown error, which the capability funnel reports as a failed call.
+- **Direct catalog invocation has no Mastra context.** The normal model path through `invoke_tool` forwards Mastra's complete live `ToolExecutionContext` unchanged, including `requestContext`, workspace, agent thread/resource metadata, `mastra`, and `abortSignal`; `requestContextSchema` therefore validates against the caller's real values. The driver-level escape hatch `r.tools.catalog.invoke(id, args)` bypasses a Mastra invocation, so it retains a minimal fallback context (`{ observe }` no-op, a fresh empty `requestContext`, other live fields absent). Pass tools through `modelTools()` when they depend on request-scoped context.
 - **Any Mastra tool schema works.** `ingest` reads Mastra's *already-normalized* input schema, so tools built with zod 3, zod 4, or a raw JSON Schema all catalog correctly — the adapter never re-converts schemas itself. (`zod` is a peer only because the exposed capability tools carry hand-written zod schemas.)
 - **Persist the conversation across turns.** Recall fires only when the last message is the user's turn. Standard Mastra memory hygiene applies; if you rebuild the message history per call, keep the user turn last so recall can find it.
 
@@ -65,6 +65,7 @@ It is a no-op — spending no recall-id — when the last message is not a user 
 
 - Package name: `@ratel-ai/mastra`
 - Pure TypeScript, **zero runtime dependencies** — the adapter is glue. `@mastra/core@>=1.11.0 <2`, `zod@^3.25.0 || ^4.0.0` (matching Mastra's own zod peer), and `@ratel-ai/sdk` are peers the host already installs.
+- Live context forwarding spans this adapter and `@ratel-ai/sdk`; upgrade their RCs together. An older SDK silently drops the adapter's opaque context before catalog execution.
 - Requires Node.js 22.13 or newer, matching Mastra's own requirement.
 - MIT ([ADR-0009](../../../docs/adr/0009-licensing.md)); member of the pnpm workspace; `publishConfig` provenance on.
 
@@ -72,7 +73,7 @@ It is a no-op — spending no recall-id — when the last message is not a user 
 
 The supported range is `@mastra/core@>=1.11.0 <2`. Version 1.11 is the floor because it is the first 1.x release where `createTool()` normalizes zod and raw JSON schemas to the Standard Schema surface that `ingest` reads.
 
-There is no runtime version detection. The adapter stays on the common public tool, message, and processor shapes and owns two tiny compatibility details locally: the no-op observer context and the structural validation-error check. This avoids imports that Mastra only exported later (`isValidationError` in 1.18 and `noopObserve` in 1.37) while preserving their behavior. CI runs the adapter build, suite, and type tests against exact 1.11.0, 1.31.0, and 1.51.0; the worked Mastra example also drives a real 1.51 Agent loop.
+There is no runtime version detection. The adapter stays on the common public tool, message, processor, and `ToolExecutionContext` shapes and owns two tiny compatibility details locally: the direct-call no-op observer fallback and the structural validation-error check. This avoids imports that Mastra only exported later (`isValidationError` in 1.18 and `noopObserve` in 1.37) while preserving their behavior. CI runs the adapter build, suite, and type tests against exact 1.11.0, 1.31.0, and 1.51.0; the worked Mastra example also drives a real 1.51 Agent loop.
 
 ## Build & test
 

--- a/src/adapters/ts-mastra/package.json
+++ b/src/adapters/ts-mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/mastra",
-  "version": "0.1.0-rc.2",
+  "version": "0.1.0-rc.3",
   "description": "Mastra adapter for Ratel — adapts the context-engineering core to @mastra/core tool and message shapes, with a per-turn recall input processor.",
   "private": false,
   "type": "module",

--- a/src/adapters/ts-mastra/package.json
+++ b/src/adapters/ts-mastra/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@ratel-ai/mastra-adapter",
+  "version": "0.1.0",
+  "description": "Mastra adapter for Ratel — adapts the context-engineering core to @mastra/core tool and message shapes, with a per-turn recall input processor.",
+  "private": false,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "license": "MIT",
+  "author": "Agentified",
+  "homepage": "https://github.com/ratel-ai/ratel",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ratel-ai/ratel.git",
+    "directory": "src/adapters/ts-mastra"
+  },
+  "bugs": {
+    "url": "https://github.com/ratel-ai/ratel/issues"
+  },
+  "keywords": [
+    "ratel",
+    "mastra",
+    "framework-adapter",
+    "tool-calling",
+    "context-engineering",
+    "ai-agents"
+  ],
+  "engines": {
+    "node": ">=20.6.0"
+  },
+  "files": [
+    "dist",
+    "LICENSE.md",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.type-tests.json",
+    "lint": "biome check src",
+    "test": "vitest run"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "peerDependencies": {
+    "@mastra/core": "^1.51.0",
+    "@ratel-ai/sdk": "workspace:^",
+    "zod": "^3.25.0 || ^4.0.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.13",
+    "@mastra/core": "1.51.0",
+    "@ratel-ai/sdk": "workspace:^",
+    "typescript": "^5.6.0",
+    "vitest": "^4.1.5",
+    "zod": "^4.4.3"
+  }
+}

--- a/src/adapters/ts-mastra/package.json
+++ b/src/adapters/ts-mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/mastra-adapter",
-  "version": "0.1.0",
+  "version": "0.1.0-rc.1",
   "description": "Mastra adapter for Ratel — adapts the context-engineering core to @mastra/core tool and message shapes, with a per-turn recall input processor.",
   "private": false,
   "type": "module",

--- a/src/adapters/ts-mastra/package.json
+++ b/src/adapters/ts-mastra/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ratel-ai/mastra-adapter",
+  "name": "@ratel-ai/mastra",
   "version": "0.1.0-rc.1",
   "description": "Mastra adapter for Ratel — adapts the context-engineering core to @mastra/core tool and message shapes, with a per-turn recall input processor.",
   "private": false,

--- a/src/adapters/ts-mastra/package.json
+++ b/src/adapters/ts-mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/mastra",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "description": "Mastra adapter for Ratel — adapts the context-engineering core to @mastra/core tool and message shapes, with a per-turn recall input processor.",
   "private": false,
   "type": "module",

--- a/src/adapters/ts-mastra/package.json
+++ b/src/adapters/ts-mastra/package.json
@@ -26,7 +26,7 @@
     "ai-agents"
   ],
   "engines": {
-    "node": ">=20.6.0"
+    "node": ">=22.13.0"
   },
   "files": [
     "dist",
@@ -45,7 +45,7 @@
     "provenance": true
   },
   "peerDependencies": {
-    "@mastra/core": "^1.51.0",
+    "@mastra/core": ">=1.11.0 <2",
     "@ratel-ai/sdk": "workspace:^",
     "zod": "^3.25.0 || ^4.0.0"
   },

--- a/src/adapters/ts-mastra/package.json
+++ b/src/adapters/ts-mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/mastra",
-  "version": "0.1.0-rc.3",
+  "version": "0.1.0-rc.4",
   "description": "Mastra adapter for Ratel — adapts the context-engineering core to @mastra/core tool and message shapes, with a per-turn recall input processor.",
   "private": false,
   "type": "module",

--- a/src/adapters/ts-mastra/src/conformance.test.ts
+++ b/src/adapters/ts-mastra/src/conformance.test.ts
@@ -40,8 +40,8 @@ function mastraConformanceOptions(): AdapterConformanceOptions<MastraTool, Mastr
       createTool({ id: "conformance_passthrough", description: spec.description }),
     callExposedTool: (tool, args) => {
       const execute = tool.execute as (input: unknown, context: unknown) => unknown;
-      // Exposed tools ignore the context; fabricate the minimal one so the call
-      // is shaped like a real Mastra invocation.
+      // Supply the minimal live context shape; the exposed capability preserves
+      // it for any catalog tool reached through invoke_tool.
       return execute(args, TEST_CONTEXT);
     },
     validateRecallPair,

--- a/src/adapters/ts-mastra/src/conformance.test.ts
+++ b/src/adapters/ts-mastra/src/conformance.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import type { MastraDBMessage } from "@mastra/core/agent";
-import { createTool, noopObserve, Tool } from "@mastra/core/tools";
+import { createTool, Tool } from "@mastra/core/tools";
 import { SEARCH_CAPABILITIES_ID } from "@ratel-ai/sdk";
 import {
   type AdapterConformanceOptions,
@@ -10,6 +10,15 @@ import {
 } from "@ratel-ai/sdk/testkit";
 import { describe, it } from "vitest";
 import { type MastraTool, mastra } from "./mastra.js";
+
+const TEST_CONTEXT = {
+  observe: {
+    async span<T>(_name: string, fn: () => T | Promise<T>): Promise<T> {
+      return fn();
+    },
+    log(): void {},
+  },
+};
 
 // The framework hooks that teach the shared conformance battery how to build
 // Mastra tools, invoke exposed ones, and read back the recall message. Kept
@@ -33,7 +42,7 @@ function mastraConformanceOptions(): AdapterConformanceOptions<MastraTool, Mastr
       const execute = tool.execute as (input: unknown, context: unknown) => unknown;
       // Exposed tools ignore the context; fabricate the minimal one so the call
       // is shaped like a real Mastra invocation.
-      return execute(args, { observe: noopObserve });
+      return execute(args, TEST_CONTEXT);
     },
     validateRecallPair,
     validateExposedTool,

--- a/src/adapters/ts-mastra/src/conformance.test.ts
+++ b/src/adapters/ts-mastra/src/conformance.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import type { MastraDBMessage } from "@mastra/core/agent";
+import { createTool, noopObserve, Tool } from "@mastra/core/tools";
+import { SEARCH_CAPABILITIES_ID } from "@ratel-ai/sdk";
+import {
+  type AdapterConformanceOptions,
+  type ConformanceToolSpec,
+  describeAdapterConformance,
+  type RecallExpectation,
+} from "@ratel-ai/sdk/testkit";
+import { describe, it } from "vitest";
+import { type MastraTool, mastra } from "./mastra.js";
+
+// The framework hooks that teach the shared conformance battery how to build
+// Mastra tools, invoke exposed ones, and read back the recall message. Kept
+// test-only: the testkit ships the reference worked example, so publishing ours
+// would add a semver-bound API for zero users. Supplying makePassthroughTool
+// (a Mastra tool with no `execute`) means 0 skips.
+function mastraConformanceOptions(): AdapterConformanceOptions<MastraTool, MastraDBMessage> {
+  return {
+    adapter: mastra,
+    // A neutral createTool id: the catalog id is the register key ingest is
+    // handed, not the tool's own id, so this is irrelevant to registration.
+    makeExecutableTool: (spec: ConformanceToolSpec) =>
+      createTool({
+        id: "conformance_exec",
+        description: spec.description,
+        execute: async () => spec.result ?? { ok: true },
+      }),
+    makePassthroughTool: (spec: ConformanceToolSpec) =>
+      createTool({ id: "conformance_passthrough", description: spec.description }),
+    callExposedTool: (tool, args) => {
+      const execute = tool.execute as (input: unknown, context: unknown) => unknown;
+      // Exposed tools ignore the context; fabricate the minimal one so the call
+      // is shaped like a real Mastra invocation.
+      return execute(args, { observe: noopObserve });
+    },
+    validateRecallPair,
+    validateExposedTool,
+  };
+}
+
+describeAdapterConformance(mastraConformanceOptions(), { describe, it });
+
+// The recall is ONE assistant message (a MastraDBMessage has no `tool` role): a
+// single resolved `tool-invocation` part carrying the call args and the result.
+function validateRecallPair(messages: MastraDBMessage[], expected: RecallExpectation): void {
+  assert.equal(messages.length, 1, "recall is a single assistant message");
+  const [message] = messages;
+  assert.equal(message.role, "assistant", "the recall message is an assistant turn");
+  assert.equal(message.content.format, 2, "content is format 2");
+  const parts = message.content.parts;
+  assert.equal(parts.length, 1, "one part");
+  const part = parts[0] as { type: string; toolInvocation: Record<string, unknown> };
+  assert.equal(part.type, "tool-invocation");
+  const invocation = part.toolInvocation;
+  assert.equal(invocation.state, "result", "a resolved tool-invocation carries args + result");
+  assert.equal(invocation.toolCallId, expected.callId, "carries the expected call id");
+  assert.equal(invocation.toolName, SEARCH_CAPABILITIES_ID);
+  assert.deepEqual(
+    invocation.args,
+    { query: expected.query },
+    "carries the query as the call args",
+  );
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(invocation.result)),
+    JSON.parse(JSON.stringify(expected.recall)),
+    "carries the canonical recall (round-tripped)",
+  );
+}
+
+// An `expose` codec output is a genuine Mastra tool: a `createTool` result (a
+// `Tool` instance with an id, a description, and a callable execute).
+function validateExposedTool(tool: MastraTool): void {
+  assert.ok(tool instanceof Tool, "exposed tool is a Mastra createTool result");
+  assert.equal(typeof tool.execute, "function", "exposed tool is callable");
+  assert.equal(typeof tool.id, "string", "exposed tool keeps a Mastra id");
+  assert.equal(typeof tool.description, "string", "exposed tool keeps a description");
+}

--- a/src/adapters/ts-mastra/src/index.ts
+++ b/src/adapters/ts-mastra/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * `@ratel-ai/mastra-adapter` — the Mastra adapter for Ratel. Implements the
+ * `@ratel-ai/mastra` — the Mastra adapter for Ratel. Implements the
  * `@ratel-ai/sdk` framework-adapter SPI (ADR-0013) for `@mastra/core`, so
  * `ratel(config).adaptTo(mastra())` speaks Mastra's native `Tool` (from
  * `createTool`) and `MastraDBMessage` shapes and adds a per-turn recall input

--- a/src/adapters/ts-mastra/src/index.ts
+++ b/src/adapters/ts-mastra/src/index.ts
@@ -1,0 +1,11 @@
+/**
+ * `@ratel-ai/mastra-adapter` — the Mastra adapter for Ratel. Implements the
+ * `@ratel-ai/sdk` framework-adapter SPI (ADR-0013) for `@mastra/core`, so
+ * `ratel(config).adaptTo(mastra())` speaks Mastra's native `Tool` (from
+ * `createTool`) and `MastraDBMessage` shapes and adds a per-turn recall input
+ * processor for an Agent's `inputProcessors`.
+ *
+ * @packageDocumentation
+ */
+
+export { type MastraExt, type MastraTool, mastra } from "./mastra.js";

--- a/src/adapters/ts-mastra/src/mastra.integration.test.ts
+++ b/src/adapters/ts-mastra/src/mastra.integration.test.ts
@@ -1,0 +1,88 @@
+import { Agent } from "@mastra/core/agent";
+// Mastra ships its built-in mock as JS with no type declarations; test files are
+// excluded from `tsc`, so the plain import is fine and keeps the loop authentic.
+import { createMockModel } from "@mastra/core/test-utils/llm-mock";
+import { createTool } from "@mastra/core/tools";
+import { ratel, SEARCH_CAPABILITIES_ID } from "@ratel-ai/sdk";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { mastra } from "./mastra.js";
+
+// Drives the REAL Mastra Agent loop with a mock model (no API key, no network),
+// exercising what the codec + processor unit tests can't: that the recall pair the
+// recallProcessor injects actually reaches the model prompt through Mastra's own
+// message pipeline.
+
+function viewWithDeployTool() {
+  const view = ratel().adaptTo(mastra());
+  view.tools.register({
+    deploy_app: createTool({
+      id: "deploy_app",
+      description: "Deploy the app to production servers.",
+      inputSchema: z.object({}),
+      execute: async () => ({ deployed: true }),
+    }),
+  });
+  return view;
+}
+
+describe("Agent integration (the real Mastra loop)", () => {
+  it("injects the recall pair into the model prompt for a user turn", async () => {
+    const view = viewWithDeployTool();
+    const prompts: string[] = [];
+    const model = createMockModel({
+      mockText: "deployed.",
+      spyGenerate: (props: { prompt: unknown }) => prompts.push(JSON.stringify(props.prompt)),
+    });
+    const agent = new Agent({
+      id: "integration",
+      name: "integration",
+      instructions: "help the user",
+      model,
+      tools: view.expose(),
+      inputProcessors: [view.recallProcessor()],
+    });
+
+    const result = await agent.generate("deploy to production");
+    expect(result.text).toContain("deployed");
+    expect(prompts).toHaveLength(1);
+    // Recall reached the model: the synthetic search_capabilities pair and the
+    // user's query both appear in the prompt the model actually saw.
+    expect(prompts[0]).toContain(SEARCH_CAPABILITIES_ID);
+    expect(prompts[0]).toContain("deploy to production");
+    // Exactly one recall pair for the turn — recall_0, never re-injected as recall_1.
+    expect(prompts[0]).toContain("recall_0");
+    expect(prompts[0]).not.toContain("recall_1");
+  });
+
+  it("mints a fresh recall id per user turn (processInput = once per generation)", async () => {
+    const view = viewWithDeployTool();
+    const prompts: string[] = [];
+    const model = createMockModel({
+      mockText: "ok",
+      spyGenerate: (props: { prompt: unknown }) => prompts.push(JSON.stringify(props.prompt)),
+    });
+    const agent = new Agent({
+      id: "integration2",
+      name: "integration2",
+      instructions: "help the user",
+      model,
+      tools: view.expose(),
+      inputProcessors: [view.recallProcessor()],
+    });
+
+    await agent.generate("deploy to production");
+    await agent.generate("deploy the service again");
+    expect(prompts[0]).toContain("recall_0");
+    expect(prompts[1]).toContain("recall_1");
+  });
+
+  it("recalls via processInput, not processInputStep (no re-injection during the tool loop)", () => {
+    const processor = viewWithDeployTool().recallProcessor() as {
+      processInput?: unknown;
+      processInputStep?: unknown;
+    };
+    expect(typeof processor.processInput).toBe("function");
+    expect(processor.processInputStep).toBeUndefined();
+  });
+});

--- a/src/adapters/ts-mastra/src/mastra.integration.test.ts
+++ b/src/adapters/ts-mastra/src/mastra.integration.test.ts
@@ -39,7 +39,7 @@ describe("Agent integration (the real Mastra loop)", () => {
       name: "integration",
       instructions: "help the user",
       model,
-      tools: view.expose(),
+      tools: view.modelTools(),
       inputProcessors: [view.recallProcessor()],
     });
 
@@ -67,7 +67,7 @@ describe("Agent integration (the real Mastra loop)", () => {
       name: "integration2",
       instructions: "help the user",
       model,
-      tools: view.expose(),
+      tools: view.modelTools(),
       inputProcessors: [view.recallProcessor()],
     });
 

--- a/src/adapters/ts-mastra/src/mastra.test.ts
+++ b/src/adapters/ts-mastra/src/mastra.test.ts
@@ -1,5 +1,5 @@
 import type { MastraDBMessage } from "@mastra/core/agent";
-import { createTool, isValidationError, noopObserve, Tool } from "@mastra/core/tools";
+import { createTool, Tool } from "@mastra/core/tools";
 import {
   GET_SKILL_CONTENT_ID,
   INVOKE_TOOL_ID,
@@ -27,7 +27,14 @@ function userMsg(...texts: string[]): MastraDBMessage {
 // Invoke an exposed Mastra tool with the fabricated minimal context.
 function callExposed(tool: Tool, args: Record<string, unknown>): Promise<unknown> {
   const execute = tool.execute as (input: unknown, context: unknown) => Promise<unknown>;
-  return execute(args, { observe: noopObserve });
+  return execute(args, {
+    observe: {
+      async span<T>(_name: string, fn: () => T | Promise<T>): Promise<T> {
+        return fn();
+      },
+      log(): void {},
+    },
+  });
 }
 
 function countHits(result: SearchCapabilitiesResult): number {
@@ -137,6 +144,19 @@ describe("ingest codec", () => {
     await expect(reg.execute({})).rejects.toThrow();
   });
 
+  it("does not mistake an ordinary error-shaped tool result for a ValidationError", async () => {
+    const domainFailure = { error: true, message: "card declined" };
+    const charge = createTool({
+      id: "charge",
+      description: "Charge a card",
+      execute: async () => domainFailure,
+    });
+    const reg = mastra().ingest("charge", charge);
+    if (reg === "passthrough") throw new Error("expected an executable registration");
+
+    await expect(reg.execute({})).resolves.toEqual(domainFailure);
+  });
+
   it("fabricates a minimal Mastra context when the catalog runs the tool", async () => {
     let seenContext: Record<string, unknown> | undefined;
     const view = ratel().adaptTo(mastra());
@@ -219,7 +239,6 @@ describe("expose codec", () => {
       query: "grep files",
       topKTools: 999,
     })) as SearchCapabilitiesResult;
-    expect(isValidationError(high)).toBe(false);
     expect(countHits(high)).toBeGreaterThan(5);
     expect(countHits(high)).toBeLessThanOrEqual(50);
     // A negative value is accepted too and falls back to the default inside the core.
@@ -227,7 +246,6 @@ describe("expose codec", () => {
       query: "grep files",
       topKTools: -1,
     })) as SearchCapabilitiesResult;
-    expect(isValidationError(low)).toBe(false);
     expect(countHits(low)).toBeLessThanOrEqual(5);
   });
 

--- a/src/adapters/ts-mastra/src/mastra.test.ts
+++ b/src/adapters/ts-mastra/src/mastra.test.ts
@@ -1,4 +1,5 @@
 import type { MastraDBMessage } from "@mastra/core/agent";
+import { RequestContext } from "@mastra/core/request-context";
 import { createTool, Tool } from "@mastra/core/tools";
 import {
   GET_SKILL_CONTENT_ID,
@@ -24,8 +25,13 @@ function userMsg(...texts: string[]): MastraDBMessage {
   };
 }
 
-// Invoke an exposed Mastra tool with the fabricated minimal context.
-function callExposed(tool: Tool, args: Record<string, unknown>): Promise<unknown> {
+// Invoke an exposed Mastra tool with a valid minimal context plus any live
+// fields the test supplies.
+function callExposed(
+  tool: Tool,
+  args: Record<string, unknown>,
+  context: Record<string, unknown> = {},
+): Promise<unknown> {
   const execute = tool.execute as (input: unknown, context: unknown) => Promise<unknown>;
   return execute(args, {
     observe: {
@@ -34,6 +40,7 @@ function callExposed(tool: Tool, args: Record<string, unknown>): Promise<unknown
       },
       log(): void {},
     },
+    ...context,
   });
 }
 
@@ -160,7 +167,7 @@ describe("ingest codec", () => {
   it("fabricates a minimal Mastra context when the catalog runs the tool", async () => {
     let seenContext: Record<string, unknown> | undefined;
     const view = ratel().adaptTo(mastra());
-    view.tools.register({
+    await view.tools.register({
       spy: createTool({
         id: "spy",
         description: "spy",
@@ -172,12 +179,155 @@ describe("ingest codec", () => {
     });
     const out = await view.tools.catalog.invoke("spy", {});
     expect(out).toEqual({ ran: true });
-    // The fabricated context carries the no-op `observe` and a fresh requestContext;
+    // The direct-call fallback carries the no-op `observe` and a fresh requestContext;
     // a tool reading `agent` / `mastra` / `workflow` sees undefined, not a crash.
     expect(seenContext?.observe).toBeDefined();
     expect(seenContext?.requestContext).toBeDefined();
     expect(seenContext?.agent).toBeUndefined();
     expect(seenContext?.mastra).toBeUndefined();
+  });
+
+  it("preserves the caller's Mastra execution context through invoke_tool", async () => {
+    const requestContext = new RequestContext([["tenantId", "tenant-42"]]);
+    const workspace = { marker: "workspace" };
+    const agent = {
+      toolCallId: "call-1",
+      messages: [],
+      suspend: async () => {},
+      threadId: "thread-9",
+      resourceId: "resource-3",
+    };
+    const mastraInstance = { marker: "mastra" };
+    const abortSignal = new AbortController().signal;
+    const core = ratel();
+    const registrationView = core.adaptTo(mastra());
+    const invocationView = core.adaptTo(mastra());
+    await registrationView.tools.register({
+      tenant_probe: createTool({
+        id: "tenant_probe",
+        description: "Read the current tenant",
+        execute: async (_input, context) => ({
+          sameContext: context.requestContext === requestContext,
+          tenantId: context.requestContext?.get("tenantId"),
+          sameWorkspace: context.workspace === workspace,
+          threadId: context.agent?.threadId,
+          resourceId: context.agent?.resourceId,
+          sameMastra: context.mastra === mastraInstance,
+          sameAbortSignal: context.abortSignal === abortSignal,
+        }),
+      }),
+    });
+
+    const out = await callExposed(
+      invocationView.modelTools()[INVOKE_TOOL_ID] as Tool,
+      {
+        toolId: "tenant_probe",
+        args: {},
+      },
+      {
+        requestContext,
+        workspace,
+        agent,
+        mastra: mastraInstance,
+        abortSignal,
+      },
+    );
+
+    expect(out).toEqual({
+      sameContext: true,
+      tenantId: "tenant-42",
+      sameWorkspace: true,
+      threadId: "thread-9",
+      resourceId: "resource-3",
+      sameMastra: true,
+      sameAbortSignal: true,
+    });
+  });
+
+  it("satisfies a registered tool's request context schema through invoke_tool", async () => {
+    const requestContext = new RequestContext([["actorId", "actor-7"]]);
+    const view = ratel().adaptTo(mastra());
+    await view.tools.register({
+      actor_probe: createTool({
+        id: "actor_probe",
+        description: "Read the authorized actor",
+        requestContextSchema: z.object({ actorId: z.string() }),
+        execute: async (_input, context) => ({
+          actorId: context.requestContext?.get("actorId"),
+        }),
+      }),
+    });
+
+    const out = await callExposed(
+      view.modelTools()[INVOKE_TOOL_ID] as Tool,
+      {
+        toolId: "actor_probe",
+        args: {},
+      },
+      { requestContext },
+    );
+
+    expect(out).toEqual({ actorId: "actor-7" });
+  });
+
+  it("isolates request contexts across concurrent invoke_tool calls", async () => {
+    let arrivals = 0;
+    let releaseBoth!: () => void;
+    const bothArrived = new Promise<void>((resolve) => {
+      releaseBoth = resolve;
+    });
+    const view = ratel().adaptTo(mastra());
+    await view.tools.register({
+      tenant_probe: createTool({
+        id: "tenant_probe",
+        description: "Read the current tenant after calls overlap",
+        execute: async (_input, context) => {
+          arrivals += 1;
+          if (arrivals === 2) releaseBoth();
+          await bothArrived;
+          return { tenantId: context.requestContext?.get("tenantId") };
+        },
+      }),
+    });
+    const invokeTool = view.modelTools()[INVOKE_TOOL_ID] as Tool;
+
+    const invokeFor = (tenantId: string) =>
+      callExposed(
+        invokeTool,
+        { toolId: "tenant_probe", args: {} },
+        {
+          requestContext: new RequestContext([["tenantId", tenantId]]),
+        },
+      );
+
+    expect(await Promise.all([invokeFor("tenant-a"), invokeFor("tenant-b")])).toEqual([
+      { tenantId: "tenant-a" },
+      { tenantId: "tenant-b" },
+    ]);
+  });
+
+  it("does not mistake a lookalike foreign context for Mastra context", async () => {
+    const core = ratel();
+    const view = core.adaptTo(mastra());
+    await view.tools.register({
+      tenant_probe: createTool({
+        id: "tenant_probe",
+        description: "Read the current tenant",
+        execute: async (_input, context) => ({
+          tenantId: context.requestContext?.get("tenantId"),
+        }),
+      }),
+    });
+
+    const result = await core.modelTools()[INVOKE_TOOL_ID].execute(
+      { toolId: "tenant_probe", args: {} },
+      {
+        adapter: "mastra",
+        value: { requestContext: new RequestContext([["tenantId", "foreign-tenant"]]) },
+      },
+    );
+
+    expect(result).toEqual({ tenantId: undefined });
   });
 });
 

--- a/src/adapters/ts-mastra/src/mastra.test.ts
+++ b/src/adapters/ts-mastra/src/mastra.test.ts
@@ -1,0 +1,328 @@
+import type { MastraDBMessage } from "@mastra/core/agent";
+import { createTool, isValidationError, noopObserve, Tool } from "@mastra/core/tools";
+import {
+  GET_SKILL_CONTENT_ID,
+  INVOKE_TOOL_ID,
+  ratel,
+  SEARCH_CAPABILITIES_ID,
+  type SearchCapabilitiesResult,
+} from "@ratel-ai/sdk";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { mastra } from "./mastra.js";
+
+// A JSON Schema whose `properties` we read positionally in assertions.
+type JsonObjectSchema = { type?: string; properties?: Record<string, { type?: string }> };
+
+// A user MastraDBMessage carrying one text part (Mastra's format-2 content).
+function userMsg(...texts: string[]): MastraDBMessage {
+  return {
+    id: `u_${texts.join("_")}`,
+    role: "user",
+    createdAt: new Date(),
+    content: { format: 2, parts: texts.map((text) => ({ type: "text", text })) },
+  };
+}
+
+// Invoke an exposed Mastra tool with the fabricated minimal context.
+function callExposed(tool: Tool, args: Record<string, unknown>): Promise<unknown> {
+  const execute = tool.execute as (input: unknown, context: unknown) => Promise<unknown>;
+  return execute(args, { observe: noopObserve });
+}
+
+function countHits(result: SearchCapabilitiesResult): number {
+  return result.tools.groups.reduce((n, g) => n + g.hits.length, 0);
+}
+
+// A view over a fresh core with one BM25-discoverable executable Mastra tool.
+function viewWithDeployTool() {
+  const view = ratel().adaptTo(mastra());
+  view.tools.register({
+    deploy_app: createTool({
+      id: "deploy_app",
+      description: "Deploy the app to production servers.",
+      inputSchema: z.object({}),
+      execute: async () => ({ deployed: true }),
+    }),
+  });
+  return view;
+}
+
+describe("mastra() identity", () => {
+  it('names itself "mastra" — matches the core KNOWN_FRAMEWORKS table', () => {
+    expect(mastra().name).toBe("mastra");
+  });
+});
+
+describe("ingest codec", () => {
+  it("passes through a Mastra tool with no execute (client/provider-executed)", () => {
+    const providerTool = createTool({ id: "provider_search", description: "provider-run search" });
+    expect(mastra().ingest("provider_search", providerTool)).toBe("passthrough");
+  });
+
+  it("ingests an executable: description, extracted input schema, omitted output schema", () => {
+    const weather = createTool({
+      id: "weather",
+      description: "Get the weather in a location",
+      inputSchema: z.object({ location: z.string() }),
+      execute: async ({ location }) => ({ location, tempF: 70 }),
+    });
+    const reg = mastra().ingest("weather", weather);
+    if (reg === "passthrough") throw new Error("expected an executable registration");
+    expect(reg.description).toBe("Get the weather in a location");
+    const input = reg.inputSchema as JsonObjectSchema;
+    expect(input.type).toBe("object");
+    expect(input.properties?.location.type).toBe("string");
+    // The `$schema` dialect marker is stripped; absent output schema stays absent.
+    expect((reg.inputSchema as Record<string, unknown>).$schema).toBeUndefined();
+    expect(reg.outputSchema).toBeUndefined();
+  });
+
+  it("extracts JSON schema from a tool built with a raw JSON Schema", () => {
+    const t = createTool({
+      id: "raw",
+      description: "raw json schema",
+      // Mastra accepts a raw JSON Schema; ingest reads it back off the normalized schema.
+      inputSchema: {
+        type: "object",
+        properties: { q: { type: "string" } },
+        required: ["q"],
+      } as never,
+      execute: async () => ({}),
+    });
+    const reg = mastra().ingest("raw", t);
+    if (reg === "passthrough") throw new Error("expected an executable registration");
+    const input = reg.inputSchema as JsonObjectSchema;
+    expect(input.properties?.q.type).toBe("string");
+  });
+
+  it("defaults a schema-less tool to an object schema", () => {
+    const t = createTool({
+      id: "bare",
+      description: "no schema",
+      execute: async () => ({ ok: true }),
+    });
+    const reg = mastra().ingest("bare", t);
+    if (reg === "passthrough") throw new Error("expected an executable registration");
+    expect(reg.inputSchema).toEqual({ type: "object" });
+  });
+
+  it("converts the output schema when the tool declares one", () => {
+    const t = createTool({
+      id: "structured",
+      description: "structured",
+      inputSchema: z.object({}),
+      outputSchema: z.object({ ok: z.boolean() }),
+      execute: async () => ({ ok: true }),
+    });
+    const reg = mastra().ingest("structured", t);
+    if (reg === "passthrough") throw new Error("expected an executable registration");
+    const output = reg.outputSchema as JsonObjectSchema;
+    expect(output.properties?.ok.type).toBe("boolean");
+  });
+
+  it("surfaces a Mastra ValidationError as a thrown error, not a silent result", async () => {
+    const weather = createTool({
+      id: "weather",
+      description: "Get the weather in a location",
+      inputSchema: z.object({ location: z.string() }),
+      execute: async ({ location }) => ({ location }),
+    });
+    const reg = mastra().ingest("weather", weather);
+    if (reg === "passthrough") throw new Error("expected an executable registration");
+    // Good args pass through the createTool validation wrapper.
+    expect(await reg.execute({ location: "Paris" })).toEqual({ location: "Paris" });
+    // Missing required arg: Mastra returns a ValidationError object (does not throw);
+    // the adapter re-throws so the capability funnel frames it as a failed call.
+    await expect(reg.execute({})).rejects.toThrow();
+  });
+
+  it("fabricates a minimal Mastra context when the catalog runs the tool", async () => {
+    let seenContext: Record<string, unknown> | undefined;
+    const view = ratel().adaptTo(mastra());
+    view.tools.register({
+      spy: createTool({
+        id: "spy",
+        description: "spy",
+        execute: async (_input, context) => {
+          seenContext = context as Record<string, unknown>;
+          return { ran: true };
+        },
+      }),
+    });
+    const out = await view.tools.catalog.invoke("spy", {});
+    expect(out).toEqual({ ran: true });
+    // The fabricated context carries the no-op `observe` and a fresh requestContext;
+    // a tool reading `agent` / `mastra` / `workflow` sees undefined, not a crash.
+    expect(seenContext?.observe).toBeDefined();
+    expect(seenContext?.requestContext).toBeDefined();
+    expect(seenContext?.agent).toBeUndefined();
+    expect(seenContext?.mastra).toBeUndefined();
+  });
+});
+
+describe("expose codec", () => {
+  it("wraps a Ratel capability tool as a genuine Mastra tool that delegates execute", async () => {
+    const capability = {
+      id: SEARCH_CAPABILITIES_ID,
+      name: SEARCH_CAPABILITIES_ID,
+      description: "search the catalog",
+      inputSchema: { type: "object", properties: { query: { type: "string" } } },
+      outputSchema: { type: "object" },
+      execute: async (args: unknown) => ({ echoed: args }),
+    };
+    const exposed = mastra().expose(capability);
+    expect(exposed).toBeInstanceOf(Tool);
+    expect(exposed.description).toBe("search the catalog");
+    expect(typeof exposed.execute).toBe("function");
+    // Execution delegates to the capability's own executor (args validated by the
+    // hand-written zod schema, then forwarded).
+    expect(await callExposed(exposed, { query: "hi" })).toEqual({ echoed: { query: "hi" } });
+  });
+
+  it("preserves the capability tools' canonical parameter descriptions for the model", () => {
+    const view = ratel().adaptTo(mastra());
+    const exposed = view.expose();
+    const jsonOf = (tool: Tool) =>
+      (
+        tool.inputSchema as {
+          "~standard": { jsonSchema: { input(o: { target: string }): Record<string, unknown> } };
+        }
+      )["~standard"].jsonSchema.input({ target: "draft-07" }) as {
+        properties: Record<string, { description?: string }>;
+      };
+    const search = jsonOf(exposed[SEARCH_CAPABILITIES_ID] as Tool);
+    expect(search.properties.query.description).toBe("describe what you want to do");
+    expect(search.properties.topKTools.description).toContain("default 5");
+    const skill = jsonOf(exposed[GET_SKILL_CONTENT_ID] as Tool);
+    expect(skill.properties.skillId.description).toContain("id of the skill to load");
+  });
+
+  it("is permissive on topK so out-of-range values reach the core's clamp", async () => {
+    const view = ratel({ recallTopK: 5 }).adaptTo(mastra());
+    view.tools.register(
+      Object.fromEntries(
+        Array.from({ length: 60 }, (_, i) => [
+          `grep_${i}`,
+          createTool({
+            id: `grep_${i}`,
+            description: `Search files variant ${i}: grep ripgrep.`,
+            execute: async () => ({ ok: true }),
+          }),
+        ]),
+      ),
+    );
+    const search = view.expose()[SEARCH_CAPABILITIES_ID];
+    // A value far above the default is honoured, then clamped to 50 by the core —
+    // it is NOT rejected by the exposed tool's schema.
+    const high = (await callExposed(search, {
+      query: "grep files",
+      topKTools: 999,
+    })) as SearchCapabilitiesResult;
+    expect(isValidationError(high)).toBe(false);
+    expect(countHits(high)).toBeGreaterThan(5);
+    expect(countHits(high)).toBeLessThanOrEqual(50);
+    // A negative value is accepted too and falls back to the default inside the core.
+    const low = (await callExposed(search, {
+      query: "grep files",
+      topKTools: -1,
+    })) as SearchCapabilitiesResult;
+    expect(isValidationError(low)).toBe(false);
+    expect(countHits(low)).toBeLessThanOrEqual(5);
+  });
+
+  it("does not strip a nested args object for invoke_tool", async () => {
+    const view = ratel().adaptTo(mastra());
+    view.tools.register({
+      echo_tool: createTool({
+        id: "echo_tool",
+        description: "echo the args back",
+        execute: async (input) => ({ got: input }),
+      }),
+    });
+    const invoke = view.expose()[INVOKE_TOOL_ID];
+    const result = await callExposed(invoke, {
+      toolId: "echo_tool",
+      args: { path: "/tmp/x", n: 3 },
+    });
+    expect(result).toEqual({ got: { path: "/tmp/x", n: 3 } });
+  });
+});
+
+describe("recallMessages codec", () => {
+  it("renders the recall as one assistant message with a resolved tool-invocation", () => {
+    const recall = {
+      tools: { groups: [{ server: { name: "fs" }, hits: [{ toolId: "read_file", score: 1 }] }] },
+      skills: [],
+    } as unknown as SearchCapabilitiesResult;
+    const messages = mastra().recallMessages({ callId: "recall_0", query: "read a file" }, recall);
+    expect(messages).toHaveLength(1);
+    const [message] = messages;
+    expect(message.role).toBe("assistant");
+    expect(message.content.format).toBe(2);
+    const part = message.content.parts[0] as {
+      type: string;
+      toolInvocation: Record<string, unknown>;
+    };
+    expect(part.type).toBe("tool-invocation");
+    expect(part.toolInvocation.state).toBe("result");
+    expect(part.toolInvocation.toolCallId).toBe("recall_0");
+    expect(part.toolInvocation.toolName).toBe(SEARCH_CAPABILITIES_ID);
+    expect(part.toolInvocation.args).toEqual({ query: "read a file" });
+    expect(part.toolInvocation.result).toEqual(recall);
+  });
+});
+
+describe("recallProcessor (extend)", () => {
+  // The processor's processInput, called directly with a partial args object (it
+  // reads only `messages`). Cast keeps the tests off the wide ProcessInputArgs type.
+  function inject(view: ReturnType<typeof viewWithDeployTool>, messages: MastraDBMessage[]) {
+    const processor = view.recallProcessor() as {
+      processInput: (args: { messages: MastraDBMessage[] }) => Promise<MastraDBMessage[]>;
+    };
+    return processor.processInput({ messages });
+  }
+  function toolCallId(message: MastraDBMessage): unknown {
+    return (message.content.parts[0] as { toolInvocation: { toolCallId: unknown } }).toolInvocation
+      .toolCallId;
+  }
+
+  it("appends the recall message after a user turn with hits (spends recall_0)", async () => {
+    const view = viewWithDeployTool();
+    const out = await inject(view, [userMsg("deploy to production")]);
+    expect(out).toHaveLength(2);
+    expect(out[1].role).toBe("assistant");
+    expect(toolCallId(out[1])).toBe("recall_0");
+  });
+
+  it("no-ops (no id spent) when the last message is not a user turn", async () => {
+    const view = viewWithDeployTool();
+    const assistant: MastraDBMessage = {
+      id: "a1",
+      role: "assistant",
+      createdAt: new Date(),
+      content: { format: 2, parts: [{ type: "text", text: "on it" }] },
+    };
+    const out = await inject(view, [userMsg("deploy to production"), assistant]);
+    expect(out).toHaveLength(2);
+    // No id spent, so the next real recall on the same view is still recall_0.
+    const real = await inject(view, [userMsg("deploy to production")]);
+    expect(toolCallId(real[1])).toBe("recall_0");
+  });
+
+  it("no-ops on empty user text and on a zero-hit query, preserving id economy", async () => {
+    const view = viewWithDeployTool();
+    expect(await inject(view, [userMsg("")])).toHaveLength(1);
+    expect(await inject(view, [userMsg("zzzqqq utterly unrelated")])).toHaveLength(1);
+    const real = await inject(view, [userMsg("deploy to production")]);
+    expect(toolCallId(real[1])).toBe("recall_0");
+  });
+
+  it("joins multi-part user text with newlines for the recall query", async () => {
+    const view = viewWithDeployTool();
+    const out = await inject(view, [userMsg("deploy", "to production")]);
+    const args = (out[1].content.parts[0] as { toolInvocation: { args: unknown } }).toolInvocation
+      .args;
+    expect(args).toEqual({ query: "deploy\nto production" });
+  });
+});

--- a/src/adapters/ts-mastra/src/mastra.test.ts
+++ b/src/adapters/ts-mastra/src/mastra.test.ts
@@ -182,7 +182,7 @@ describe("expose codec", () => {
 
   it("preserves the capability tools' canonical parameter descriptions for the model", () => {
     const view = ratel().adaptTo(mastra());
-    const exposed = view.expose();
+    const exposed = view.modelTools();
     const jsonOf = (tool: Tool) =>
       (
         tool.inputSchema as {
@@ -212,7 +212,7 @@ describe("expose codec", () => {
         ]),
       ),
     );
-    const search = view.expose()[SEARCH_CAPABILITIES_ID];
+    const search = view.modelTools()[SEARCH_CAPABILITIES_ID];
     // A value far above the default is honoured, then clamped to 50 by the core —
     // it is NOT rejected by the exposed tool's schema.
     const high = (await callExposed(search, {
@@ -240,7 +240,7 @@ describe("expose codec", () => {
         execute: async (input) => ({ got: input }),
       }),
     });
-    const invoke = view.expose()[INVOKE_TOOL_ID];
+    const invoke = view.modelTools()[INVOKE_TOOL_ID];
     const result = await callExposed(invoke, {
       toolId: "echo_tool",
       args: { path: "/tmp/x", n: 3 },

--- a/src/adapters/ts-mastra/src/mastra.ts
+++ b/src/adapters/ts-mastra/src/mastra.ts
@@ -1,0 +1,230 @@
+import type { MastraDBMessage, ToolsInput } from "@mastra/core/agent";
+import type { InputProcessor, ProcessInputArgs } from "@mastra/core/processors";
+import { createTool, isValidationError, noopObserve } from "@mastra/core/tools";
+import type {
+  CatalogRegistration,
+  JSONSchema7,
+  RatelAdapter,
+  RecallRef,
+  SearchCapabilitiesResult,
+} from "@ratel-ai/sdk";
+import { GET_SKILL_CONTENT_ID, INVOKE_TOOL_ID, SEARCH_CAPABILITIES_ID } from "@ratel-ai/sdk";
+import { z } from "zod";
+
+/**
+ * A Mastra tool — the per-entry type of Mastra's `ToolsInput` (a `createTool`
+ * result, or an AI SDK / provider tool a Mastra Agent accepts). Deliberately broad
+ * so an app can register any tool its Agent could hold; `ingest` duck-types it.
+ */
+export type MastraTool = ToolsInput[string];
+
+/**
+ * The Mastra-idiomatic per-turn recall helper {@link mastra} merges onto the
+ * adapted view via the SPI's `extend` hook.
+ */
+export interface MastraExt {
+  /**
+   * A fresh Mastra {@link InputProcessor} for an Agent's `inputProcessors`. Its
+   * `processInput` runs once at the start of each generation (= once per user
+   * turn): it ranks the catalog against the last user message and injects the
+   * synthetic `search_capabilities` call+result before the model runs. A no-op
+   * that spends no call id unless the last message is a user turn with text and
+   * there are hits. A factory (not a shared instance) so several agents each get
+   * their own processor.
+   */
+  recallProcessor(): InputProcessor;
+}
+
+/** Id of the recall input processor (stamped on the Mastra `Processor`). */
+const RECALL_PROCESSOR_ID = "ratel-recall";
+
+// The minimal execution context the catalog fabricates when it runs an ingested
+// Mastra tool with just its args: `observe` is the only required field of
+// `ToolExecutionContext` (the createTool wrapper fills `requestContext` itself).
+// A tool reading `mastra` / `agent` / `workflow` / `abortSignal` sees `undefined`.
+const CATALOG_CONTEXT = { observe: noopObserve };
+
+/**
+ * The Mastra adapter: `ratel(config).adaptTo(mastra())` gives the
+ * framework-neutral core `@mastra/core`'s native {@link MastraTool} (from
+ * `createTool`) and {@link MastraDBMessage} shapes. The core owns every guard
+ * (reserved ids, top-K clamp, first-registration-wins, recall-id counter), so
+ * the adapter is just the three codecs — `ingest` / `expose` / `recallMessages`
+ * — plus the {@link MastraExt} recall processor.
+ *
+ * @returns A {@link RatelAdapter} over Mastra's tool and message types.
+ */
+export function mastra(): RatelAdapter<MastraTool, MastraDBMessage, MastraExt> {
+  return {
+    name: "mastra",
+
+    ingest(_id, tool) {
+      // Duck-type the tool structurally: `MastraTool` is a broad union, but the
+      // codec only needs these four fields off a built Mastra tool.
+      const t = tool as {
+        execute?: unknown;
+        description?: string;
+        inputSchema?: unknown;
+        outputSchema?: unknown;
+      };
+      // A Mastra tool with no `execute` (client/provider-run) can't be funneled
+      // through the catalog — stay eagerly exposed in native shape.
+      if (typeof t.execute !== "function") return "passthrough";
+      const execute = t.execute as (input: unknown, context: unknown) => unknown;
+      const registration: CatalogRegistration = {
+        description: t.description ?? "",
+        // `createTool` normalized the input schema at build time; read its JSON
+        // Schema straight off the normalized standard schema (works for tools
+        // built from zod 3, zod 4, or a raw JSON Schema).
+        inputSchema: toJsonSchema(t.inputSchema),
+        // Catalog executors get only the args object: fabricate the minimal
+        // Mastra context so a tool reading it sees a no-op rather than crashing.
+        execute: async (input) => {
+          const result = await execute(input, CATALOG_CONTEXT);
+          // Mastra's createTool wrapper does not throw on a schema mismatch (or a
+          // required requestContext the fabricated context can't satisfy) — it
+          // RETURNS a ValidationError. Surface it as a real error so the capability
+          // funnel reports a failed call, not a successful one carrying an error blob.
+          if (isValidationError(result)) {
+            throw new Error(
+              (result as { message?: string }).message ?? "Mastra tool input validation failed",
+            );
+          }
+          return result;
+        },
+      };
+      // Leave a missing output schema absent — the core defaults it to
+      // `{ type: "object" }`; the adapter never fabricates one.
+      if (t.outputSchema) registration.outputSchema = toJsonSchema(t.outputSchema);
+      return registration;
+    },
+
+    expose(tool) {
+      return createTool({
+        id: tool.id,
+        description: tool.description,
+        inputSchema: capabilitySchema(tool.id, tool.inputSchema as JSONSchema7),
+        execute: async (input) => tool.execute(input as Record<string, unknown>),
+      }) as MastraTool;
+    },
+
+    recallMessages(ref: RecallRef, recall: SearchCapabilitiesResult): MastraDBMessage[] {
+      // One assistant message carrying a completed `search_capabilities` call:
+      // a MastraDBMessage has no `tool` role, so a resolved tool-invocation part
+      // (state `"result"`) holds both the args and the result. Mastra renders it
+      // to the model as an assistant tool-call followed by a tool result.
+      return [
+        {
+          id: ref.callId,
+          role: "assistant",
+          createdAt: new Date(),
+          content: {
+            format: 2,
+            parts: [
+              {
+                type: "tool-invocation",
+                toolInvocation: {
+                  state: "result",
+                  toolCallId: ref.callId,
+                  toolName: SEARCH_CAPABILITIES_ID,
+                  args: { query: ref.query },
+                  result: recall,
+                },
+              },
+            ],
+          },
+        },
+      ];
+    },
+
+    extend(base) {
+      return {
+        recallProcessor(): InputProcessor {
+          return {
+            id: RECALL_PROCESSOR_ID,
+            async processInput(args: ProcessInputArgs) {
+              const query = lastUserText(args.messages);
+              if (!query) return args.messages;
+              // base.recall mints the id and returns [] on no hits (spending none).
+              const pair = await base.recall(query);
+              if (pair.length === 0) return args.messages;
+              return [...args.messages, ...pair];
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+// Hand-written, deliberately permissive zod schemas for the three capability
+// tools (the model-facing shapes). topK carries no int/min/max — the core owns
+// clamping, so an out-of-range value must reach it rather than being rejected
+// here. An unknown id (defensive: the core only exposes the three) passes the
+// catalog's own JSON Schema straight through — `createTool` accepts a raw JSON
+// Schema, so there is still no schema converter in the adapter.
+function capabilitySchema(id: string, fallback: JSONSchema7): z.ZodTypeAny {
+  switch (id) {
+    case SEARCH_CAPABILITIES_ID:
+      // Descriptions mirror the core's canonical schema so the model keeps the
+      // same guidance; topK carries no int/min so out-of-range reaches the clamp.
+      return z.object({
+        query: z.string().describe("describe what you want to do"),
+        topKTools: z.number().describe("max tools to return (default 5)").optional(),
+        topKSkills: z.number().describe("max skills to return (default 3)").optional(),
+      });
+    case INVOKE_TOOL_ID:
+      return z.object({
+        toolId: z
+          .string()
+          .describe(
+            "id of the tool to invoke (use the catalog's search tool to find available ids)",
+          ),
+        // Arbitrary nested args — a record so zod never strips the tool's fields.
+        args: z
+          .record(z.string(), z.unknown())
+          .describe("arguments object matching the tool's inputSchema, nested as a single object"),
+      });
+    case GET_SKILL_CONTENT_ID:
+      return z.object({
+        skillId: z
+          .string()
+          .describe("id of the skill to load (use search_capabilities to find available ids)"),
+      });
+    default:
+      return fallback as unknown as z.ZodTypeAny;
+  }
+}
+
+// Read the JSON Schema off a built Mastra tool's normalized `inputSchema` via the
+// Standard JSON Schema spec. `createTool` normalizes zod/JSON into this shape, so
+// there is one extraction path for every schema flavour. A tool with no input
+// schema leaves it `undefined`; the catalog wants an object schema, so default.
+function toJsonSchema(schema: unknown): JSONSchema7 {
+  const input = (schema as StandardJsonSchema | null | undefined)?.["~standard"]?.jsonSchema?.input;
+  if (!input) return { type: "object" };
+  // Drop the `$schema` dialect marker — the catalog wants a bare JSONSchema7.
+  const { $schema: _dialect, ...json } = input({ target: "draft-07" });
+  return json as JSONSchema7;
+}
+
+// The slice of the Standard JSON Schema spec the adapter reads off a normalized
+// Mastra tool schema.
+interface StandardJsonSchema {
+  "~standard": { jsonSchema: { input(options: { target: string }): Record<string, unknown> } };
+}
+
+// The recall query is the last message's text iff it is a user turn: recall only
+// fires right after the user's turn, which also makes a second call in the same
+// turn a no-op (the last message is then an assistant/tool turn). Multi-part text
+// joins with newlines.
+function lastUserText(messages: MastraDBMessage[]): string | undefined {
+  const last = messages.at(-1);
+  if (last?.role !== "user") return undefined;
+  const parts = last.content?.parts ?? [];
+  const text = parts
+    .filter((part) => part.type === "text")
+    .map((part) => (part as { text: string }).text)
+    .join("\n");
+  return text || undefined;
+}

--- a/src/adapters/ts-mastra/src/mastra.ts
+++ b/src/adapters/ts-mastra/src/mastra.ts
@@ -1,6 +1,6 @@
 import type { MastraDBMessage, ToolsInput } from "@mastra/core/agent";
 import type { InputProcessor, ProcessInputArgs } from "@mastra/core/processors";
-import { createTool } from "@mastra/core/tools";
+import { createTool, type ToolExecutionContext } from "@mastra/core/tools";
 import type {
   CatalogRegistration,
   JSONSchema7,
@@ -43,10 +43,14 @@ export interface MastraExt {
 /** Id of the recall input processor (stamped on the Mastra `Processor`). */
 const RECALL_PROCESSOR_ID = "ratel-recall";
 
-// The minimal execution context the catalog fabricates when it runs an ingested
-// Mastra tool with just its args: `observe` is the only required field of
-// `ToolExecutionContext` (the createTool wrapper fills `requestContext` itself).
-// A tool reading `mastra` / `agent` / `workflow` / `abortSignal` sees `undefined`.
+// Package-stable and collision-resistant across multiple Mastra views or package
+// copies sharing one catalog. Other framework adapters use their own key.
+const MASTRA_CONTEXT_KEY = Symbol.for("@ratel-ai/mastra.execution-context");
+
+// Direct catalog calls have no Mastra invocation to supply context. Preserve a
+// minimal fallback for that driver-level path (and for a foreign adapter tag):
+// `observe` is the only required field of `ToolExecutionContext`; createTool
+// fills a fresh empty `requestContext`. Other live fields remain undefined.
 const CATALOG_CONTEXT = {
   observe: {
     async span<T>(_name: string, fn: () => T | Promise<T>): Promise<T> {
@@ -89,12 +93,14 @@ export function mastra(): RatelAdapter<MastraTool, MastraDBMessage, MastraExt> {
         // Schema straight off the normalized standard schema (works for tools
         // built from zod 3, zod 4, or a raw JSON Schema).
         inputSchema: toJsonSchema(t.inputSchema),
-        // Catalog executors get only the args object: fabricate the minimal
-        // Mastra context so a tool reading it sees a no-op rather than crashing.
-        execute: async (input) => {
-          const result = await execute(input, CATALOG_CONTEXT);
+        // A model-facing capability call carries Mastra's live context through
+        // the catalog as an opaque, adapter-tagged value. Direct catalog calls
+        // have none, so preserve their minimal no-op fallback.
+        execute: async (input, invocationContext) => {
+          const context = mastraContext(invocationContext) ?? CATALOG_CONTEXT;
+          const result = await execute(input, context);
           // Mastra's createTool wrapper does not throw on a schema mismatch (or a
-          // required requestContext the fabricated context can't satisfy) — it
+          // required requestContext the direct-call fallback can't satisfy) — it
           // RETURNS a ValidationError. Surface it as a real error so the capability
           // funnel reports a failed call, not a successful one carrying an error blob.
           if (isMastraValidationError(result)) {
@@ -118,7 +124,13 @@ export function mastra(): RatelAdapter<MastraTool, MastraDBMessage, MastraExt> {
         id: tool.id,
         description: tool.description,
         inputSchema: capabilitySchema(tool.id, tool.inputSchema as JSONSchema7),
-        execute: async (input) => tool.execute(input as Record<string, unknown>),
+        // Keep the whole live context opaque to the core. The stable private
+        // symbol lets any Mastra view over this catalog recover it, while a
+        // different adapter's carrier can never be mistaken for Mastra's.
+        execute: async (input, context) =>
+          tool.execute(input as Record<string, unknown>, {
+            [MASTRA_CONTEXT_KEY]: context,
+          }),
       }) as MastraTool;
     },
 
@@ -169,6 +181,13 @@ export function mastra(): RatelAdapter<MastraTool, MastraDBMessage, MastraExt> {
       };
     },
   };
+}
+
+function mastraContext(value: unknown): ToolExecutionContext | undefined {
+  if (value === null || typeof value !== "object" || !(MASTRA_CONTEXT_KEY in value)) {
+    return undefined;
+  }
+  return (value as { [MASTRA_CONTEXT_KEY]: ToolExecutionContext })[MASTRA_CONTEXT_KEY];
 }
 
 // Mastra exports this structural guard from 1.18 onward. Keep the equivalent

--- a/src/adapters/ts-mastra/src/mastra.ts
+++ b/src/adapters/ts-mastra/src/mastra.ts
@@ -1,6 +1,6 @@
 import type { MastraDBMessage, ToolsInput } from "@mastra/core/agent";
 import type { InputProcessor, ProcessInputArgs } from "@mastra/core/processors";
-import { createTool, isValidationError, noopObserve } from "@mastra/core/tools";
+import { createTool } from "@mastra/core/tools";
 import type {
   CatalogRegistration,
   JSONSchema7,
@@ -10,6 +10,11 @@ import type {
 } from "@ratel-ai/sdk";
 import { GET_SKILL_CONTENT_ID, INVOKE_TOOL_ID, SEARCH_CAPABILITIES_ID } from "@ratel-ai/sdk";
 import { z } from "zod";
+
+interface MastraValidationError {
+  error: true;
+  validationErrors: unknown;
+}
 
 /**
  * A Mastra tool — the per-entry type of Mastra's `ToolsInput` (a `createTool`
@@ -42,7 +47,14 @@ const RECALL_PROCESSOR_ID = "ratel-recall";
 // Mastra tool with just its args: `observe` is the only required field of
 // `ToolExecutionContext` (the createTool wrapper fills `requestContext` itself).
 // A tool reading `mastra` / `agent` / `workflow` / `abortSignal` sees `undefined`.
-const CATALOG_CONTEXT = { observe: noopObserve };
+const CATALOG_CONTEXT = {
+  observe: {
+    async span<T>(_name: string, fn: () => T | Promise<T>): Promise<T> {
+      return fn();
+    },
+    log(): void {},
+  },
+};
 
 /**
  * The Mastra adapter: `ratel(config).adaptTo(mastra())` gives the
@@ -85,10 +97,12 @@ export function mastra(): RatelAdapter<MastraTool, MastraDBMessage, MastraExt> {
           // required requestContext the fabricated context can't satisfy) — it
           // RETURNS a ValidationError. Surface it as a real error so the capability
           // funnel reports a failed call, not a successful one carrying an error blob.
-          if (isValidationError(result)) {
-            throw new Error(
-              (result as { message?: string }).message ?? "Mastra tool input validation failed",
-            );
+          if (isMastraValidationError(result)) {
+            const message =
+              "message" in result && typeof result.message === "string"
+                ? result.message
+                : "Mastra tool input validation failed";
+            throw new Error(message);
           }
           return result;
         },
@@ -155,6 +169,18 @@ export function mastra(): RatelAdapter<MastraTool, MastraDBMessage, MastraExt> {
       };
     },
   };
+}
+
+// Mastra exports this structural guard from 1.18 onward. Keep the equivalent
+// check local so the adapter also works with 1.11–1.17 without version probing.
+function isMastraValidationError(value: unknown): value is MastraValidationError {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "error" in value &&
+    value.error === true &&
+    "validationErrors" in value
+  );
 }
 
 // Hand-written, deliberately permissive zod schemas for the three capability

--- a/src/adapters/ts-mastra/src/mastra.type-test.ts
+++ b/src/adapters/ts-mastra/src/mastra.type-test.ts
@@ -8,8 +8,8 @@ import { mastra } from "./mastra.js";
 
 const view = ratel().adaptTo(mastra());
 
-// `expose()` returns tools assignable straight to an Agent's `ToolsInput` — no cast.
-const tools: ToolsInput = view.expose();
+// `modelTools()` returns tools assignable straight to an Agent's `ToolsInput` — no cast.
+const tools: ToolsInput = view.modelTools();
 
 // `recallProcessor()` is a Mastra `Processor` and, more specifically, an
 // `InputProcessor` (id + processInput), so it drops into `inputProcessors`.
@@ -22,7 +22,7 @@ const agent = new Agent({
   name: "type-test",
   instructions: "test",
   model: "openai/gpt-4o-mini",
-  tools: view.expose(),
+  tools: view.modelTools(),
   inputProcessors: [view.recallProcessor()],
 });
 

--- a/src/adapters/ts-mastra/src/mastra.type-test.ts
+++ b/src/adapters/ts-mastra/src/mastra.type-test.ts
@@ -1,0 +1,32 @@
+// Compile-only assertions that the adapter's outputs line up with `@mastra/core`'s
+// surface, so a drift in Mastra's types fails `tsc -p tsconfig.type-tests.json`
+// rather than at a host's call site.
+import { Agent, type ToolsInput } from "@mastra/core/agent";
+import type { InputProcessor, Processor } from "@mastra/core/processors";
+import { ratel } from "@ratel-ai/sdk";
+import { mastra } from "./mastra.js";
+
+const view = ratel().adaptTo(mastra());
+
+// `expose()` returns tools assignable straight to an Agent's `ToolsInput` — no cast.
+const tools: ToolsInput = view.expose();
+
+// `recallProcessor()` is a Mastra `Processor` and, more specifically, an
+// `InputProcessor` (id + processInput), so it drops into `inputProcessors`.
+const processor: Processor = view.recallProcessor();
+const inputProcessor: InputProcessor = view.recallProcessor();
+
+// Both slot into a real Agent construction with no cast.
+const agent = new Agent({
+  id: "type-test",
+  name: "type-test",
+  instructions: "test",
+  model: "openai/gpt-4o-mini",
+  tools: view.expose(),
+  inputProcessors: [view.recallProcessor()],
+});
+
+void tools;
+void processor;
+void inputProcessor;
+void agent;

--- a/src/adapters/ts-mastra/src/package-layout.test.ts
+++ b/src/adapters/ts-mastra/src/package-layout.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+interface PackageManifest {
+  private?: boolean;
+  license?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  publishConfig?: { access?: string; provenance?: boolean };
+}
+
+const manifest = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+) as PackageManifest;
+
+describe("published mastra-adapter dependency layout", () => {
+  it("carries no runtime dependencies — the adapter is pure glue", () => {
+    // Everything the adapter touches (`@mastra/core`, `zod`, `@ratel-ai/sdk`) is
+    // the host's to provide, so it ships as peers with zero runtime `dependencies`.
+    expect(manifest.dependencies ?? {}).toEqual({});
+  });
+
+  it("peers on @mastra/core@^1.51, zod (matching Mastra's range), and the workspace SDK", () => {
+    expect(manifest.peerDependencies?.["@mastra/core"]).toBe("^1.51.0");
+    // zod is a runtime peer (unlike the AI SDK adapter): the exposed capability
+    // tools carry hand-written zod schemas. The range matches @mastra/core's own
+    // zod peer so a Mastra app on zod 3.25.x resolves cleanly.
+    expect(manifest.peerDependencies?.zod).toBe("^3.25.0 || ^4.0.0");
+    expect(manifest.peerDependencies?.["@ratel-ai/sdk"]).toBe("workspace:^");
+  });
+
+  it("dev-pins @mastra/core to the live-verified release and the workspace SDK", () => {
+    // A pinned dev `@mastra/core` (not a range) keeps the codecs + type-tests
+    // honest against the exact release the adapter was verified on; the workspace
+    // SDK satisfies its own peer locally and forces the topological build edge.
+    expect(manifest.devDependencies?.["@mastra/core"]).toBe("1.51.0");
+    expect(manifest.devDependencies?.["@ratel-ai/sdk"]).toBe("workspace:^");
+  });
+
+  it("publishes public with provenance under MIT", () => {
+    expect(manifest.private).toBe(false);
+    expect(manifest.license).toBe("MIT");
+    expect(manifest.publishConfig?.access).toBe("public");
+    expect(manifest.publishConfig?.provenance).toBe(true);
+  });
+});

--- a/src/adapters/ts-mastra/src/package-layout.test.ts
+++ b/src/adapters/ts-mastra/src/package-layout.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 interface PackageManifest {
   private?: boolean;
   license?: string;
+  engines?: Record<string, string>;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
@@ -21,8 +22,8 @@ describe("published mastra dependency layout", () => {
     expect(manifest.dependencies ?? {}).toEqual({});
   });
 
-  it("peers on @mastra/core@^1.51, zod (matching Mastra's range), and the workspace SDK", () => {
-    expect(manifest.peerDependencies?.["@mastra/core"]).toBe("^1.51.0");
+  it("supports @mastra/core from 1.11 through 1.x", () => {
+    expect(manifest.peerDependencies?.["@mastra/core"]).toBe(">=1.11.0 <2");
     // zod is a runtime peer (unlike the AI SDK adapter): the exposed capability
     // tools carry hand-written zod schemas. The range matches @mastra/core's own
     // zod peer so a Mastra app on zod 3.25.x resolves cleanly.
@@ -30,12 +31,15 @@ describe("published mastra dependency layout", () => {
     expect(manifest.peerDependencies?.["@ratel-ai/sdk"]).toBe("workspace:^");
   });
 
-  it("dev-pins @mastra/core to the live-verified release and the workspace SDK", () => {
-    // A pinned dev `@mastra/core` (not a range) keeps the codecs + type-tests
-    // honest against the exact release the adapter was verified on; the workspace
-    // SDK satisfies its own peer locally and forces the topological build edge.
-    expect(manifest.devDependencies?.["@mastra/core"]).toBe("1.51.0");
+  it("dev-pins a concrete @mastra/core release and the workspace SDK", () => {
+    // CI replaces this exact dev version with the exact supported floor and reruns
+    // the suite; a range here would make either side of that matrix nondeterministic.
+    expect(manifest.devDependencies?.["@mastra/core"]).toMatch(/^\d+\.\d+\.\d+$/);
     expect(manifest.devDependencies?.["@ratel-ai/sdk"]).toBe("workspace:^");
+  });
+
+  it("matches Mastra's Node.js floor", () => {
+    expect(manifest.engines?.node).toBe(">=22.13.0");
   });
 
   it("publishes public with provenance under MIT", () => {

--- a/src/adapters/ts-mastra/src/package-layout.test.ts
+++ b/src/adapters/ts-mastra/src/package-layout.test.ts
@@ -14,7 +14,7 @@ const manifest = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf8"),
 ) as PackageManifest;
 
-describe("published mastra-adapter dependency layout", () => {
+describe("published mastra dependency layout", () => {
   it("carries no runtime dependencies — the adapter is pure glue", () => {
     // Everything the adapter touches (`@mastra/core`, `zod`, `@ratel-ai/sdk`) is
     // the host's to provide, so it ships as peers with zero runtime `dependencies`.

--- a/src/adapters/ts-mastra/tsconfig.json
+++ b/src/adapters/ts-mastra/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.type-test.ts"]
+}

--- a/src/adapters/ts-mastra/tsconfig.type-tests.json
+++ b/src/adapters/ts-mastra/tsconfig.type-tests.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/mastra.type-test.ts"],
+  "exclude": []
+}

--- a/src/sdk/ts/native/Cargo.toml
+++ b/src/sdk/ts/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratel-sdk-ts-native"
-version = "0.5.0" # locked to @ratel-ai/sdk; ships in the sdk-ts-v* unit (ADR-0008)
+version = "0.5.1-rc.1" # locked to @ratel-ai/sdk; ships in the sdk-ts-v* unit (ADR-0008)
 edition.workspace = true
 license = "MIT"
 repository.workspace = true


### PR DESCRIPTION
## OSI-16 — `@ratel-ai/mastra-adapter` (Phase 4, lane B)

Mastra adapter so Ratel speaks `@mastra/core`'s native tool/message shapes via `ratel(config).adaptTo(mastra())`. Implements the framework-adapter SPI (ADR-0013): the three codecs plus a per-turn recall `InputProcessor`.

**Stacked on `feat/ai-sdk-adapter`** (the base of this PR). GitHub auto-retargets to `main` as the stack merges.

### What
- `src/adapters/ts-mastra/` — `mastra()`: `ingest` / `expose` / `recallMessages` + `recallProcessor()`.
- `examples/mastra/` — adapter-based example (Mastra model-router string, mock-model test, diagnostic mode).
- Wiring: `pnpm-workspace.yaml`, adapters/root/examples READMEs, root `CLAUDE.md`, `ts.yml` example row.

### Design (verified via a throwaway live spike against `@mastra/core@1.51.0`)
- **ingest** reads Mastra's already-normalized input schema through the Standard-JSON-Schema spec, so tools built with **zod 3, zod 4, or a raw JSON Schema all catalog correctly** — no schema converter and no zod-version gate. (Supersedes the OSI-16 plan's "zod-4-only ingest" note, which assumed ingest saw the raw schema; `createTool` normalizes eagerly.)
- **expose** wraps the three capability tools with `createTool`, permissive `topK` (the core owns clamping), canonical parameter descriptions preserved; returns genuine `Tool` instances.
- **recallMessages** encodes the synthetic `search_capabilities` call+result as **one** assistant `MastraDBMessage` (`content.format: 2`, a single resolved `tool-invocation` part) — a `MastraDBMessage` has no `tool` role.
- **recallProcessor()** injects recall via `processInput` (once per user turn; confirmed live that the pair reaches the model prompt; not re-injected during the tool loop).
- Peers only: `@mastra/core@^1.51.0`, `zod@^3.25.0 || ^4.0.0` (matches Mastra's own zod peer), `@ratel-ai/sdk`; zero runtime dependencies.

### Tests
- `@ratel-ai/sdk/testkit` conformance battery **21/21, 0 skips**.
- Unit (codec edges, `ValidationError` surfacing, schema-description preservation), a real-Agent mock-model integration test, and a compile-only type-test.
- Full `pnpm -r build / typecheck / lint / test` green; `examples/mastra` mock-model test passes with no API key.

### Adversarial self-review (fixed before opening)
- `ingest` now surfaces Mastra's returned `ValidationError` as a thrown error (it previously framed a validation failure as a successful result).
- `zod` peer widened `^4.0.0` → `^3.25.0 || ^4.0.0` to match Mastra (a Mastra app on zod 3.25.x would otherwise hit ERESOLVE).
- `expose` preserves the capability tools' canonical parameter descriptions.
- dropped an unused `tsx` devDependency.

### TODO
- [ ] Record one real-key live run of `examples/mastra` (mock-model + diagnostic mode verified; the real-key run needs an `OPENAI_API_KEY`/`ANTHROPIC_API_KEY`).
