### PR TITLE
fix(mastra): review follow-ups (test guards, release wiring, docs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -616,20 +616,26 @@ jobs:
           node -e "const v = require('child_process').execSync('npm --version').toString().trim(); const [maj, min, patch] = v.split('.').map(Number); if (maj < 11 || (maj === 11 && (min < 5 || (min === 5 && patch < 1)))) { console.error('npm CLI ' + v + ' < 11.5.1 (required for Trusted Publishers)'); process.exit(1); } console.log('npm ' + v + ' OK');"
       - name: Install
         run: pnpm install --frozen-lockfile
+      # The `...` build closure pulls @ratel-ai/sdk, whose build compiles the native
+      # ML crate — set up cargo + a warm cache so the release isn't cold-compiling.
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src/sdk/ts/native
       # Build the adapter and its @ratel-ai/sdk workspace dependency (topo order).
       - name: Build TS
         run: pnpm --filter "@ratel-ai/mastra..." run build
-      # npm keeps `workspace:` specifiers verbatim, so pin the @ratel-ai/sdk peer to
-      # the concrete co-released version before publishing (ephemeral CI edit; not
-      # committed). Keeps the npm-OIDC dir publish + provenance identical to the
-      # other units rather than switching to `pnpm publish`.
-      - name: Pin the @ratel-ai/sdk peer dependency for publish
+      # npm keeps `workspace:` specifiers verbatim, so pin the @ratel-ai/sdk peer AND
+      # dev deps to the concrete co-released version before publishing (ephemeral CI
+      # edit; not committed). Keeps the npm-OIDC dir publish + provenance identical to
+      # the other units rather than switching to `pnpm publish`.
+      - name: Pin the @ratel-ai/sdk peer and dev dependencies for publish
         shell: bash
         run: |
           set -e
           sdk_ver=$(node -p "require('./src/sdk/ts/package.json').version")
-          SDK_VER="$sdk_ver" node -e "const fs=require('fs'); const f='./src/adapters/ts-mastra/package.json'; const p=require(f); p.peerDependencies['@ratel-ai/sdk']='^'+process.env.SDK_VER; fs.writeFileSync(f, JSON.stringify(p, null, 2) + '\n')"
-          echo "pinned @ratel-ai/sdk -> $(node -p "require('./src/adapters/ts-mastra/package.json').peerDependencies['@ratel-ai/sdk']")"
+          SDK_VER="$sdk_ver" node -e "const fs=require('fs'); const f='./src/adapters/ts-mastra/package.json'; const p=require(f); const v='^'+process.env.SDK_VER; p.peerDependencies['@ratel-ai/sdk']=v; p.devDependencies['@ratel-ai/sdk']=v; fs.writeFileSync(f, JSON.stringify(p, null, 2) + '\n')"
+          echo "pinned @ratel-ai/sdk -> $(node -p "const p=require('./src/adapters/ts-mastra/package.json'); p.peerDependencies['@ratel-ai/sdk'] + ' (peer), ' + p.devDependencies['@ratel-ai/sdk'] + ' (dev)'")"
       # Preflight dry-run BEFORE the real (immutable) publish, mirroring the SDK job.
       - name: Preflight — dry-run npm publish
         shell: bash
@@ -680,20 +686,26 @@ jobs:
           node -e "const v = require('child_process').execSync('npm --version').toString().trim(); const [maj, min, patch] = v.split('.').map(Number); if (maj < 11 || (maj === 11 && (min < 5 || (min === 5 && patch < 1)))) { console.error('npm CLI ' + v + ' < 11.5.1 (required for Trusted Publishers)'); process.exit(1); } console.log('npm ' + v + ' OK');"
       - name: Install
         run: pnpm install --frozen-lockfile
+      # The `...` build closure pulls @ratel-ai/sdk, whose build compiles the native
+      # ML crate — set up cargo + a warm cache so the release isn't cold-compiling.
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src/sdk/ts/native
       # Build the adapter and its @ratel-ai/sdk workspace dependency (topo order).
       - name: Build TS
         run: pnpm --filter "@ratel-ai/vercel-ai-sdk..." run build
-      # npm keeps `workspace:` specifiers verbatim, so pin the @ratel-ai/sdk peer to
-      # the concrete co-released version before publishing (ephemeral CI edit; not
-      # committed). Keeps the npm-OIDC dir publish + provenance identical to the
-      # other units rather than switching to `pnpm publish`.
-      - name: Pin the @ratel-ai/sdk peer dependency for publish
+      # npm keeps `workspace:` specifiers verbatim, so pin the @ratel-ai/sdk peer AND
+      # dev deps to the concrete co-released version before publishing (ephemeral CI
+      # edit; not committed). Keeps the npm-OIDC dir publish + provenance identical to
+      # the other units rather than switching to `pnpm publish`.
+      - name: Pin the @ratel-ai/sdk peer and dev dependencies for publish
         shell: bash
         run: |
           set -e
           sdk_ver=$(node -p "require('./src/sdk/ts/package.json').version")
-          SDK_VER="$sdk_ver" node -e "const fs=require('fs'); const f='./src/adapters/ts-vercel-ai-sdk/package.json'; const p=require(f); p.peerDependencies['@ratel-ai/sdk']='^'+process.env.SDK_VER; fs.writeFileSync(f, JSON.stringify(p, null, 2) + '\n')"
-          echo "pinned @ratel-ai/sdk -> $(node -p "require('./src/adapters/ts-vercel-ai-sdk/package.json').peerDependencies['@ratel-ai/sdk']")"
+          SDK_VER="$sdk_ver" node -e "const fs=require('fs'); const f='./src/adapters/ts-vercel-ai-sdk/package.json'; const p=require(f); const v='^'+process.env.SDK_VER; p.peerDependencies['@ratel-ai/sdk']=v; p.devDependencies['@ratel-ai/sdk']=v; fs.writeFileSync(f, JSON.stringify(p, null, 2) + '\n')"
+          echo "pinned @ratel-ai/sdk -> $(node -p "const p=require('./src/adapters/ts-vercel-ai-sdk/package.json'); p.peerDependencies['@ratel-ai/sdk'] + ' (peer), ' + p.devDependencies['@ratel-ai/sdk'] + ' (dev)'")"
       # Preflight dry-run BEFORE the real (immutable) publish, mirroring the SDK job.
       - name: Preflight — dry-run npm publish
         shell: bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -159,7 +159,8 @@ rstagi with a one-member team. Run the E2E locally per `e2e/README.md`.
    - `telemetry-py` → `src/telemetry/python/pyproject.toml` (PEP 440 spelling, e.g. `0.1.0rc1`).
    - `telemetry-ts-otlp` → `src/telemetry/ts-otlp/package.json`.
    - `vercel-ai-sdk` → `src/adapters/ts-vercel-ai-sdk/package.json`.
-     The four telemetry units and the adapter version independently; bump only the unit(s)
+   - `mastra` → `src/adapters/ts-mastra/package.json`.
+     The four telemetry units and the adapters version independently; bump only the unit(s)
      you are releasing.
 3. **Update the CHANGELOG:** run the `/changelog` skill (`.claude/skills/changelog/`) for
    `$UNIT`. It drafts entries with [git-cliff](https://git-cliff.org) scoped to the unit,

--- a/examples/mastra/README.md
+++ b/examples/mastra/README.md
@@ -12,9 +12,9 @@ pnpm -F @ratel-ai/example-mastra start
 pnpm -F @ratel-ai/example-mastra start "send an email to alice@example.com saying ship it"
 ```
 
-Without a model API key the script runs in diagnostic mode — it prints Ratel's initial BM25 ranking for the prompt and exits before any model call.
+Diagnostic mode: with neither `OPENAI_API_KEY` nor `ANTHROPIC_API_KEY` set, the script prints Ratel's initial BM25 ranking for the prompt and exits before any model call.
 
-The model is a [Mastra model-router](https://mastra.ai/en/docs/getting-started/model-providers) id (default `openai/gpt-4o-mini`), so there is no provider SDK dependency — the router resolves the key from the environment. Override with `MASTRA_MODEL=anthropic/claude-haiku-4-5` (and set the matching key).
+The model is a [Mastra model-router](https://mastra.ai/en/docs/getting-started/model-providers) id (default `openai/gpt-4o-mini`), so there is no provider SDK dependency — the router resolves the key from the environment. Set `OPENAI_API_KEY` to run the default model, or `MASTRA_MODEL=anthropic/claude-haiku-4-5` with `ANTHROPIC_API_KEY`. The auto-run gate checks only those two keys, so a different provider key alone still lands in diagnostic mode.
 
 ## Layout
 

--- a/src/adapters/ts-mastra/src/mastra.integration.test.ts
+++ b/src/adapters/ts-mastra/src/mastra.integration.test.ts
@@ -29,10 +29,10 @@ function viewWithDeployTool() {
 describe("Agent integration (the real Mastra loop)", () => {
   it("injects the recall pair into the model prompt for a user turn", async () => {
     const view = viewWithDeployTool();
-    const prompts: string[] = [];
+    const prompts: unknown[][] = [];
     const model = createMockModel({
       mockText: "deployed.",
-      spyGenerate: (props: { prompt: unknown }) => prompts.push(JSON.stringify(props.prompt)),
+      spyGenerate: (props: { prompt: unknown[] }) => prompts.push(props.prompt),
     });
     const agent = new Agent({
       id: "integration",
@@ -46,21 +46,25 @@ describe("Agent integration (the real Mastra loop)", () => {
     const result = await agent.generate("deploy to production");
     expect(result.text).toContain("deployed");
     expect(prompts).toHaveLength(1);
-    // Recall reached the model: the synthetic search_capabilities pair and the
-    // user's query both appear in the prompt the model actually saw.
-    expect(prompts[0]).toContain(SEARCH_CAPABILITIES_ID);
-    expect(prompts[0]).toContain("deploy to production");
-    // Exactly one recall pair for the turn — recall_0, never re-injected as recall_1.
-    expect(prompts[0]).toContain("recall_0");
-    expect(prompts[0]).not.toContain("recall_1");
+    // Both halves of the recall reached the model: Mastra expands the single
+    // format-2 assistant message into an assistant tool-CALL plus a role:"tool"
+    // tool-RESULT, so the recall id appears exactly twice. A dropped or reshaped
+    // tool-result half pushes the count below 2 and fails this assertion.
+    expect(recallIdOccurrences(prompts[0], "recall_0")).toBe(2);
+    expect(JSON.stringify(prompts[0])).toContain(SEARCH_CAPABILITIES_ID);
+    // The recalled capability id rode along in the tool-result payload — guards
+    // the result half specifically, not just the assistant tool-call.
+    expect(JSON.stringify(prompts[0])).toContain("deploy_app");
+    // Exactly one recall pair for the turn — never re-injected as recall_1.
+    expect(recallIdOccurrences(prompts[0], "recall_1")).toBe(0);
   });
 
   it("mints a fresh recall id per user turn (processInput = once per generation)", async () => {
     const view = viewWithDeployTool();
-    const prompts: string[] = [];
+    const prompts: unknown[][] = [];
     const model = createMockModel({
       mockText: "ok",
-      spyGenerate: (props: { prompt: unknown }) => prompts.push(JSON.stringify(props.prompt)),
+      spyGenerate: (props: { prompt: unknown[] }) => prompts.push(props.prompt),
     });
     const agent = new Agent({
       id: "integration2",
@@ -73,8 +77,8 @@ describe("Agent integration (the real Mastra loop)", () => {
 
     await agent.generate("deploy to production");
     await agent.generate("deploy the service again");
-    expect(prompts[0]).toContain("recall_0");
-    expect(prompts[1]).toContain("recall_1");
+    expect(recallIdOccurrences(prompts[0], "recall_0")).toBe(2);
+    expect(recallIdOccurrences(prompts[1], "recall_1")).toBe(2);
   });
 
   it("recalls via processInput, not processInputStep (no re-injection during the tool loop)", () => {
@@ -86,3 +90,11 @@ describe("Agent integration (the real Mastra loop)", () => {
     expect(processor.processInputStep).toBeUndefined();
   });
 });
+
+// Count a recall call id's occurrences in the raw prompt the model saw. A live
+// recall pair is rendered as two model messages (assistant tool-call + tool
+// result), so a surviving pair shows the id twice. Mirrors the sibling AI SDK
+// adapter's `generate-text.test.ts` helper.
+function recallIdOccurrences(prompt: unknown[], callId: string): number {
+  return JSON.stringify(prompt).split(callId).length - 1;
+}

--- a/src/adapters/ts-mastra/src/mastra.test.ts
+++ b/src/adapters/ts-mastra/src/mastra.test.ts
@@ -10,6 +10,10 @@ import {
 } from "@ratel-ai/sdk";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
+// A genuine zod 3 schema (the dev dep pins zod 4, which ships the v3 API under
+// its `zod/v3` export). The peer range allows zod 3, and Mastra routes v3 through
+// a different converter than v4, so the v3 ingest path needs its own coverage.
+import { z as z3 } from "zod/v3";
 import { mastra } from "./mastra.js";
 
 // A JSON Schema whose `properties` we read positionally in assertions.
@@ -90,6 +94,20 @@ describe("ingest codec", () => {
     // The `$schema` dialect marker is stripped; absent output schema stays absent.
     expect((reg.inputSchema as Record<string, unknown>).$schema).toBeUndefined();
     expect(reg.outputSchema).toBeUndefined();
+  });
+
+  it("ingests a tool built with a zod 3 schema (the peer's other converter)", () => {
+    const weather = createTool({
+      id: "weather",
+      description: "Get the weather in a location",
+      inputSchema: z3.object({ location: z3.string() }),
+      execute: async ({ location }) => ({ location, tempF: 70 }),
+    });
+    const reg = mastra().ingest("weather", weather);
+    if (reg === "passthrough") throw new Error("expected an executable registration");
+    const input = reg.inputSchema as JsonObjectSchema;
+    expect(input.type).toBe("object");
+    expect(input.properties?.location.type).toBe("string");
   });
 
   it("extracts JSON schema from a tool built with a raw JSON Schema", () => {

--- a/src/adapters/ts-mastra/src/mastra.ts
+++ b/src/adapters/ts-mastra/src/mastra.ts
@@ -123,7 +123,7 @@ export function mastra(): RatelAdapter<MastraTool, MastraDBMessage, MastraExt> {
       return createTool({
         id: tool.id,
         description: tool.description,
-        inputSchema: capabilitySchema(tool.id, tool.inputSchema as JSONSchema7),
+        inputSchema: capabilitySchema(tool.id),
         // Keep the whole live context opaque to the core. The stable private
         // symbol lets any Mastra view over this catalog recover it, while a
         // different adapter's carrier can never be mistaken for Mastra's.
@@ -172,9 +172,10 @@ export function mastra(): RatelAdapter<MastraTool, MastraDBMessage, MastraExt> {
               const query = lastUserText(args.messages);
               if (!query) return args.messages;
               // base.recall mints the id and returns [] on no hits (spending none).
-              const pair = await base.recall(query);
-              if (pair.length === 0) return args.messages;
-              return [...args.messages, ...pair];
+              // Mastra recall is a single message (unlike the AI SDK adapter's pair).
+              const recalled = await base.recall(query);
+              if (recalled.length === 0) return args.messages;
+              return [...args.messages, ...recalled];
             },
           };
         },
@@ -205,10 +206,9 @@ function isMastraValidationError(value: unknown): value is MastraValidationError
 // Hand-written, deliberately permissive zod schemas for the three capability
 // tools (the model-facing shapes). topK carries no int/min/max — the core owns
 // clamping, so an out-of-range value must reach it rather than being rejected
-// here. An unknown id (defensive: the core only exposes the three) passes the
-// catalog's own JSON Schema straight through — `createTool` accepts a raw JSON
-// Schema, so there is still no schema converter in the adapter.
-function capabilitySchema(id: string, fallback: JSONSchema7): z.ZodTypeAny {
+// here. The core only ever exposes these three ids, so an unknown id is a broken
+// invariant — throw rather than guess a schema.
+function capabilitySchema(id: string): z.ZodTypeAny {
   switch (id) {
     case SEARCH_CAPABILITIES_ID:
       // Descriptions mirror the core's canonical schema so the model keeps the
@@ -237,7 +237,7 @@ function capabilitySchema(id: string, fallback: JSONSchema7): z.ZodTypeAny {
           .describe("id of the skill to load (use search_capabilities to find available ids)"),
       });
     default:
-      return fallback as unknown as z.ZodTypeAny;
+      throw new Error(`mastra: no capability schema for id "${id}"`);
   }
 }
 


### PR DESCRIPTION
Clears the 8 review findings + 1 cleanup left after #119 merged the `@ratel-ai/mastra` adapter. Adapter behavior is unchanged (it was already correct); this hardens the tests around its invariants and aligns release wiring/docs. **None block a release.**

## Test guards
- **F1/F5** — `mastra.integration.test.ts` now asserts the recall reaches the model as BOTH halves: the recall id must occur exactly twice (assistant tool-call + `role:"tool"` result) via an occurrence-count helper mirroring the AI SDK adapter, plus a `deploy_app` payload assertion that guards the result half specifically. Replaces the old substring/tautological checks (proven to bite: drops below 2 if the tool-result half is lost).
- **F2** — adds a zod-3 `ingest` test (`zod/v3` subpath) so the peer's `^3` path is covered — Mastra routes v3 through a different converter than v4.

## Release wiring (both `publish-mastra` and `publish-vercel-ai-sdk` jobs)
- **F3** — the pin step now rewrites `devDependencies['@ratel-ai/sdk']` alongside the peer, so a CI/OIDC publish no longer ships `workspace:^` verbatim in the published devDeps (matches the local `publish-rc.sh` path).
- **F4** — adds `dtolnay/rust-toolchain` + `Swatinem/rust-cache` before "Build TS" (the `...` build closure compiles the native SDK crate), so the release isn't cold-compiling uncached.

## Refactor (`mastra.ts`)
- **F6** — rename `pair` → `recalled` in `recallProcessor` (Mastra recall is a single message, not a pair).
- **F9** — drop the dead `capabilitySchema` `fallback` param + `as JSONSchema7` cast; the unreachable `default` branch now throws (the core only ever exposes the three fixed capability ids; passthrough tools bypass `expose`).

## Docs
- **F7** — add `mastra` to the RELEASING.md bump-step list; pluralize "adapters".
- **F8** — reword the mastra example README so diagnostic mode matches the two-provider gate (`OPENAI_API_KEY`/`ANTHROPIC_API_KEY`), instead of overpromising "any provider key".

Verified locally: `pnpm -r build`; adapter test (53/53) + typecheck + lint; example agent test + diagnostic mode; F3 rewrite validated against temp manifests; release.yml YAML valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
