### PR TITLE
release: sdk-ts-v0.5.2, sdk-py-v0.5.1, mastra-v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ version = "0.1.0"
 
 [[package]]
 name = "ratel-sdk-python-native"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "pyo3",
  "pythonize",
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "ratel-sdk-ts-native"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "napi",
  "napi-build",

--- a/src/adapters/ts-mastra/CHANGELOG.md
+++ b/src/adapters/ts-mastra/CHANGELOG.md
@@ -6,26 +6,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
-## [0.1.0-rc.4] - 2026-07-21
-
-### Fixed
-
-- Preserve Mastra's complete live `ToolExecutionContext` through `invoke_tool`, including `requestContext`, workspace, agent thread/resource metadata, `mastra`, and `abortSignal`. Required `requestContextSchema` values now validate against the caller's real context, and concurrent invocations remain isolated. Direct `ToolCatalog.invoke` calls still use the documented context-free fallback. This requires the paired `@ratel-ai/sdk` release containing opaque invocation-context forwarding.
-
-## [0.1.0-rc.3] - 2026-07-21
-
-### Changed
-
-- Lower the supported `@mastra/core` floor from 1.51.0 to 1.11.0. The adapter now owns the no-op observer and validation-error guard locally instead of importing helpers added in later Mastra releases; CI runs its build, full suite, and type tests against 1.11.0, 1.31.0, and 1.51.0. Align the declared Node.js floor with Mastra at 22.13.0.
-
-## [0.1.0-rc.2] - 2026-07-21
-
-### Changed
-
-- Follow the SDK's model-facing `expose()` → `modelTools()` rename at the call sites (the adapter's `expose` SPI codec is unchanged). Rebased onto the current adapter SPI and built against `@ratel-ai/sdk@0.5.1-rc.0`.
-
-## [0.1.0-rc.1] - 2026-07-18
+## [0.1.0] - 2026-07-24
 
 ### Added
 
-- Initial release: `@ratel-ai/mastra`, the [Mastra](https://mastra.ai) (`@mastra/core`) adapter for Ratel. (Supersedes the pre-release `@ratel-ai/mastra-adapter@0.1.0-rc.1`, published under the old name before the rename.) `ratel(config).adaptTo(mastra())` speaks Mastra's native `Tool` (from `createTool`) and `MastraDBMessage` shapes through the framework-adapter SPI (ADR-0013): the `ingest` / `expose` / `recallMessages` codecs plus a per-turn recall idiom — `recallProcessor()`, a Mastra `Processor` you drop into an Agent's `inputProcessors`. `ingest` reads Mastra's normalized input schema (so zod 3, zod 4, and raw JSON Schema tools all work); `expose` wraps the three capability tools as genuine `createTool` results; `recallMessages` encodes the synthetic `search_capabilities` call+result as one assistant message (`content.format: 2`, a single resolved `tool-invocation` part). Peers `@mastra/core@^1.51.0`, `zod@^3.25.0 || ^4.0.0`, and `@ratel-ai/sdk` with zero runtime dependencies; passes the `@ratel-ai/sdk/testkit` conformance battery (21 cases).
+- Initial release: `@ratel-ai/mastra`, the [Mastra](https://mastra.ai) (`@mastra/core`) adapter for Ratel. `ratel(config).adaptTo(mastra())` speaks Mastra's native `Tool` (from `createTool`) and `MastraDBMessage` shapes through the framework-adapter SPI (ADR-0013): the `ingest` / `expose` / `recallMessages` codecs plus a per-turn recall idiom — `recallProcessor()`, a Mastra `Processor` you drop into an Agent's `inputProcessors`. `ingest` reads Mastra's normalized input schema (so zod 3, zod 4, and raw JSON Schema tools all work); `expose` wraps the three capability tools as genuine `createTool` results; `recallMessages` encodes the synthetic `search_capabilities` call+result as one assistant message (`content.format: 2`, a single resolved `tool-invocation` part). Tool execution preserves Mastra's complete live `ToolExecutionContext` through `invoke_tool` — `requestContext`, workspace, agent thread/resource metadata, `mastra`, and `abortSignal` — so `requestContextSchema` values validate against the caller's real context and concurrent invocations stay isolated (direct `ToolCatalog.invoke` calls use the documented context-free fallback). Peers `@mastra/core@>=1.11.0 <2` (the adapter owns its no-op observer and validation-error guard locally, and is CI-tested against 1.11.0, 1.31.0, and 1.51.0), `zod@^3.25.0 || ^4.0.0`, and `@ratel-ai/sdk` (Node.js ≥ 22.13.0) with zero runtime dependencies; passes the `@ratel-ai/sdk/testkit` conformance battery.

--- a/src/adapters/ts-mastra/package.json
+++ b/src/adapters/ts-mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/mastra",
-  "version": "0.1.0-rc.4",
+  "version": "0.1.0",
   "description": "Mastra adapter for Ratel — adapts the context-engineering core to @mastra/core tool and message shapes, with a per-turn recall input processor.",
   "private": false,
   "type": "module",

--- a/src/sdk/python/CHANGELOG.md
+++ b/src/sdk/python/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-07-24
+
+### Changed
+
+- Ship the native extension built with symbol stripping and thin LTO (`[profile.release]`), materially shrinking the wheel's compiled binary. No API or behavior change.
+
 ## [0.5.0] - 2026-07-20
 
 ### Added

--- a/src/sdk/python/native/Cargo.toml
+++ b/src/sdk/python/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratel-sdk-python-native"
-version = "0.5.0" # locked to ratel-ai (PyPI); ships in the sdk-py-v* unit (ADR-0008)
+version = "0.5.1" # locked to ratel-ai (PyPI); ships in the sdk-py-v* unit (ADR-0008)
 edition.workspace = true
 license = "MIT"
 repository.workspace = true

--- a/src/sdk/python/pyproject.toml
+++ b/src/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ratel-ai"
-version = "0.5.0"
+version = "0.5.1"
 description = "Python SDK for Ratel — context engineering platform for AI agents. BM25 tool retrieval, MCP ingestion, framework-neutral capability tools."
 readme = "README.md"
 license = { file = "LICENSE.md" }

--- a/src/sdk/ts/CHANGELOG.md
+++ b/src/sdk/ts/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-07-24
+
+### Changed
+
+- Ship the native addon built with symbol stripping and thin LTO (`[profile.release]`), shrinking the `.node` binary ~26% (9.90 MB → 7.36 MB on the sdk-ts cdylib). No API or behavior change.
+
 ## [0.5.1] - 2026-07-23
 
 ### Added

--- a/src/sdk/ts/native/Cargo.toml
+++ b/src/sdk/ts/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratel-sdk-ts-native"
-version = "0.5.1" # locked to @ratel-ai/sdk; ships in the sdk-ts-v* unit (ADR-0008)
+version = "0.5.2" # locked to @ratel-ai/sdk; ships in the sdk-ts-v* unit (ADR-0008)
 edition.workspace = true
 license = "MIT"
 repository.workspace = true

--- a/src/sdk/ts/npm/darwin-arm64/package.json
+++ b/src/sdk/ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/sdk-darwin-arm64",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "cpu": [
     "arm64"
   ],

--- a/src/sdk/ts/npm/darwin-x64/package.json
+++ b/src/sdk/ts/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/sdk-darwin-x64",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "cpu": [
     "x64"
   ],

--- a/src/sdk/ts/npm/linux-arm64-gnu/package.json
+++ b/src/sdk/ts/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/sdk-linux-arm64-gnu",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "cpu": [
     "arm64"
   ],

--- a/src/sdk/ts/npm/linux-x64-gnu/package.json
+++ b/src/sdk/ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/sdk-linux-x64-gnu",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "cpu": [
     "x64"
   ],

--- a/src/sdk/ts/npm/win32-x64-msvc/package.json
+++ b/src/sdk/ts/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/sdk-win32-x64-msvc",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "cpu": [
     "x64"
   ],

--- a/src/sdk/ts/package.json
+++ b/src/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/sdk",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "TypeScript SDK for Ratel — context engineering platform for AI agents. BM25 tool retrieval, MCP ingestion, framework-neutral capability tools.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
Cuts three GA release units (no RCs, per request). `core` is deliberately **not** released — no `src/core` change since `core-v0.5.0`, and the workspace `[profile.release]` change doesn't affect the crates.io crate.

| Unit | From → To | What ships |
|---|---|---|
| `sdk-ts` | 0.5.1 → **0.5.2** | strip + thin-LTO native addon (`f1bb8a5`): `.node` 9.90 MB → 7.36 MB (−26%). No API change. |
| `sdk-py` | 0.5.0 → **0.5.1** | same profile → smaller wheel binary. No API change. |
| `mastra` | 0.1.0-rc.4 → **0.1.0** | GA graduation; rc.1–rc.4 changelog collapsed into one `## [0.1.0]`. |

**Verification (local):**
- `check-release-tag.mjs` green for all 3 tags (`latest` dist-tag).
- `pnpm --frozen-lockfile` clean; `Cargo.lock` synced (`cargo update --workspace`).
- sdk native rebuilt with the profile → **7.4 MB** addon confirmed.
- mastra: typecheck clean, **53/53** tests pass.

**Note on the mastra peer:** `@ratel-ai/sdk: "workspace:^"` resolves at pack time to the workspace SDK version at the tagged commit. Since all three bumps are in one commit (sdk-ts = 0.5.2), published `@ratel-ai/mastra@0.1.0` will peer-depend on `@ratel-ai/sdk@^0.5.2`. mastra only needs the opaque-context forwarding from 0.5.1, so if you'd prefer the looser `^0.5.1`, say so and I'll split mastra onto a pre-SDK-bump commit.

After merge, tag on `main` (publish order: SDKs first, then mastra):
```
git tag sdk-ts-v0.5.2 && git tag sdk-py-v0.5.1 && git tag mastra-v0.1.0
git push origin main sdk-ts-v0.5.2 sdk-py-v0.5.1   # wait for sdk-ts publish
git push origin mastra-v0.1.0
```
Then `verify-install.yml` per unit.