### PR TITLE
feat(telemetry): add startTelemetry with processor composition and forceFlush

### DIFF
--- a/src/telemetry/CONVENTIONS.md
+++ b/src/telemetry/CONVENTIONS.md
@@ -263,3 +263,11 @@ A caller who already runs the OTel SDK skips `init()` and adds `ratelSpanProcess
 signal filter and can be overridden. Installing `@ratel-ai/telemetry-otlp` or the Python `[otlp]`
 extra supplies the complete exporter/SDK implementation; callers do not assemble the individual
 OpenTelemetry packages themselves.
+
+**Composition on the owned provider (TS).** The TS turnkey entry is now `startTelemetry`
+(`init` retained as a back-compat alias). Beyond `spanFilter`, it accepts host `spanProcessors`
+registered alongside Ratel's on the same owned provider — one span stream fans out to all of
+them, each applying its own filter — so a greenfield caller dual-exports (e.g. to Langfuse)
+without ceding the global provider to a foreign one. The returned handle adds `forceFlush()`
+(drain every registered processor; for serverless/jobs) beside `shutdown()`. Additive per
+ADR-0007 schema discipline; the Python helper keeps the `init()` surface until it follows.

--- a/src/telemetry/ts-otlp/README.md
+++ b/src/telemetry/ts-otlp/README.md
@@ -1,12 +1,14 @@
 # `@ratel-ai/telemetry-otlp`
 
 The OTLP exporter surface for Ratel telemetry over the OTel-free [`@ratel-ai/telemetry`](../ts/README.md)
-vocabulary: turnkey `init()` wiring for a greenfield app, plus a composable `ratelSpanProcessor`
-for coexisting with a provider a partner already owns. `init()` wires an OTLP `http/protobuf`
-exporter from `RATEL_URL` + `RATEL_API_KEY` (or explicit `{ endpoint, apiKey, headers }`) with a
-`service.name` resource and batch processor over the
-[OpenTelemetry JS SDK](https://opentelemetry.io/docs/languages/js/), registers it as the global
-tracer provider, and returns a shutdown handle. It is split from the vocabulary package
+vocabulary: turnkey `startTelemetry()` wiring for a greenfield app (with `init` retained as a
+back-compat alias), plus a composable `ratelSpanProcessor` for coexisting with a provider a partner
+already owns. `startTelemetry()` wires an OTLP `http/protobuf` exporter from `RATEL_URL` +
+`RATEL_API_KEY` (or explicit `{ endpoint, apiKey, headers }`) with a `service.name` resource and
+batch processor over the [OpenTelemetry JS SDK](https://opentelemetry.io/docs/languages/js/),
+registers it as the global tracer provider, and returns a handle with `forceFlush()` and
+`shutdown()`. Pass host processors via `spanProcessors` to fan the same span stream out to another
+backend (e.g. Langfuse) without ceding the provider. It is split from the vocabulary package
 (ADR-0007) so importing the `ratel.*` constants never pulls the OpenTelemetry SDK.
 
 ## Usage
@@ -14,10 +16,10 @@ tracer provider, and returns a shutdown handle. It is split from the vocabulary 
 ```ts
 import { trace } from "@opentelemetry/api";
 import { EXECUTE_TOOL, GEN_AI_OPERATION_NAME, GEN_AI_TOOL_NAME, Origin, RATEL_ORIGIN } from "@ratel-ai/telemetry";
-import { init } from "@ratel-ai/telemetry-otlp";
+import { startTelemetry } from "@ratel-ai/telemetry-otlp";
 
 // Wire the exporter from RATEL_URL + RATEL_API_KEY once at startup.
-const telemetry = init();
+const telemetry = startTelemetry();
 
 // Emit a standard gen_ai `execute_tool` span enriched with the ratel.* overlay.
 const span = trace.getTracer("my-agent").startSpan(EXECUTE_TOOL, {
@@ -29,19 +31,23 @@ const span = trace.getTracer("my-agent").startSpan(EXECUTE_TOOL, {
 });
 span.end();
 
-await telemetry.shutdown(); // flush the exporter on exit
+await telemetry.forceFlush(); // drain pending spans (serverless / batch jobs)
+await telemetry.shutdown(); // flush + stop the exporter on exit
 ```
 
 Explicit options beat the environment: an explicit `apiKey` sets the Bearer header, and the
 `RATEL_API_KEY` fallback never overrides an `Authorization` header you pass yourself. On first
-setup, pass `enabled: false` to get a no-op shutdown handle without requiring endpoint
-configuration, or `spanFilter` to narrow the spans exported by the turnkey provider (the default
-exports every span). Repeated `init()` calls return the exact handle from the first successful
-Ratel-owned initialization—even if a later caller is disabled—so hot reload and multiple callers
-do not fight over the global provider; the first call's configuration remains authoritative, and
-shutting that shared handle down stops export for every caller. A foreign provider still produces
-the actionable `ratelSpanProcessor` error before endpoint validation. Shutdown is terminal: after
-`handle.shutdown()`, a later `init()` throws (call `trace.disable()` first to re-initialize).
+setup, pass `enabled: false` to get a no-op handle without requiring endpoint configuration, or
+`spanFilter` to narrow the spans exported by the turnkey provider (the default exports every span).
+Pass `spanProcessors: [...]` to compose host processors (e.g. `new LangfuseSpanProcessor()`) onto
+the same owned provider — every finished span fans out to all of them, each applying its own filter
+— and call `handle.forceFlush()` to drain them all (serverless / jobs). Repeated `startTelemetry`
+calls return the exact handle from the first successful Ratel-owned initialization—even if a later
+caller is disabled—so hot reload and multiple callers do not fight over the global provider; the
+first call's configuration remains authoritative, and shutting that shared handle down stops export
+for every caller. A foreign provider still produces the actionable `ratelSpanProcessor` error before
+endpoint validation. Shutdown is terminal: after `handle.shutdown()`, a later call throws (call
+`trace.disable()` first to re-initialize).
 
 A complete, offline-runnable version (console exporter + a `ratel.search` → `execute_tool` trace)
 is in
@@ -50,7 +56,7 @@ is in
 ## Coexisting with another provider (Langfuse, the Vercel AI SDK, ...)
 
 OpenTelemetry's model is **one provider, many span-processors**. When a partner already owns
-the provider, add `ratelSpanProcessor` to it instead of calling `init()` — every span fans out
+the provider, add `ratelSpanProcessor` to it instead of calling `startTelemetry()` — every span fans out
 to both, and Ratel ingests only the `gen_ai.*` / `ratel.*` signal (the default
 `ratelSignalFilter`), so the framework's `ai.*` wrapper noise stays out:
 
@@ -96,7 +102,8 @@ pnpm --filter @ratel-ai/telemetry-otlp lint
 pnpm --filter @ratel-ai/telemetry-otlp test
 ```
 
-The tests cover disabled, filtered, idempotent, misconfigured, and foreign-provider `init()`
-behavior; the published dependency layout; and that `ratelSpanProcessor` forwards only the spans
-its filter accepts. Endpoint/auth resolution is covered in
+The tests cover disabled, filtered, idempotent, misconfigured, and foreign-provider `startTelemetry`
+behavior, host-processor composition and `forceFlush` fan-out, the `init` alias, the published
+dependency layout, and that `ratelSpanProcessor` forwards only the spans its filter accepts.
+Endpoint/auth resolution is covered in
 [`@ratel-ai/telemetry`](../ts/README.md) (the pure `resolveOtlpConfig`).

--- a/src/telemetry/ts-otlp/src/index.ts
+++ b/src/telemetry/ts-otlp/src/index.ts
@@ -17,7 +17,7 @@ export {
   type ResolvedOtlpConfig,
   resolveOtlpConfig,
 } from "@ratel-ai/telemetry";
-export { init, type TelemetryHandle, type TelemetryInitOptions } from "./init.js";
+export { init, startTelemetry, type TelemetryHandle, type TelemetryInitOptions } from "./init.js";
 export {
   type RatelSpanProcessorOptions,
   ratelSignalFilter,

--- a/src/telemetry/ts-otlp/src/init.test.ts
+++ b/src/telemetry/ts-otlp/src/init.test.ts
@@ -1,9 +1,13 @@
 import { trace } from "@opentelemetry/api";
-import { BatchSpanProcessor, type ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import {
+  BatchSpanProcessor,
+  type ReadableSpan,
+  type SpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { ENDPOINT_ENV } from "@ratel-ai/telemetry";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { init } from "./init.js";
+import { init, startTelemetry } from "./init.js";
 
 describe("init", () => {
   // init() registers a global provider; reset it so each case starts clean.
@@ -141,6 +145,83 @@ describe("init", () => {
       if (saved === undefined) delete process.env[ENDPOINT_ENV];
       else process.env[ENDPOINT_ENV] = saved;
       await existing.shutdown();
+    }
+  });
+});
+
+describe("startTelemetry", () => {
+  // startTelemetry registers a global provider; reset it so each case starts clean.
+  afterEach(() => {
+    trace.disable();
+    vi.restoreAllMocks();
+  });
+
+  it("returns a handle exposing forceFlush and shutdown", async () => {
+    const handle = startTelemetry({ endpoint: "http://localhost:4318/v1/traces" });
+    try {
+      expect(typeof handle.forceFlush).toBe("function");
+      expect(typeof handle.shutdown).toBe("function");
+      await expect(handle.forceFlush()).resolves.toBeUndefined();
+    } finally {
+      await handle.shutdown().catch(() => {});
+    }
+  });
+
+  it("keeps init working as a back-compat alias carrying the new handle shape", async () => {
+    const handle = init({ endpoint: "http://localhost:4318/v1/traces" });
+    try {
+      expect(typeof handle.forceFlush).toBe("function");
+      expect(typeof handle.shutdown).toBe("function");
+    } finally {
+      await handle.shutdown().catch(() => {});
+    }
+  });
+
+  it("fans finished spans out to host spanProcessors on the Ratel-owned provider", async () => {
+    // Neutralize the Ratel BatchSpanProcessor's real export path (no network in unit tests);
+    // the host processor below is a plain object, so its onEnd stays observable.
+    vi.spyOn(BatchSpanProcessor.prototype, "onEnd").mockImplementation(() => {});
+    const hostOnEnd = vi.fn();
+    const host: SpanProcessor = {
+      onStart: () => {},
+      onEnd: hostOnEnd,
+      forceFlush: async () => {},
+      shutdown: async () => {},
+    };
+    const handle = startTelemetry({
+      endpoint: "http://localhost:4318/v1/traces",
+      spanProcessors: [host],
+    });
+    try {
+      trace.getTracer("test").startSpan("ratel.search").end();
+
+      // The host processor is a first-class entry on the same provider, so it sees the
+      // provider's whole span stream — independent of the Ratel processor's own filter.
+      expect(hostOnEnd).toHaveBeenCalledTimes(1);
+      expect((hostOnEnd.mock.calls[0]?.[0] as ReadableSpan).name).toBe("ratel.search");
+    } finally {
+      await handle.shutdown().catch(() => {});
+    }
+  });
+
+  it("flushes every registered processor when the handle is force-flushed", async () => {
+    const hostForceFlush = vi.fn(async () => {});
+    const host: SpanProcessor = {
+      onStart: () => {},
+      onEnd: () => {},
+      forceFlush: hostForceFlush,
+      shutdown: async () => {},
+    };
+    const handle = startTelemetry({
+      endpoint: "http://localhost:4318/v1/traces",
+      spanProcessors: [host],
+    });
+    try {
+      await handle.forceFlush();
+
+      expect(hostForceFlush).toHaveBeenCalledTimes(1);
+    } finally {
+      await handle.shutdown().catch(() => {});
     }
   });
 });

--- a/src/telemetry/ts-otlp/src/init.ts
+++ b/src/telemetry/ts-otlp/src/init.ts
@@ -1,36 +1,49 @@
 /**
- * `init()` — the turnkey greenfield path: sugar over the standard OpenTelemetry JS SDK
- * that wires an OTLP `http/protobuf` span exporter at the Ratel endpoint and registers a
- * provider Ratel owns. No custom transport, no schema (ADR-0007, CONVENTIONS.md § init()
- * surface). The `ratel.*` vocabulary and the pure OTLP config resolution live in
- * `@ratel-ai/telemetry`; this package adds only the exporter wiring.
+ * `startTelemetry()` — the turnkey greenfield path: sugar over the standard OpenTelemetry JS
+ * SDK that wires an OTLP `http/protobuf` span exporter at the Ratel endpoint and registers a
+ * provider Ratel owns. Host span processors passed via `spanProcessors` compose onto that same
+ * provider, so a single call dual-exports (e.g. to Langfuse) without a foreign provider. No
+ * custom transport, no schema (ADR-0007, CONVENTIONS.md § init() surface). The `ratel.*`
+ * vocabulary and the pure OTLP config resolution live in `@ratel-ai/telemetry`; this package
+ * adds only the exporter wiring. `init` is the back-compat alias for the pre-composition name.
  *
  * When a partner already runs their own OTel provider (Langfuse, the Vercel AI SDK, ...),
- * `init()` cannot take over the global provider — it throws, pointing at
+ * `startTelemetry` cannot take over the global provider — it throws, pointing at
  * {@link ratelSpanProcessor}, which composes onto the existing provider instead.
  */
 
 import { ProxyTracerProvider, trace } from "@opentelemetry/api";
 import { resourceFromAttributes } from "@opentelemetry/resources";
+import type { SpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import { type InitOptions, resolveOtlpConfig } from "@ratel-ai/telemetry";
 import { ratelSpanProcessor, type SpanFilter } from "./processor.js";
 
-/** Handle returned by {@link init}; `shutdown()` flushes and stops the exporter. */
+/**
+ * Handle returned by {@link startTelemetry}. `forceFlush()` drains every registered span
+ * processor's pending spans to its exporter (serverless/jobs); `shutdown()` flushes and stops.
+ */
 export interface TelemetryHandle {
+  forceFlush(): Promise<void>;
   shutdown(): Promise<void>;
 }
 
-/** Options for the turnkey {@link init} path. */
+/** Options for the turnkey {@link startTelemetry} path. */
 export interface TelemetryInitOptions extends InitOptions {
   /** On first setup, set false to skip configuration and provider registration. */
   enabled?: boolean;
-  /** Override the default filter; `init()` forwards every span when omitted. */
+  /** Override the default filter; `startTelemetry` forwards every span when omitted. */
   spanFilter?: SpanFilter;
+  /**
+   * Host OTel span processors (e.g. `new LangfuseSpanProcessor()`) to register alongside
+   * Ratel's on the owned provider. Every processor sees the same span stream; each does its
+   * own filtering. This is the composition seam for dual-export without a foreign provider.
+   */
+  spanProcessors?: SpanProcessor[];
 }
 
-const NOOP_HANDLE: TelemetryHandle = { shutdown: async () => {} };
+const NOOP_HANDLE: TelemetryHandle = { forceFlush: async () => {}, shutdown: async () => {} };
 const ACCEPT_ALL_SPANS: SpanFilter = () => true;
 const RATEL_PROVIDER_HANDLE = Symbol.for("@ratel-ai/telemetry-otlp/provider-handle");
 /** Marks a Ratel-owned provider whose handle has been shut down (its exporter is dead). */
@@ -39,19 +52,21 @@ const NOOP_GLOBAL_PROVIDER = new ProxyTracerProvider().getDelegate();
 
 /**
  * Wire an OTLP `http/protobuf` exporter + batch processor + `service.name` resource over
- * a `NodeTracerProvider`, register it as the global provider, and return a shutdown handle.
- * Everything else is the untouched OTel SDK.
+ * a `NodeTracerProvider`, register it as the global provider, and return a handle exposing
+ * `forceFlush()` (drain every registered processor) and `shutdown()`. Everything else is the
+ * untouched OTel SDK.
  *
- * `init()` owns the global provider, so it exports every span by default (unlike
+ * `startTelemetry` owns the global provider, so it exports every span by default (unlike
  * {@link ratelSpanProcessor}, whose default `gen_ai.*`/`ratel.*` filter exists for sharing a
- * provider). Pass `spanFilter` to narrow that set, or `enabled: false` for a no-op handle on
+ * provider). Pass `spanFilter` to narrow the Ratel side, `spanProcessors` to fan the same span
+ * stream out to host processors (Langfuse, ...), or `enabled: false` for a no-op handle on
  * first setup. Repeated calls return the existing handle when Ratel already owns the active
  * provider—even if a later caller is disabled—so shutting that handle down stops export for
  * every caller. It throws with a pointer to {@link ratelSpanProcessor} when a foreign provider
- * is registered. Shutdown is terminal: after `handle.shutdown()`, a later `init()` throws
- * rather than hand back the dead handle (call `trace.disable()` first to re-initialize).
+ * is registered. Shutdown is terminal: after `handle.shutdown()`, a later call throws rather
+ * than hand back the dead handle (call `trace.disable()` first to re-initialize).
  */
-export function init(opts: TelemetryInitOptions = {}): TelemetryHandle {
+export function startTelemetry(opts: TelemetryInitOptions = {}): TelemetryHandle {
   const activeProvider = activeGlobalProvider();
   const existingHandle = ratelOwnedHandle(activeProvider);
   if (existingHandle) {
@@ -59,7 +74,12 @@ export function init(opts: TelemetryInitOptions = {}): TelemetryHandle {
     return existingHandle;
   }
 
-  const { enabled = true, spanFilter = ACCEPT_ALL_SPANS, ...configOpts } = opts;
+  const {
+    enabled = true,
+    spanFilter = ACCEPT_ALL_SPANS,
+    spanProcessors = [],
+    ...configOpts
+  } = opts;
   if (!enabled) return NOOP_HANDLE;
   if (activeProvider !== NOOP_GLOBAL_PROVIDER) throw foreignProviderError();
 
@@ -67,14 +87,18 @@ export function init(opts: TelemetryInitOptions = {}): TelemetryHandle {
   const { serviceName } = resolveOtlpConfig(configOpts);
   const provider = new NodeTracerProvider({
     resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: serviceName }),
-    spanProcessors: [ratelSpanProcessor({ ...configOpts, spanFilter })],
+    // Ratel's processor plus any host processors, all on one provider: every finished span
+    // fans out to all of them, each applying its own filter.
+    spanProcessors: [ratelSpanProcessor({ ...configOpts, spanFilter }), ...spanProcessors],
   });
   const handle: TelemetryHandle = {
+    // Delegate to the provider so every registered processor (Ratel's + hosts') drains.
+    forceFlush: () => provider.forceFlush(),
     shutdown: async () => {
       try {
         await provider.shutdown();
       } finally {
-        // Flag the dead provider so a later init() fails loud instead of returning this handle.
+        // Flag the dead provider so a later startTelemetry() fails loud instead of returning it.
         Object.defineProperty(provider, RATEL_PROVIDER_SHUTDOWN, {
           value: true,
           configurable: true,
@@ -96,6 +120,9 @@ export function init(opts: TelemetryInitOptions = {}): TelemetryHandle {
   return handle;
 }
 
+/** Back-compat alias for {@link startTelemetry}, the pre-composition name. */
+export const init = startTelemetry;
+
 function providerIsShutDown(provider: unknown): boolean {
   if ((typeof provider !== "object" && typeof provider !== "function") || provider === null) {
     return false;
@@ -105,18 +132,18 @@ function providerIsShutDown(provider: unknown): boolean {
 
 function foreignProviderError(): Error {
   return new Error(
-    "ratel telemetry init(): an OpenTelemetry TracerProvider is already registered globally, " +
-      "so init() (the turnkey path that owns the provider) cannot take over. To send Ratel " +
-      "telemetry alongside an existing provider (e.g. Langfuse + the Vercel AI SDK), add " +
-      "ratelSpanProcessor({ apiKey }) to that provider's spanProcessors instead of calling init().",
+    "ratel telemetry startTelemetry(): an OpenTelemetry TracerProvider is already registered " +
+      "globally, so startTelemetry() (the turnkey path that owns the provider) cannot take over. " +
+      "To send Ratel telemetry alongside an existing provider (e.g. Langfuse + the Vercel AI SDK), " +
+      "add ratelSpanProcessor({ apiKey }) to that provider's spanProcessors instead.",
   );
 }
 
 function alreadyShutDownError(): Error {
   return new Error(
-    "ratel telemetry init(): telemetry was already shut down in this process. The global " +
-      "OpenTelemetry tracer provider is registered once, so a later init() cannot re-take it. " +
-      "Call trace.disable() before init() if you must re-initialize (e.g. in tests).",
+    "ratel telemetry startTelemetry(): telemetry was already shut down in this process. The " +
+      "global OpenTelemetry tracer provider is registered once, so a later startTelemetry() " +
+      "cannot re-take it. Call trace.disable() first if you must re-initialize (e.g. in tests).",
   );
 }
 


### PR DESCRIPTION
Evolves `@ratel-ai/telemetry-otlp`'s `init()` into `startTelemetry` (additive; `init` stays as a back-compat alias) so a greenfield caller dual-exports from one Ratel-owned provider without ceding it to a foreign one. First phase of the **TS Telemetry DX Northstar** plan.

## What
- **`startTelemetry(opts)`** accepts host `spanProcessors` (e.g. `new LangfuseSpanProcessor()`) registered alongside `ratelSpanProcessor` on the owned `NodeTracerProvider` — every finished span fans out to all of them, each applying its own filter.
- Handle now exposes **`forceFlush()`** (drain every registered processor; serverless / batch jobs) beside `shutdown()`.
- `init` retained as an alias. All prior behavior preserved: idempotence, foreign-provider error pointing at `ratelSpanProcessor`, `enabled: false` no-op, terminal shutdown.
- Docs kept current (package README + `CONVENTIONS.md` init-surface note); full northstar examples land with the docs phase (RS-44).

## Testing
TDD, tests first (composition, flush fan-out, alias shape). `@ratel-ai/telemetry-otlp` 24 tests green; full pnpm workspace build / typecheck / lint / test green.

## Notes for reviewers / merge order
- **Rebase on RS-15** ("Fix telemetry capture modes") when it lands — this branch is based on `main`.
- Shares `resolveOtlpConfig` with **RS-42** (dedicated OTLP endpoint var); sequence the ts-otlp merges — second to merge rebases and re-runs ts-otlp tests.

---
Kestral task: **RS-41** — https://app.kestral.ai/workspace/10V6J6nL/task/15Q0BFlj
Plan: TS Telemetry DX Northstar (doc `15Pxf82c`)
