### PR TITLE
feat(sdk-ts): accept Standard Schema validators for tool input/output schema

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
   src/telemetry/ts:
     devDependencies:

--- a/src/sdk/ts/package.json
+++ b/src/sdk/ts/package.json
@@ -79,7 +79,8 @@
     "@opentelemetry/sdk-trace-base": "^2.9.0",
     "typedoc": "^0.28.20",
     "typescript": "^5.6.0",
-    "vitest": "^4.1.5"
+    "vitest": "^4.1.5",
+    "zod": "^4.4.3"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/sdk/ts/src/catalog.test.ts
+++ b/src/sdk/ts/src/catalog.test.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 import { EmbedderError, type ExecutableTool, ToolCatalog } from "./index.js";
 import { startDelayedEmbeddingServer } from "./test-support/delayed-embedding-server.js";
 
@@ -58,6 +59,29 @@ describe("ToolCatalog", () => {
     expect(hits.length).toBeGreaterThan(0);
     expect(hits[0].toolId).toBe("read_file");
     expect(hits[0].score).toBeGreaterThan(0);
+  });
+
+  it("accepts a Standard Schema validator (Zod) as inputSchema/outputSchema", async () => {
+    const catalog = new ToolCatalog();
+    await catalog.register({
+      id: "read_file",
+      name: "read_file",
+      description: "Read a file from local disk and return its textual contents.",
+      inputSchema: z.object({ path: z.string().describe("absolute path to the file") }),
+      outputSchema: z.object({ contents: z.string() }),
+      execute: async ({ path }: { path: string }) => ({ contents: `contents of ${path}` }),
+    });
+
+    const hits = catalog.search("read file", 5);
+    expect(hits[0]?.toolId).toBe("read_file");
+
+    // Stored/indexed metadata is plain JSON Schema, not a leaked Zod internal.
+    const stored = catalog.get("read_file");
+    expect(stored?.inputSchema).toMatchObject({
+      type: "object",
+      properties: { path: { type: "string", description: "absolute path to the file" } },
+    });
+    expect(stored?.outputSchema).toMatchObject({ type: "object" });
   });
 
   it("registers an iterable of tools as one batch", async () => {

--- a/src/sdk/ts/src/catalog.ts
+++ b/src/sdk/ts/src/catalog.ts
@@ -1,4 +1,5 @@
 import { SearchTarget } from "@ratel-ai/telemetry";
+import type { JSONSchema7 } from "json-schema";
 import type { SearchHit, Tool } from "../native/index.cjs";
 import { isAsyncIterable, isPromiseLike } from "./async.js";
 import { ToolRegistry } from "./registry.js";
@@ -47,13 +48,47 @@ export type InputValidator = (
   input: unknown,
 ) => InputValidationResult | PromiseLike<InputValidationResult>;
 
+/** The slice of the Standard Schema JSON Schema extension
+ * (https://standardschema.dev/json-schema) a validator (Zod, Effect Schema, ...)
+ * exposes so its shape can be read without a hard dependency on any one library. */
+export interface StandardJsonSchema {
+  /** The Standard Schema namespace every compliant validator exposes. */
+  "~standard": {
+    /** The JSON Schema conversion extension. */
+    jsonSchema: {
+      /** Converts the validator to plain JSON Schema for the requested dialect. */
+      input(options: { target: string }): Record<string, unknown>;
+    };
+  };
+}
+
+/** A tool's input/output schema: either a plain JSON Schema object (the catalog's
+ * native spelling) or a Standard Schema-compliant validator. */
+export type ToolSchema = JSONSchema7 | StandardJsonSchema;
+
+/** Normalizes a {@link ToolSchema} to plain JSON Schema. A Standard Schema
+ * validator is read via `~standard.jsonSchema.input` (draft-07); anything else
+ * is assumed to already be JSON Schema and passes through unchanged, so this is
+ * additive — existing bare-JSON-Schema callers are unaffected. */
+function toJsonSchema(schema: ToolSchema): JSONSchema7 {
+  const input = (schema as StandardJsonSchema)?.["~standard"]?.jsonSchema?.input;
+  if (typeof input !== "function") return schema as JSONSchema7;
+  const { $schema: _dialect, ...json } = input({ target: "draft-07" });
+  return json as JSONSchema7;
+}
+
 /**
  * A tool the catalog can both retrieve *and* run: the searchable metadata of a
  * `Tool` (id, name, description, schemas) plus its {@link Executor}. The unit
  * {@link ToolCatalog.register} accepts and {@link ToolCatalog.getExecutable}
- * returns.
+ * returns. `inputSchema`/`outputSchema` accept a {@link ToolSchema} — plain JSON
+ * Schema or a Standard Schema validator (Zod, Effect Schema, ...).
  */
-export interface ExecutableTool extends Tool {
+export interface ExecutableTool extends Omit<Tool, "inputSchema" | "outputSchema"> {
+  /** JSON Schema of the arguments, or a Standard Schema validator. See {@link ToolSchema}. */
+  inputSchema: ToolSchema;
+  /** JSON Schema of the result, or a Standard Schema validator. See {@link ToolSchema}. */
+  outputSchema: ToolSchema;
   /** Shared parser used before execution and by model-facing host bridges. */
   validateInput?: InputValidator;
   /** Runs the tool. Called by {@link ToolCatalog.invoke} with args and optional context. */
@@ -282,19 +317,24 @@ export class ToolCatalog {
         throw new Error(`tool ${tool.id} has no execute handler`);
       }
     }
-    this.registry.registerItems(
-      batch.map(({ execute: _execute, validateInput: _validateInput, ...metadata }) => metadata),
+    const normalized = batch.map(
+      ({ execute: _execute, validateInput: _validateInput, ...metadata }): Tool => ({
+        ...metadata,
+        inputSchema: toJsonSchema(metadata.inputSchema),
+        outputSchema: toJsonSchema(metadata.outputSchema),
+      }),
     );
-    for (const tool of batch) {
-      const { execute, validateInput, ...metadata } = tool;
+    this.registry.registerItems(normalized);
+    batch.forEach((tool, i) => {
+      const { execute, validateInput } = tool;
       this.executors.set(tool.id, execute);
       if (validateInput) {
         this.inputValidators.set(tool.id, validateInput);
       } else {
         this.inputValidators.delete(tool.id);
       }
-      this.tools.set(tool.id, metadata);
-    }
+      this.tools.set(tool.id, normalized[i]);
+    });
     await this.registry.buildDense();
   }
 

--- a/src/sdk/ts/src/index.ts
+++ b/src/sdk/ts/src/index.ts
@@ -45,7 +45,9 @@ export type {
   InputValidator,
   SearchMethod,
   SearchOrigin,
+  StandardJsonSchema,
   ToolCatalogOptions,
+  ToolSchema,
   TraceSinkConfig,
 } from "./catalog.js";
 export { ToolCatalog } from "./catalog.js";


### PR DESCRIPTION
## Summary

Closes #53. `ToolCatalog.register()` (and the `ExecutableTool` type) only accepted a bare JSON Schema object for `inputSchema`/`outputSchema`. A caller using Zod, Effect Schema, or any [Standard Schema](https://standardschema.dev/json-schema)-compliant validator had no conversion path when using `ToolCatalog` directly.

Both framework adapters (`@ratel-ai/mastra`, `@ratel-ai/vercel-ai-sdk`) already solved this internally (`toJsonSchema()` reading `schema["~standard"].jsonSchema.input(...)`), but the fix never made it into the shared catalog layer. This generalizes that same pattern into `ToolCatalog`.

## Changes

- `ExecutableTool.inputSchema`/`outputSchema` widened from `JSONSchema7` to a new `ToolSchema = JSONSchema7 | StandardJsonSchema` union.
- New `toJsonSchema()` helper in `catalog.ts`, called once in `register()` and reused for both the native registry and the catalog's internal metadata cache — so `catalog.get(id)` never leaks a raw Zod/validator object back to a caller.
- Additive and non-breaking: a plain JSON Schema object has no `~standard` key, so it passes through the helper unchanged. Existing bare-JSON-Schema callers are unaffected.
- `ToolSchema`/`StandardJsonSchema` exported from the package's public entrypoint.
- Test in `catalog.test.ts` registering a tool with a real `zod` schema, asserting it's searchable and that the stored/indexed metadata is plain JSON Schema.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test` scoped to `src/sdk/ts`
- [x] `pnpm -r typecheck && pnpm -r lint && pnpm -r test` from repo root (no regressions elsewhere)
- [x] `cargo build/clippy/fmt/test --workspace` (no Rust files touched; confirms no regression)