### PR TITLE
build: shrink SDK native addon ~26% via strip + thin LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,13 @@ authors = ["Agentified"]
 
 [workspace.dependencies]
 ratel-ai-core = { path = "src/core" }
+
+# Release builds ship as native addons (SDK cdylibs) where binary size is user-
+# facing install weight. `strip` drops symbol/debug tables that serve no runtime
+# purpose; `lto = "thin"` + `codegen-units = 1` let dead-code elimination cross
+# crate boundaries (unused candle-transformers models, gemm kernels). Must live
+# in the workspace root — cargo ignores `[profile]` in member manifests.
+[profile.release]
+strip = true
+lto = "thin"
+codegen-units = 1


### PR DESCRIPTION
## What

Add a `[profile.release]` to the **workspace-root** `Cargo.toml`:

```toml
[profile.release]
strip = true
lto = "thin"
codegen-units = 1
```

Release builds ship as native NAPI addons (SDK cdylibs) where binary size is user-facing install weight. The default release profile ships symbol/debug tables and skips cross-crate dead-code elimination.

`[profile]` **must** live in the workspace root — cargo silently ignores it in member manifests (`src/sdk/ts/native/Cargo.toml`).

## Measured impact

Same source (`0.5.0-rc.2`), comparing the compiled `sdk-ts` cdylib:

| Build config | Size | Δ |
|---|---|---|
| baseline (plain release) | 9.90 MB | — |
| `strip` only | 8.17 MB | -17.4% |
| **`strip` + `lto="thin"` + `codegen-units=1`** | **7.36 MB** | **-25.6%** |

- `strip` removes ~1.73MB of symbol/debug tables that serve no runtime purpose.
- `lto="thin"` + `codegen-units=1` remove a further ~0.81MB via cross-crate DCE (unused `candle-transformers` model architectures, gemm kernels).

On the published `.node` (10.9MB, +~1MB napi packaging/signature over the raw dylib) this lands the shipped artifact around **~8MB**.

## Scope

Applies to all release builds (`ratel-ai-core`, both SDK native addons). crates.io publishes source, not binaries, so this only affects locally/CI-built artifacts.

## Tradeoffs / follow-ups

- Adds LTO link time to release CI builds.
- `lto="thin"` generally *improves* the inference hot path, but given recent embedding-perf work this should be confirmed against ratel-bench rather than assumed.
- Not touched here: vendoring just `models::bert` out of `candle-transformers`. With LTO on, that's mostly a compile-time / dependency-surface win, not much further size reduction — better as a separate spike.