### PR TITLE
ci(pr-gate): install local ratel-ai-telemetry before the SDK wheel

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -118,6 +118,15 @@ jobs:
             PY="arch -x86_64 /Library/Frameworks/Python.framework/Versions/3.11/bin/python3"
           fi
           $PY -c "import platform; print('e2e interpreter machine:', platform.machine())"
+          # ratel-ai hard-depends on the ratel-ai-telemetry vocabulary, which lives in
+          # this repo and releases on its own tag (telemetry-py-v*). Between an in-repo
+          # version bump and that release the floor isn't on PyPI yet, so resolving it
+          # from the index fails every leg. Install the monorepo sibling first, mirroring
+          # the Node leg below (which pre-builds its @ratel-ai/telemetry workspace dep)
+          # and the local-source pin examples/pydantic-ai already carries for the same
+          # unreleased floor. Resolution against the real index stays covered by
+          # verify-install.yml, which installs the published wheel from PyPI.
+          $PY -m pip install ./src/telemetry/python
           $PY -m pip install src/sdk/python/dist/*.whl
           $PY e2e/python/run_e2e.py
 


### PR DESCRIPTION
PR Gate has been red on `main` for the last 3 commits: all 5 verify legs fail with `No matching distribution found for ratel-ai-telemetry>=0.1.3`. c8fe351 (#130) gave `src/sdk/python` a new hard dep on `ratel-ai-telemetry>=0.1.3` and bumped the in-repo telemetry package to 0.1.3, but PyPI tops out at 0.1.2, so pip cannot resolve the freshly built wheel. This installs the monorepo sibling before the SDK wheel, mirroring what the Node leg (pre-builds its `@ratel-ai/telemetry` workspace dep), `python.yml` (`-e ../../telemetry/python`) and `examples/pydantic-ai` (local-source pin for the same "unreleased telemetry floor") already do; resolution against the real index stays covered by `verify-install.yml`. Verified locally by building the real wheel with maturin and running both paths in clean venvs: the old command reproduces CI's exact error, the new one installs clean and `e2e/python/run_e2e.py` passes.

Two follow-ups this surfaced, both out of scope here:

- [ ] `telemetry-py-v0.1.3-rc.1` exists as a local tag but was never pushed or published, while `telemetry-ts-v0.1.3` shipped. The Python half of that release got dropped.
- [ ] Do not publish `ratel-ai` 0.5.2 before `ratel-ai-telemetry` 0.1.3. Published 0.5.1 has `dependencies = []` so nobody is broken today, but 0.5.2 carries the hard floor and releasing it first would break `pip install ratel-ai` and turn `verify-install.yml` red.