### PR TITLE
test(telemetry-otlp): prove Langfuse + AI SDK 7 + host-provider coexistence

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
     dependencies:
       '@mastra/core':
         specifier: ^1.51.0
-        version: 1.51.0(ai@7.0.33(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
+        version: 1.51.0(ai@7.0.37(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
       '@ratel-ai/mastra':
         specifier: workspace:*
         version: link:../../src/adapters/ts-mastra
@@ -128,7 +128,7 @@ importers:
         version: 2.4.13
       '@mastra/core':
         specifier: 1.51.0
-        version: 1.51.0(ai@7.0.33(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
+        version: 1.51.0(ai@7.0.37(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
       '@ratel-ai/sdk':
         specifier: workspace:^
         version: link:../../sdk/ts
@@ -269,12 +269,21 @@ importers:
         specifier: workspace:^
         version: link:../ts
     devDependencies:
+      '@ai-sdk/otel':
+        specifier: ^1.0.37
+        version: 1.0.37(zod@4.4.3)
       '@biomejs/biome':
         specifier: ^2.4.13
         version: 2.4.13
+      '@langfuse/otel':
+        specifier: ^5.9.1
+        version: 5.9.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
+      ai:
+        specifier: 7.0.33
+        version: 7.0.33(zod@4.4.3)
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -311,11 +320,21 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@4.0.28':
+    resolution: {integrity: sha512-ee9TsNO3mkgHDWmTmJ8Fvltr6PFh52zhrV2+FaKJY3F3iu7kWZi5tCRJCR1HVhhlpj6lHniUb28nLQdPHkA/1Q==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/openai@3.0.55':
     resolution: {integrity: sha512-1pZPT/VEKbn/7ItAr5Hkhy41GxbjiJUhsgTFFIPTwYT7Ph/swuByl4YCXLSfuav27zSzQdscOoxCtDasseeQHA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/otel@1.0.37':
+    resolution: {integrity: sha512-qaXUeOTZfbugaYKcqgqho79YOdvLWFlBQt984n5fOozChfgkybJJHotkqsKy3aJGU5GcgJuMM+oamb9JtPQnwA==}
+    engines: {node: '>=22'}
 
   '@ai-sdk/provider-utils@2.2.8':
     resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
@@ -750,6 +769,20 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@langfuse/core@5.9.1':
+    resolution: {integrity: sha512-KvyAskAO+2ixJwr9wy148ttR/Zn3oapvOJ2Br4Xcp6zhDpjSIIGB4jW/jkp53/KU9MyEHj0RSFPK/yKoxLC4KA==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
+  '@langfuse/otel@5.9.1':
+    resolution: {integrity: sha512-viM5Qq/AIPZPXfO7YdSmDHxEDSrNU/MyGzuE9zKA6hGBII1iLowU+qL99O+TjnXqxoADqlNibhY2pg1/WTIPcw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^2.0.1
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.202.0 <1.0.0'
+      '@opentelemetry/sdk-trace-base': ^2.0.1
 
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
@@ -1190,6 +1223,10 @@ packages:
     resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/api-logs@0.221.0':
+    resolution: {integrity: sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
@@ -1200,6 +1237,12 @@ packages:
 
   '@opentelemetry/context-async-hooks@2.9.0':
     resolution: {integrity: sha512-OQ0vzvbZBiUhjqLnUaoNfYmP8553Crr3aggB4y0ZUi815mZ7idpdJXQmoKdeBKJelYttoBlLSSHubmyw3wvX4w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -1216,6 +1259,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-trace-otlp-http@0.221.0':
+    resolution: {integrity: sha512-AySXiKoC+meiWm6zdVj5T2LnPDZuatveBby1cMOeQteIWsYXAUxs8Sru13G2pVSPrUXz6vF+og7QVBX6GdC/oQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/exporter-trace-otlp-proto@0.220.0':
     resolution: {integrity: sha512-voTAD8XgJxlK7zLkXh8EzMB09zrQr3tyY/BsnDTlDiQU/UdK58MZ63A3mUjdEDrxMjCVmBHU3WQJhRmQe+Dvzg==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -1228,11 +1277,29 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/otlp-exporter-base@0.221.0':
+    resolution: {integrity: sha512-UFPIq80OH3Ns/oPFHRj14d4DTOxUo+MUFU8hUiCq5jTqFhdeJnfVSANHT+xp92409cA+oxzvlZCe6NM1wvCuBA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/otlp-transformer@0.220.0':
     resolution: {integrity: sha512-lXGrv7KXZ0gNH9SVNUaa6vv6phVYGvJxfXAlMbzbakiXru75f5MZl8Z7oqiMMQD77riVHJCFlQvbZs/VVN2/4A==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.221.0':
+    resolution: {integrity: sha512-lg6lkOU08Az23jVcn/0Els9HP+V8PnR4Km6p0KgpTggS0n/WuhnmY64rSh83Of9iR9nD+dpWr6adlcX8KzAwjg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
   '@opentelemetry/resources@2.9.0':
     resolution: {integrity: sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==}
@@ -1245,6 +1312,18 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.221.0':
+    resolution: {integrity: sha512-FaDcazjyMp7TZZZAsqbo4IkovP0UegoCu0EBkiNt+qCqvUf7FPAsfcrZ3+ZEkKgXZ/jHafop+JoGPDk3A0SmLg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.10.0':
+    resolution: {integrity: sha512-t6r1VSvXNtSDnPXU1FbZeetJb7yyovHmgu0wRSoftxtE0g2rSNhQZQUy69sRUCL+iioJpX8SN/S6wq6ZtvLySQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
 
   '@opentelemetry/sdk-metrics@2.9.0':
     resolution: {integrity: sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==}
@@ -1263,6 +1342,12 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
   '@opentelemetry/sdk-trace@2.9.0':
     resolution: {integrity: sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==}
@@ -1498,6 +1583,12 @@ packages:
 
   ai@7.0.33:
     resolution: {integrity: sha512-31X29OiXn7OBUcar1RRf1q75FirvGXCL/xL3VykeLG+Lp3AcZkeG0tthO6hvNM/jZo3h/0g32fhgHVYekiBAZQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@7.0.37:
+    resolution: {integrity: sha512-stF+SEQJgKY3Qfe3FwNzqUrehHviOp2l7LemoI8YMOa0Zk5PxKsRNgUk3cHXz0RAue9RRyCAis2fz6LSCP6EKw==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2658,11 +2749,26 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
+  '@ai-sdk/gateway@4.0.28(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
   '@ai-sdk/openai@3.0.55(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.25(zod@4.4.3)
       zod: 4.4.3
+
+  '@ai-sdk/otel@1.0.37(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@opentelemetry/api': 1.9.1
+      ai: 7.0.37(zod@4.4.3)
+    transitivePeerDependencies:
+      - zod
 
   '@ai-sdk/provider-utils@2.2.8(zod@4.4.3)':
     dependencies:
@@ -2999,13 +3105,25 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
+  '@langfuse/core@5.9.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@langfuse/otel@5.9.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@langfuse/core': 5.9.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
+
   '@lukeed/csprng@1.1.0': {}
 
   '@lukeed/uuid@2.0.1':
     dependencies:
       '@lukeed/csprng': 1.1.0
 
-  '@mastra/core@1.51.0(ai@7.0.33(zod@4.4.3))(express@5.2.1)(zod@4.4.3)':
+  '@mastra/core@1.51.0(ai@7.0.37(zod@4.4.3))(express@5.2.1)(zod@4.4.3)':
     dependencies:
       '@a2a-js/sdk': 0.3.14(express@5.2.1)
       '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.28(zod@4.4.3)'
@@ -3022,7 +3140,7 @@ snapshots:
       '@sindresorhus/slugify': 2.2.1
       '@standard-schema/spec': 1.1.0
       ajv: 8.20.0
-      chat: 4.34.0(ai@7.0.33(zod@4.4.3))(zod@4.4.3)
+      chat: 4.34.0(ai@7.0.37(zod@4.4.3))(zod@4.4.3)
       croner: 10.0.1
       dotenv: 17.4.2
       execa: 9.6.1
@@ -3414,6 +3532,10 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
 
+  '@opentelemetry/api-logs@0.221.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/api@1.9.0': {}
 
   '@opentelemetry/api@1.9.1': {}
@@ -3421,6 +3543,11 @@ snapshots:
   '@opentelemetry/context-async-hooks@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -3433,6 +3560,13 @@ snapshots:
       '@opentelemetry/otlp-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.220.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -3449,6 +3583,12 @@ snapshots:
       '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/otlp-exporter-base@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/otlp-transformer@0.220.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -3458,6 +3598,22 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.220.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace': 2.9.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/resources@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -3472,6 +3628,20 @@ snapshots:
       '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/sdk-metrics@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -3493,6 +3663,13 @@ snapshots:
       '@opentelemetry/context-async-hooks': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/sdk-trace@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -3700,6 +3877,13 @@ snapshots:
       '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
       zod: 4.4.3
 
+  ai@7.0.37(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.28(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
+      zod: 4.4.3
+
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
@@ -3763,7 +3947,7 @@ snapshots:
 
   chardet@2.1.1: {}
 
-  chat@4.34.0(ai@7.0.33(zod@4.4.3))(zod@4.4.3):
+  chat@4.34.0(ai@7.0.37(zod@4.4.3))(zod@4.4.3):
     dependencies:
       '@workflow/serde': 4.1.0-beta.2
       mdast-util-to-string: 4.0.0
@@ -3773,7 +3957,7 @@ snapshots:
       remend: 1.3.0
       unified: 11.0.5
     optionalDependencies:
-      ai: 7.0.33(zod@4.4.3)
+      ai: 7.0.37(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color

--- a/src/telemetry/ts-otlp/package.json
+++ b/src/telemetry/ts-otlp/package.json
@@ -60,8 +60,11 @@
     "@opentelemetry/api": ">=1.3.0 <1.10.0"
   },
   "devDependencies": {
+    "@ai-sdk/otel": "^1.0.37",
     "@biomejs/biome": "^2.4.13",
+    "@langfuse/otel": "^5.9.1",
     "@opentelemetry/api": "^1.9.1",
+    "ai": "7.0.33",
     "typescript": "^5.6.0",
     "vitest": "^4.1.5"
   }

--- a/src/telemetry/ts-otlp/src/coexistence.test.ts
+++ b/src/telemetry/ts-otlp/src/coexistence.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Coexistence proof for the TS Telemetry DX northstar (RS-43): Ratel telemetry sharing an
+ * OpenTelemetry pipeline with Langfuse and the AI SDK 7 `@ai-sdk/otel` integration, using the
+ * real vendor packages and in-memory export capture (no network). Mirrors appendix examples
+ * 1, 3, 5, and 6 of the plan doc (15Pxf82c).
+ *
+ * Two composition modes are covered:
+ *  - guest mode — a host `NodeTracerProvider` owns the pipeline; `ratelSpanProcessor` and
+ *    `LangfuseSpanProcessor` are peer processors on it (examples 3, 5).
+ *  - owner mode — `startTelemetry` owns the pipeline and AI SDK 7's `registerTelemetry(new
+ *    OpenTelemetry())` emits `gen_ai.*` spans onto it, alongside a composed
+ *    `LangfuseSpanProcessor` (examples 1, 6).
+ *
+ * Each backend is observed at its own OTLP exporter's `export` boundary — Ratel exports over
+ * `@opentelemetry/exporter-trace-otlp-proto`, Langfuse over `-http`, so the two never collide.
+ */
+
+import { OpenTelemetry } from "@ai-sdk/otel";
+import { LangfuseSpanProcessor } from "@langfuse/otel";
+import { type Tracer, trace } from "@opentelemetry/api";
+import { logs } from "@opentelemetry/api-logs";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import type { SpanExporter } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { generateText, registerTelemetry } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { startTelemetry } from "./init.js";
+import { ratelSignalFilter, ratelSpanProcessor } from "./processor.js";
+
+const ENDPOINT = "http://localhost:4318/v1/traces";
+type Predicate = (arg: { otelSpan: { name: string } }) => boolean;
+const ACCEPT_ALL: Predicate = () => true;
+const RATEL_ONLY: Predicate = ({ otelSpan }) => otelSpan.name.startsWith("ratel.");
+
+/** Capture the span names Ratel's OTLP-proto exporter would ship, network-free. */
+function captureRatel(into: string[]): void {
+  vi.spyOn(OTLPTraceExporter.prototype, "export").mockImplementation((spans, resultCallback) => {
+    into.push(...spans.map((span) => span.name));
+    resultCallback({ code: 0 });
+  });
+}
+
+/** Build a `LangfuseSpanProcessor` whose internal OTLP-http exporter is captured, network-free. */
+function langfuseCapturing(into: string[], shouldExportSpan: Predicate): LangfuseSpanProcessor {
+  const processor = new LangfuseSpanProcessor({
+    publicKey: "pk",
+    secretKey: "sk",
+    baseUrl: "http://127.0.0.1:1",
+    shouldExportSpan,
+  });
+  const exporter = (processor as unknown as { processor: { _exporter: SpanExporter } }).processor
+    ._exporter;
+  vi.spyOn(exporter, "export").mockImplementation((spans, resultCallback) => {
+    into.push(...spans.map((span) => span.name));
+    resultCallback({ code: 0 });
+  });
+  return processor;
+}
+
+/** The northstar's mixed span stream: a Ratel span, a gen_ai span, AI SDK wrapper noise, and unrelated. */
+function emitFixtureSpans(tracer: Tracer): void {
+  tracer.startSpan("ratel.search").end();
+  tracer.startSpan("chat gpt-4o", { attributes: { "gen_ai.request.model": "gpt-4o" } }).end();
+  tracer.startSpan("ai.generateText", { attributes: { "ai.model.id": "gpt-4o" } }).end();
+  tracer.startSpan("GET /health").end();
+}
+
+const mockModel = () =>
+  new MockLanguageModelV3({
+    doGenerate: async () => ({
+      finishReason: "stop",
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      content: [{ type: "text", text: "hi" }],
+      warnings: [],
+    }),
+  });
+
+const sorted = (names: string[]): string[] => [...names].sort();
+
+describe("telemetry coexistence", () => {
+  afterEach(() => {
+    trace.disable();
+    logs.disable();
+    vi.restoreAllMocks();
+  });
+
+  // Example 5: a partner already owns the provider; Ratel joins as a peer span-processor with
+  // its default signal filter, Langfuse keeps everything. One shared stream, independent
+  // per-destination export sets.
+  describe("guest mode: host provider + LangfuseSpanProcessor + ratelSpanProcessor", () => {
+    it("fans every span to both processors while each exports its own filtered set", async () => {
+      const ratelNames: string[] = [];
+      const langfuseNames: string[] = [];
+      captureRatel(ratelNames);
+      const host = new NodeTracerProvider({
+        spanProcessors: [
+          langfuseCapturing(langfuseNames, ACCEPT_ALL),
+          ratelSpanProcessor({ endpoint: ENDPOINT, apiKey: "k" }),
+        ],
+      });
+
+      emitFixtureSpans(host.getTracer("test"));
+      await host.forceFlush();
+      await host.shutdown();
+
+      // Ratel's default ratelSignalFilter forwards only ratel.*/gen_ai.* — ai.* noise and
+      // the unrelated span are dropped.
+      expect(sorted(ratelNames)).toEqual(["chat gpt-4o", "ratel.search"]);
+      // Langfuse, told to accept all, receives the full shared stream — proving both
+      // processors saw every span and filtered independently.
+      expect(sorted(langfuseNames)).toEqual([
+        "GET /health",
+        "ai.generateText",
+        "chat gpt-4o",
+        "ratel.search",
+      ]);
+    });
+  });
+
+  // Example 6: no foreign provider, so startTelemetry owns it; AI SDK 7's registerTelemetry
+  // integration emits onto that same provider, and a composed LangfuseSpanProcessor rides along.
+  // The @ai-sdk/otel OpenTelemetry integration memoizes its tracer on first use, so this mode
+  // is proven with a single generateText cycle.
+  describe("owner mode: startTelemetry + AI SDK 7 registerTelemetry(new OpenTelemetry())", () => {
+    beforeAll(() => {
+      // Global emit-side integration; register once so operations emit a single span set.
+      registerTelemetry(new OpenTelemetry());
+    });
+
+    it("routes AI SDK 7 gen_ai spans and Ratel's own spans to both destinations", async () => {
+      const ratelNames: string[] = [];
+      const langfuseNames: string[] = [];
+      captureRatel(ratelNames);
+      const handle = startTelemetry({
+        serviceName: "my-agent",
+        endpoint: ENDPOINT,
+        apiKey: "k",
+        spanFilter: ratelSignalFilter,
+        spanProcessors: [langfuseCapturing(langfuseNames, ACCEPT_ALL)],
+      });
+
+      // A ratel.* span rides the same owned provider automatically (no wiring on ratel())...
+      trace.getTracer("ratel").startSpan("ratel.search").end();
+      // ...alongside AI SDK 7's gen_ai.* spans, emitted via the registered integration.
+      await generateText({
+        model: mockModel(),
+        prompt: "hello",
+        experimental_telemetry: { isEnabled: true },
+      });
+      await handle.forceFlush();
+      await handle.shutdown();
+
+      // The integration emitted chat/step/invoke_agent onto startTelemetry's owned provider.
+      // Those spans are gen_ai.*-tagged, so ratelSignalFilter keeps every one — the "drops ai.*
+      // wrapper noise" caveat applies to the legacy experimental_telemetry path, not @ai-sdk/otel.
+      expect(ratelNames).toContain("chat mock-model-id");
+      expect(ratelNames).toContain("ratel.search");
+      expect(ratelNames.every((name) => !name.startsWith("ai."))).toBe(true);
+      // Both destinations saw the same shared stream (Langfuse accepts all; Ratel keeps the signal,
+      // which here is everything because AI SDK 7 emits gen_ai.* rather than ai.* spans).
+      expect(sorted(ratelNames)).toEqual(sorted(langfuseNames));
+    });
+  });
+
+  // Example 3 (second block): the source can't be silenced, so each destination filters to
+  // ratel.* independently — Ratel via spanFilter, Langfuse via shouldExportSpan.
+  describe("per-destination filtering: only ratel.* spans reach both backends", () => {
+    it("drops non-ratel spans on both the Ratel and Langfuse sides", async () => {
+      const ratelNames: string[] = [];
+      const langfuseNames: string[] = [];
+      captureRatel(ratelNames);
+      const handle = startTelemetry({
+        serviceName: "my-agent",
+        endpoint: ENDPOINT,
+        apiKey: "k",
+        spanFilter: (span) => span.name.startsWith("ratel."),
+        spanProcessors: [langfuseCapturing(langfuseNames, RATEL_ONLY)],
+      });
+
+      emitFixtureSpans(trace.getTracer("test"));
+      await handle.forceFlush();
+      await handle.shutdown();
+
+      expect(sorted(ratelNames)).toEqual(["ratel.search"]);
+      expect(sorted(langfuseNames)).toEqual(["ratel.search"]);
+    });
+  });
+});


### PR DESCRIPTION
Adds a real-dependency coexistence test suite (`src/telemetry/ts-otlp/src/coexistence.test.ts`) for the TS telemetry DX northstar (RS-43, Phase 4), proving Ratel telemetry shares one OpenTelemetry pipeline with Langfuse and the AI SDK 7 `@ai-sdk/otel` integration. It covers guest mode (host provider + `LangfuseSpanProcessor` + `ratelSpanProcessor` with the default signal filter), owner mode (`startTelemetry` + `registerTelemetry(new OpenTelemetry())`), and per-destination `ratel.*`-only filtering — each backend observed at its own OTLP exporter boundary, no network — and adds `@langfuse/otel`, `@ai-sdk/otel`, and `ai` as ts-otlp devDeps. Finding for the docs phase (RS-44): AI SDK 7's `@ai-sdk/otel` integration emits `gen_ai.*`-tagged `chat`/`step`/`invoke_agent` spans, so `ratelSignalFilter` keeps them all; the "drops ai.* noise" caveat applies only to the legacy `experimental_telemetry` path. Full TS workspace green (ts-otlp 33, ts 54, sdk 265, adapters 71+53).