### PR TITLE
feat(sdk): paginated MCP tools/list in TS sdk and Python sdk

### DIFF
--- a/src/sdk/python/ratel_ai/__init__.py
+++ b/src/sdk/python/ratel_ai/__init__.py
@@ -43,7 +43,7 @@ from .catalog import (
 # callers keep working after upgrading to 0.2.0. Slated for removal (RAT-250).
 from .compat import SEARCH_TOOLS_ID, search_tools_tool
 from .exceptions import DimensionMismatchError, EmbedderError
-from .mcp import McpServerHandle, register_mcp_server
+from .mcp import McpServerHandle, McpToolsListError, register_mcp_server
 from .skill_catalog import Skill, SkillCatalog, SkillRegistry
 from .skill_tools import GET_SKILL_CONTENT_ID, get_skill_content_tool
 
@@ -70,6 +70,7 @@ __all__ = [
     "HuggingFaceEmbeddingConfig",
     "LocalEmbeddingConfig",
     "McpServerHandle",
+    "McpToolsListError",
     "OnUnauthorized",
     "OllamaEmbeddingConfig",
     "SearchHit",

--- a/src/sdk/python/ratel_ai/mcp.py
+++ b/src/sdk/python/ratel_ai/mcp.py
@@ -58,9 +58,9 @@ def _require_mcp() -> None:
 
 
 def _next_cursor(result: Any) -> str | None:
-    nc = getattr(result, "next_cursor", None)
+    nc = getattr(result, "nextCursor", None)
     if nc is None:
-        nc = getattr(result, "nextCursor", None)
+        nc = getattr(result, "next_cursor", None)
     return nc
 
 

--- a/src/sdk/python/ratel_ai/mcp.py
+++ b/src/sdk/python/ratel_ai/mcp.py
@@ -1,9 +1,9 @@
 """Upstream MCP ingestion — the Python mirror of `src/sdk/ts/src/mcp.ts`.
 
-`register_mcp_server` lists an upstream MCP server's tools, registers each into a
-`ToolCatalog` under a namespaced id (`<server>__<tool>`), and wires each executor
-to the upstream `call_tool`. It emits the same `upstream_*` trace **event types**
-the TS SDK emits (ADR-0007).
+`register_mcp_server` lists every paginated upstream MCP `tools/list` page (no live
+refresh), registers each tool into a `ToolCatalog` under a namespaced id
+(`<server>__<tool>`), and wires each executor to the upstream `call_tool`. It emits
+the same `upstream_*` trace **event types** the TS SDK emits (ADR-0007).
 
 The `mcp` package is an optional dependency (`pip install ratel-ai[mcp]`) and is
 imported lazily, so the base SDK installs without it.
@@ -27,10 +27,24 @@ from __future__ import annotations
 import time
 from collections.abc import Awaitable
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, Literal
 
 from .catalog import ExecutableTool, ToolCatalog
 from .telemetry import trace_upstream_register
+
+_MCP_LIST_MAX_PAGES = 64
+
+McpToolsListErrorCode = Literal["RepeatedCursor", "PaginationExceeded"]
+
+
+class McpToolsListError(Exception):
+    """Raised when MCP `tools/list` pagination is invalid or exceeds the page cap."""
+
+    def __init__(self, message: str, code: McpToolsListErrorCode) -> None:
+        """Set the error message and pagination failure code."""
+        super().__init__(message)
+        self.code = code
+        self.name = "McpToolsListError"
 
 
 def _require_mcp() -> None:
@@ -43,13 +57,86 @@ def _require_mcp() -> None:
         ) from err
 
 
+def _next_cursor(result: Any) -> str | None:
+    nc = getattr(result, "next_cursor", None)
+    if nc is None:
+        nc = getattr(result, "nextCursor", None)
+    return nc
+
+
+def _paginated_list_params(cursor: str) -> Any:
+    try:
+        from mcp.types import PaginatedRequestParams
+
+        return PaginatedRequestParams(cursor=cursor)
+    except ImportError:
+        from types import SimpleNamespace
+
+        return SimpleNamespace(cursor=cursor)
+
+
+async def _fetch_tools_page(session: Any, cursor: str | None) -> Any:
+    if cursor is None:
+        return await session.list_tools()
+    return await session.list_tools(params=_paginated_list_params(cursor))
+
+
+async def _list_all_mcp_tools(session: Any) -> list[Any]:
+    tools: list[Any] = []
+    cursor: str | None = None
+    seen_cursors: set[str] = set()
+    for _ in range(_MCP_LIST_MAX_PAGES):
+        result = await _fetch_tools_page(session, cursor)
+        tools.extend(result.tools)
+        next_cursor = _next_cursor(result)
+        # MCP: only absent nextCursor ends pagination ("" is a valid cursor).
+        if next_cursor is None:
+            return tools
+        if next_cursor in seen_cursors:
+            raise McpToolsListError(
+                "MCP tools/list returned a repeated nextCursor",
+                "RepeatedCursor",
+            )
+        seen_cursors.add(next_cursor)
+        cursor = next_cursor
+    raise McpToolsListError(
+        f"MCP tools/list exceeded {_MCP_LIST_MAX_PAGES} pages",
+        "PaginationExceeded",
+    )
+
+
+def _build_registered_mcp_tools(
+    catalog: ToolCatalog,
+    session: Any,
+    name: str,
+    tools: list[Any],
+) -> tuple[list[str], list[ExecutableTool]]:
+    tool_ids: list[str] = []
+    registered: list[ExecutableTool] = []
+    for tool in tools:
+        tool_id = f"{name}__{tool.name}"
+        registered.append(
+            ExecutableTool(
+                id=tool_id,
+                name=tool.name,
+                description=getattr(tool, "description", None) or "",
+                input_schema=getattr(tool, "inputSchema", None) or {},
+                output_schema=getattr(tool, "outputSchema", None) or {"type": "object"},
+                execute=_make_executor(catalog, session, name, tool_id, tool.name),
+            )
+        )
+        tool_ids.append(tool_id)
+    return tool_ids, registered
+
+
 @dataclass
 class McpServerHandle:
     """What `register_mcp_server` returns: the registration's outcome.
 
     Attributes:
-        tool_ids: the namespaced `<server>__<tool>` ids registered into the
-            catalog, in upstream listing order.
+        tool_ids: namespaced `<server>__<tool>` ids in upstream list order (all
+            pages). Duplicate tool names may appear more than once;
+            `ToolCatalog.register` keeps the last row per id.
         server_instructions: the `instructions` value passed to
             `register_mcp_server` (the caller reads it from its own
             `initialize` result), or `None`.
@@ -92,14 +179,14 @@ async def register_mcp_server(
     Raises:
         ImportError: if the optional `mcp` package is not installed
             (`pip install 'ratel-ai[mcp]'`).
+        McpToolsListError: if `tools/list` repeats a cursor or exceeds the page cap.
     """
     _require_mcp()
 
     # The whole registration (list + ingest) is one `ratel.upstream.register` span;
     # per-tool invocations later get their own `execute_tool` spans (ADR-0007).
     async def _run(report_tool_count: Callable[[int], None]) -> McpServerHandle:
-        list_result = await session.list_tools()
-        tools = list_result.tools
+        tools = await _list_all_mcp_tools(session)
         report_tool_count(len(tools))
         catalog.record_event(
             {
@@ -110,21 +197,7 @@ async def register_mcp_server(
             }
         )
 
-        tool_ids: list[str] = []
-        registered: list[ExecutableTool] = []
-        for tool in tools:
-            tool_id = f"{name}__{tool.name}"
-            registered.append(
-                ExecutableTool(
-                    id=tool_id,
-                    name=tool.name,
-                    description=getattr(tool, "description", None) or "",
-                    input_schema=getattr(tool, "inputSchema", None) or {},
-                    output_schema=getattr(tool, "outputSchema", None) or {"type": "object"},
-                    execute=_make_executor(catalog, session, name, tool_id, tool.name),
-                )
-            )
-            tool_ids.append(tool_id)
+        tool_ids, registered = _build_registered_mcp_tools(catalog, session, name, tools)
         await catalog.register(registered)
 
         return McpServerHandle(

--- a/src/sdk/python/ratel_ai/mcp.py
+++ b/src/sdk/python/ratel_ai/mcp.py
@@ -64,10 +64,26 @@ def _next_cursor(result: Any) -> str | None:
     return nc
 
 
+def _paginated_list_params(cursor: str) -> Any:
+    for module_name in ("mcp.types", "mcp_types"):
+        try:
+            types_mod = __import__(module_name, fromlist=["PaginatedRequestParams"])
+            params_cls = types_mod.PaginatedRequestParams
+            return params_cls(cursor=cursor)
+        except (ImportError, AttributeError):
+            continue
+    from types import SimpleNamespace
+
+    return SimpleNamespace(cursor=cursor)
+
+
 async def _fetch_tools_page(session: Any, cursor: str | None) -> Any:
     if cursor is None:
         return await session.list_tools()
-    return await session.list_tools(cursor)
+    try:
+        return await session.list_tools(cursor)
+    except TypeError:
+        return await session.list_tools(params=_paginated_list_params(cursor))
 
 
 async def _list_all_mcp_tools(session: Any) -> list[Any]:

--- a/src/sdk/python/ratel_ai/mcp.py
+++ b/src/sdk/python/ratel_ai/mcp.py
@@ -64,21 +64,10 @@ def _next_cursor(result: Any) -> str | None:
     return nc
 
 
-def _paginated_list_params(cursor: str) -> Any:
-    try:
-        from mcp.types import PaginatedRequestParams
-
-        return PaginatedRequestParams(cursor=cursor)
-    except ImportError:
-        from types import SimpleNamespace
-
-        return SimpleNamespace(cursor=cursor)
-
-
 async def _fetch_tools_page(session: Any, cursor: str | None) -> Any:
     if cursor is None:
         return await session.list_tools()
-    return await session.list_tools(params=_paginated_list_params(cursor))
+    return await session.list_tools(cursor)
 
 
 async def _list_all_mcp_tools(session: Any) -> list[Any]:

--- a/src/sdk/python/ratel_ai/telemetry.py
+++ b/src/sdk/python/ratel_ai/telemetry.py
@@ -137,11 +137,13 @@ def _normalize_content(value: Any) -> Any:
     model_dump = getattr(value, "model_dump", None)
     if callable(model_dump):
         try:
-            return _normalize_content(
-                model_dump(mode="json", by_alias=True, exclude_none=True)
-            )
+            dumped = model_dump(mode="json", by_alias=True, exclude_none=True)
         except TypeError:
-            return _normalize_content(model_dump())
+            dumped = model_dump()
+        if type(value).__name__ == "CallToolResult" and isinstance(dumped, dict):
+            stable = ("content", "structuredContent", "isError")
+            return _normalize_content({key: dumped[key] for key in stable if key in dumped})
+        return _normalize_content(dumped)
     if isinstance(value, Enum):
         return _normalize_content(value.value)
     if isinstance(value, Mapping):

--- a/src/sdk/python/tests/test_index.py
+++ b/src/sdk/python/tests/test_index.py
@@ -25,6 +25,7 @@ def test_public_exports_present() -> None:
         "UpstreamServerInfo",
         "register_mcp_server",
         "McpServerHandle",
+        "McpToolsListError",
         # skills surface
         "SkillRegistry",
         "SkillHit",

--- a/src/sdk/python/tests/test_mcp.py
+++ b/src/sdk/python/tests/test_mcp.py
@@ -13,6 +13,7 @@ from typing import Any
 import pytest
 
 from ratel_ai import EmbedderError, ToolCatalog, TraceSinkConfig, register_mcp_server
+from ratel_ai.mcp import McpToolsListError
 
 
 @pytest.fixture
@@ -291,8 +292,9 @@ async def test_register_mcp_server_rejects_repeated_next_cursor(skip_mcp_import_
     )
     catalog = ToolCatalog()
 
-    with pytest.raises(Exception, match=r"repeated nextCursor"):
+    with pytest.raises(McpToolsListError, match=r"repeated nextCursor") as exc_info:
         await register_mcp_server(catalog, name="demo", session=session)
+    assert exc_info.value.code == "RepeatedCursor"
     assert not catalog.has("demo__stuck")
 
 
@@ -322,8 +324,9 @@ async def test_register_mcp_server_rejects_when_page_cap_exceeded(skip_mcp_impor
     session = _PaginatedFakeSession(resolve)
     catalog = ToolCatalog()
 
-    with pytest.raises(Exception, match=r"exceeded 64 pages"):
+    with pytest.raises(McpToolsListError, match=r"exceeded 64 pages") as exc_info:
         await register_mcp_server(catalog, name="demo", session=session)
+    assert exc_info.value.code == "PaginationExceeded"
     assert not catalog.has("demo__endless")
 
 

--- a/src/sdk/python/tests/test_mcp.py
+++ b/src/sdk/python/tests/test_mcp.py
@@ -6,8 +6,10 @@ require the optional `mcp` package. A separate test pins the helpful error when
 `mcp` is absent.
 """
 
+import importlib.metadata
 import importlib.util
-from collections.abc import Callable
+from collections.abc import AsyncGenerator, Callable
+from contextlib import asynccontextmanager
 from typing import Any
 
 import pytest
@@ -19,6 +21,108 @@ from ratel_ai.mcp import McpToolsListError
 @pytest.fixture
 def skip_mcp_import_check(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("ratel_ai.mcp._require_mcp", lambda: None)
+
+
+def _mcp_major_version() -> int:
+    return int(importlib.metadata.version("mcp").split(".", maxsplit=1)[0])
+
+
+@asynccontextmanager
+async def _memory_client_session(server: Any) -> AsyncGenerator[Any, None]:
+    """Yield an initialized ClientSession over in-memory transport (mcp 1.x and 2.x)."""
+    memory_mod = __import__("mcp.shared.memory", fromlist=["create_client_server_memory_streams"])
+    create_connected = getattr(memory_mod, "create_connected_server_and_client_session", None)
+    if create_connected is not None:
+        async with create_connected(server) as session:
+            yield session
+        return
+
+    import anyio
+    from mcp.client.session import ClientSession
+
+    async with memory_mod.create_client_server_memory_streams() as (
+        client_streams,
+        server_streams,
+    ):
+        client_read, client_write = client_streams
+        server_read, server_write = server_streams
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(
+                lambda: server.run(
+                    server_read,
+                    server_write,
+                    server.create_initialization_options(),
+                    raise_exceptions=False,
+                )
+            )
+            async with ClientSession(
+                read_stream=client_read,
+                write_stream=client_write,
+            ) as session:
+                await session.initialize()
+                yield session
+            tg.cancel_scope.cancel()
+
+
+def _paginated_probe_server() -> Any:
+    """Server that returns two pages of tools/list (decorator API on 1.x, handlers on 2.x)."""
+    if _mcp_major_version() >= 2:
+        import mcp_types as types
+        from mcp.server.lowlevel.server import Server
+
+        tools = [
+            types.Tool(name="alpha", description="first page", inputSchema={"type": "object"}),
+            types.Tool(name="beta", description="first page", inputSchema={"type": "object"}),
+            types.Tool(name="gamma", description="second page", inputSchema={"type": "object"}),
+        ]
+
+        async def on_list_tools(
+            _ctx: Any, params: types.PaginatedRequestParams | None
+        ) -> types.ListToolsResult:
+            cursor = None if params is None else params.cursor
+            if cursor is None:
+                return types.ListToolsResult(tools=tools[:2], nextCursor="page-2")
+            if cursor == "page-2":
+                return types.ListToolsResult(tools=tools[2:])
+            raise RuntimeError(f"unexpected tools/list cursor: {cursor!r}")
+
+        async def on_call_tool(
+            _ctx: Any, params: types.CallToolRequestParams
+        ) -> types.CallToolResult:
+            return types.CallToolResult(
+                content=[types.TextContent(type="text", text=params.name)],
+            )
+
+        return Server(
+            "ratel-pagination-probe",
+            on_list_tools=on_list_tools,
+            on_call_tool=on_call_tool,
+        )
+
+    from mcp import types
+    from mcp.server import Server
+
+    server = Server("ratel-pagination-probe")
+    tools = [
+        types.Tool(name="alpha", description="first page", inputSchema={"type": "object"}),
+        types.Tool(name="beta", description="first page", inputSchema={"type": "object"}),
+        types.Tool(name="gamma", description="second page", inputSchema={"type": "object"}),
+    ]
+
+    @server.list_tools()
+    async def handle_list_tools(request: types.ListToolsRequest) -> types.ListToolsResult:
+        cursor = None if request.params is None else request.params.cursor
+        if cursor is None:
+            return types.ListToolsResult(tools=tools[:2], nextCursor="page-2")
+        if cursor == "page-2":
+            return types.ListToolsResult(tools=tools[2:])
+        raise RuntimeError(f"unexpected tools/list cursor: {cursor!r}")
+
+    @server.call_tool()
+    async def handle_call_tool(name: str, arguments: dict | None) -> list[types.TextContent]:
+        return [types.TextContent(type="text", text=name)]
+
+    return server
 
 
 class _FakeTool:
@@ -439,33 +543,9 @@ async def test_register_mcp_server_paginated_list_tools_real_client_session() ->
     """Exercise list_tools pagination against a real in-memory ClientSession."""
     pytest.importorskip("mcp", reason="install ratel-ai[mcp] to run real MCP session tests")
 
-    from mcp import types
-    from mcp.server import Server
-    from mcp.shared.memory import create_connected_server_and_client_session
-
-    server = Server("ratel-pagination-probe")
-    tools = [
-        types.Tool(name="alpha", description="first page", inputSchema={"type": "object"}),
-        types.Tool(name="beta", description="first page", inputSchema={"type": "object"}),
-        types.Tool(name="gamma", description="second page", inputSchema={"type": "object"}),
-    ]
-
-    @server.list_tools()
-    async def handle_list_tools(request: types.ListToolsRequest) -> types.ListToolsResult:
-        cursor = None if request.params is None else request.params.cursor
-        if cursor is None:
-            return types.ListToolsResult(tools=tools[:2], nextCursor="page-2")
-        if cursor == "page-2":
-            return types.ListToolsResult(tools=tools[2:])
-        raise RuntimeError(f"unexpected tools/list cursor: {cursor!r}")
-
-    @server.call_tool()
-    async def handle_call_tool(name: str, arguments: dict | None) -> list[types.TextContent]:
-        return [types.TextContent(type="text", text=name)]
-
+    server = _paginated_probe_server()
     catalog = ToolCatalog(trace=TraceSinkConfig(kind="memory", session_id="mcp-real"))
-    async with create_connected_server_and_client_session(server) as session:
-        await session.initialize()
+    async with _memory_client_session(server) as session:
         handle = await register_mcp_server(catalog, name="demo", session=session)
         assert handle.tool_ids == ["demo__alpha", "demo__beta", "demo__gamma"]
 

--- a/src/sdk/python/tests/test_mcp.py
+++ b/src/sdk/python/tests/test_mcp.py
@@ -14,7 +14,13 @@ from typing import Any
 
 import pytest
 
-from ratel_ai import EmbedderError, McpToolsListError, ToolCatalog, TraceSinkConfig, register_mcp_server
+from ratel_ai import (
+    EmbedderError,
+    McpToolsListError,
+    ToolCatalog,
+    TraceSinkConfig,
+    register_mcp_server,
+)
 
 
 @pytest.fixture

--- a/src/sdk/python/tests/test_mcp.py
+++ b/src/sdk/python/tests/test_mcp.py
@@ -30,9 +30,9 @@ class _FakeTool:
 
 
 class _FakeListResult:
-    def __init__(self, tools, *, next_cursor: str | None = None):
+    def __init__(self, tools, *, nextCursor: str | None = None):
         self.tools = tools
-        self.next_cursor = next_cursor
+        self.nextCursor = nextCursor
 
 
 class _FakeSession:
@@ -94,7 +94,7 @@ class _PaginatedFakeSession:
         next_cursor = page.get("next_cursor")
         if next_cursor is None and "nextCursor" in page:
             next_cursor = page["nextCursor"]
-        return _FakeListResult(tools, next_cursor=next_cursor)
+        return _FakeListResult(tools, nextCursor=next_cursor)
 
     async def call_tool(self, name: str, args: dict[str, Any]) -> Any:
         self.calls.append((name, args))
@@ -433,3 +433,41 @@ async def test_register_mcp_server_duplicate_tool_name_last_page_wins(
     assert handle.tool_ids == ["demo__dup", "demo__dup"]
     result = await catalog.invoke("demo__dup", {})
     assert result == {"version": "second"}
+
+
+async def test_register_mcp_server_paginated_list_tools_real_client_session() -> None:
+    """Exercise list_tools pagination against a real in-memory ClientSession."""
+    pytest.importorskip("mcp", reason="install ratel-ai[mcp] to run real MCP session tests")
+
+    from mcp import types
+    from mcp.server import Server
+    from mcp.shared.memory import create_connected_server_and_client_session
+
+    server = Server("ratel-pagination-probe")
+    tools = [
+        types.Tool(name="alpha", description="first page", inputSchema={"type": "object"}),
+        types.Tool(name="beta", description="first page", inputSchema={"type": "object"}),
+        types.Tool(name="gamma", description="second page", inputSchema={"type": "object"}),
+    ]
+
+    @server.list_tools()
+    async def handle_list_tools(request: types.ListToolsRequest) -> types.ListToolsResult:
+        cursor = None if request.params is None else request.params.cursor
+        if cursor is None:
+            return types.ListToolsResult(tools=tools[:2], nextCursor="page-2")
+        if cursor == "page-2":
+            return types.ListToolsResult(tools=tools[2:])
+        raise RuntimeError(f"unexpected tools/list cursor: {cursor!r}")
+
+    @server.call_tool()
+    async def handle_call_tool(name: str, arguments: dict | None) -> list[types.TextContent]:
+        return [types.TextContent(type="text", text=name)]
+
+    catalog = ToolCatalog(trace=TraceSinkConfig(kind="memory", session_id="mcp-real"))
+    async with create_connected_server_and_client_session(server) as session:
+        await session.initialize()
+        handle = await register_mcp_server(catalog, name="demo", session=session)
+        assert handle.tool_ids == ["demo__alpha", "demo__beta", "demo__gamma"]
+
+    register_events = [e for e in catalog.drain_trace_events() if e["type"] == "upstream_register"]
+    assert register_events[0]["tool_count"] == 3

--- a/src/sdk/python/tests/test_mcp.py
+++ b/src/sdk/python/tests/test_mcp.py
@@ -14,8 +14,7 @@ from typing import Any
 
 import pytest
 
-from ratel_ai import EmbedderError, ToolCatalog, TraceSinkConfig, register_mcp_server
-from ratel_ai.mcp import McpToolsListError
+from ratel_ai import EmbedderError, McpToolsListError, ToolCatalog, TraceSinkConfig, register_mcp_server
 
 
 @pytest.fixture

--- a/src/sdk/python/tests/test_mcp.py
+++ b/src/sdk/python/tests/test_mcp.py
@@ -7,10 +7,25 @@ require the optional `mcp` package. A separate test pins the helpful error when
 """
 
 import importlib.util
+from collections.abc import Callable
+from typing import Any
 
 import pytest
 
 from ratel_ai import EmbedderError, ToolCatalog, TraceSinkConfig, register_mcp_server
+
+
+@pytest.fixture
+def skip_mcp_import_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("ratel_ai.mcp._require_mcp", lambda: None)
+
+
+def _cursor_from_list_tools_params(params: Any) -> str | None:
+    if params is None:
+        return None
+    if isinstance(params, dict):
+        return params.get("cursor")
+    return getattr(params, "cursor", None)
 
 
 class _FakeTool:
@@ -22,15 +37,16 @@ class _FakeTool:
 
 
 class _FakeListResult:
-    def __init__(self, tools):
+    def __init__(self, tools, *, next_cursor: str | None = None):
         self.tools = tools
+        self.next_cursor = next_cursor
 
 
 class _FakeSession:
     def __init__(self):
         self.calls = []
 
-    async def list_tools(self):
+    async def list_tools(self, *, params=None):
         return _FakeListResult(
             [_FakeTool("create_issue", "Create a GitHub issue.", {"type": "object"})]
         )
@@ -40,8 +56,62 @@ class _FakeSession:
         return {"ok": True, "name": name}
 
 
-async def test_register_mcp_server_namespaces_and_wires(monkeypatch) -> None:
-    monkeypatch.setattr("ratel_ai.mcp._require_mcp", lambda: None)
+class _PaginatedFakeSession:
+    def __init__(
+        self,
+        pages: list[dict[str, Any]]
+        | Callable[[str | None], dict[str, Any] | Exception],
+    ) -> None:
+        self._pages = pages
+        self._handlers: dict[str, Callable[[dict[str, Any]], Any]] = {}
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def _resolve_page(self, cursor: str | None) -> dict[str, Any]:
+        pages = self._pages
+        if callable(pages):
+            result = pages(cursor)
+            if isinstance(result, Exception):
+                raise result
+            return result
+        if cursor is None:
+            if not pages:
+                raise RuntimeError("paginated fake MCP has no first page")
+            return pages[0]
+        for i in range(len(pages) - 1):
+            if pages[i].get("next_cursor") == cursor:
+                return pages[i + 1]
+        raise RuntimeError(f"unexpected tools/list cursor: {cursor}")
+
+    def _tools_from_page(self, page: dict[str, Any]) -> list[_FakeTool]:
+        out: list[_FakeTool] = []
+        for spec in page.get("tools", []):
+            if isinstance(spec, _FakeTool):
+                out.append(spec)
+                continue
+            name = spec["name"]
+            description = spec.get("description") or ""
+            out.append(_FakeTool(name, description, {"type": "object"}))
+            if "handler" in spec:
+                self._handlers[name] = spec["handler"]
+        return out
+
+    async def list_tools(self, *, params=None) -> _FakeListResult:
+        page = self._resolve_page(_cursor_from_list_tools_params(params))
+        tools = self._tools_from_page(page)
+        next_cursor = page.get("next_cursor")
+        if next_cursor is None and "nextCursor" in page:
+            next_cursor = page["nextCursor"]
+        return _FakeListResult(tools, next_cursor=next_cursor)
+
+    async def call_tool(self, name: str, args: dict[str, Any]) -> Any:
+        self.calls.append((name, args))
+        handler = self._handlers.get(name)
+        if handler is not None:
+            return handler(args)
+        return {"ok": True, "name": name}
+
+
+async def test_register_mcp_server_namespaces_and_wires(skip_mcp_import_check) -> None:
     catalog = ToolCatalog(trace=TraceSinkConfig(kind="memory", session_id="s"))
     session = _FakeSession()
 
@@ -72,9 +142,7 @@ async def test_register_mcp_server_namespaces_and_wires(monkeypatch) -> None:
     await handle.close()  # default no-op close is awaitable
 
 
-async def test_register_mcp_server_records_upstream_error(monkeypatch) -> None:
-    monkeypatch.setattr("ratel_ai.mcp._require_mcp", lambda: None)
-
+async def test_register_mcp_server_records_upstream_error(skip_mcp_import_check) -> None:
     class _BoomSession(_FakeSession):
         async def call_tool(self, name, args):
             raise RuntimeError("upstream down")
@@ -88,11 +156,10 @@ async def test_register_mcp_server_records_upstream_error(monkeypatch) -> None:
     assert errors[0]["server"] == "github"
 
 
-async def test_register_mcp_server_embeds_during_registration(monkeypatch) -> None:
+async def test_register_mcp_server_embeds_during_registration(skip_mcp_import_check) -> None:
     # Embedding now happens inside `catalog.register` (RAT-379/async-register),
     # which `register_mcp_server` awaits — so a broken model surfaces the error
     # right out of `register_mcp_server` itself, not from a later, separate build.
-    monkeypatch.setattr("ratel_ai.mcp._require_mcp", lambda: None)
     catalog = ToolCatalog(method="semantic", embedding={"local": "/missing/ratel-model"})
 
     with pytest.raises(EmbedderError, match="/missing/ratel-model"):
@@ -108,3 +175,266 @@ async def test_register_mcp_server_requires_mcp_when_absent() -> None:
         pytest.skip("mcp is installed; the absent-dependency path cannot be exercised")
     with pytest.raises(ImportError, match=r"ratel-ai\[mcp\]"):
         await register_mcp_server(ToolCatalog(), name="x", session=object())
+
+
+async def test_register_mcp_server_lists_every_page_and_aggregates_tool_count(
+    skip_mcp_import_check,
+) -> None:
+    session = _PaginatedFakeSession(
+        [
+            {
+                "tools": [
+                    {
+                        "name": "page_one",
+                        "description": "first page tool",
+                        "handler": lambda _args: {"page": 1},
+                    }
+                ],
+                "next_cursor": "page-2",
+            },
+            {
+                "tools": [
+                    {
+                        "name": "page_two",
+                        "description": "second page tool",
+                        "handler": lambda _args: {"page": 2},
+                    }
+                ],
+            },
+        ]
+    )
+    catalog = ToolCatalog(trace=TraceSinkConfig(kind="memory", session_id="t"))
+    handle = await register_mcp_server(catalog, name="demo", session=session)
+
+    assert handle.tool_ids == ["demo__page_one", "demo__page_two"]
+    assert catalog.has("demo__page_one")
+    assert catalog.has("demo__page_two")
+
+    hits = catalog.search("second page tool", 5)
+    assert any(h.tool_id == "demo__page_two" for h in hits)
+
+    register_events = [e for e in catalog.drain_trace_events() if e["type"] == "upstream_register"]
+    assert register_events[0]["tool_count"] == 2
+
+    result = await catalog.invoke("demo__page_two", {})
+    assert result == {"page": 2}
+
+
+async def test_register_mcp_server_follows_empty_tools_page(skip_mcp_import_check) -> None:
+    session = _PaginatedFakeSession(
+        [
+            {"tools": [], "next_cursor": "after-empty"},
+            {
+                "tools": [
+                    {
+                        "name": "after_empty",
+                        "description": "tool listed after an empty page",
+                        "handler": lambda _args: {"ok": True},
+                    }
+                ],
+            },
+        ]
+    )
+    catalog = ToolCatalog()
+    handle = await register_mcp_server(catalog, name="demo", session=session)
+
+    assert handle.tool_ids == ["demo__after_empty"]
+    assert catalog.has("demo__after_empty")
+
+
+async def test_register_mcp_server_follows_empty_string_next_cursor(skip_mcp_import_check) -> None:
+    session = _PaginatedFakeSession(
+        [
+            {"tools": [], "next_cursor": ""},
+            {
+                "tools": [
+                    {
+                        "name": "after_empty_cursor",
+                        "description": "tool listed after empty-string cursor",
+                        "handler": lambda _args: {"ok": True},
+                    }
+                ],
+            },
+        ]
+    )
+    catalog = ToolCatalog()
+    handle = await register_mcp_server(catalog, name="demo", session=session)
+
+    assert handle.tool_ids == ["demo__after_empty_cursor"]
+    assert catalog.has("demo__after_empty_cursor")
+
+
+async def test_register_mcp_server_rejects_repeated_next_cursor(skip_mcp_import_check) -> None:
+    session = _PaginatedFakeSession(
+        [
+            {
+                "tools": [
+                    {
+                        "name": "stuck",
+                        "description": "stuck in pagination",
+                        "handler": lambda _args: {},
+                    }
+                ],
+                "next_cursor": "loop",
+            },
+            {
+                "tools": [
+                    {
+                        "name": "again",
+                        "description": "another page",
+                        "handler": lambda _args: {},
+                    }
+                ],
+                "next_cursor": "loop",
+            },
+        ]
+    )
+    catalog = ToolCatalog()
+
+    with pytest.raises(Exception, match=r"repeated nextCursor"):
+        await register_mcp_server(catalog, name="demo", session=session)
+    assert not catalog.has("demo__stuck")
+
+
+async def test_register_mcp_server_rejects_when_page_cap_exceeded(skip_mcp_import_check) -> None:
+    page_num = 0
+
+    def resolve(cursor: str | None) -> dict[str, Any]:
+        nonlocal page_num
+        if cursor is not None and not cursor.startswith("cap-page-"):
+            raise RuntimeError(f"unexpected cursor: {cursor}")
+        page_num += 1
+        return {
+            "tools": (
+                [
+                    {
+                        "name": "endless",
+                        "description": "never finishes",
+                        "handler": lambda _args: {},
+                    }
+                ]
+                if page_num == 1
+                else []
+            ),
+            "next_cursor": f"cap-page-{page_num}",
+        }
+
+    session = _PaginatedFakeSession(resolve)
+    catalog = ToolCatalog()
+
+    with pytest.raises(Exception, match=r"exceeded 64 pages"):
+        await register_mcp_server(catalog, name="demo", session=session)
+    assert not catalog.has("demo__endless")
+
+
+async def test_register_mcp_server_does_not_mutate_catalog_when_later_page_fails(
+    skip_mcp_import_check,
+) -> None:
+    def resolve(cursor: str | None) -> dict[str, Any] | Exception:
+        if cursor is None:
+            return {
+                "tools": [
+                    {
+                        "name": "first_page",
+                        "description": "only on page one",
+                        "handler": lambda _args: {},
+                    }
+                ],
+                "next_cursor": "page-2",
+            }
+        return RuntimeError("list page two failed")
+
+    session = _PaginatedFakeSession(resolve)
+    catalog = ToolCatalog()
+
+    with pytest.raises(RuntimeError, match="list page two failed"):
+        await register_mcp_server(catalog, name="demo", session=session)
+    assert not catalog.has("demo__first_page")
+
+
+async def test_register_mcp_server_retries_after_list_failure_with_new_session(
+    skip_mcp_import_check,
+) -> None:
+    catalog = ToolCatalog()
+
+    failing = _PaginatedFakeSession(
+        lambda cursor: (
+            {
+                "tools": [
+                    {
+                        "name": "first_page",
+                        "description": "only on page one",
+                        "handler": lambda _args: {},
+                    }
+                ],
+                "next_cursor": "page-2",
+            }
+            if cursor is None
+            else RuntimeError("list page two failed")
+        )
+    )
+    with pytest.raises(RuntimeError, match="list page two failed"):
+        await register_mcp_server(catalog, name="demo", session=failing)
+
+    retry_session = _PaginatedFakeSession(
+        lambda cursor: (
+            {
+                "tools": [
+                    {
+                        "name": "first_page",
+                        "description": "only on page one",
+                        "handler": lambda _args: {},
+                    }
+                ],
+            }
+            if cursor is None
+            else RuntimeError("unexpected cursor on retry")
+        )
+    )
+    handle = await register_mcp_server(catalog, name="demo", session=retry_session)
+    assert handle.tool_ids == ["demo__first_page"]
+    assert catalog.has("demo__first_page")
+
+
+async def test_register_mcp_server_empty_unpaginated_list(skip_mcp_import_check) -> None:
+    session = _PaginatedFakeSession([{"tools": []}])
+    catalog = ToolCatalog(trace=TraceSinkConfig(kind="memory", session_id="t"))
+    handle = await register_mcp_server(catalog, name="demo", session=session)
+
+    assert handle.tool_ids == []
+    register_events = [e for e in catalog.drain_trace_events() if e["type"] == "upstream_register"]
+    assert register_events[0]["tool_count"] == 0
+
+
+async def test_register_mcp_server_duplicate_tool_name_last_page_wins(
+    skip_mcp_import_check,
+) -> None:
+    session = _PaginatedFakeSession(
+        [
+            {
+                "tools": [
+                    {
+                        "name": "dup",
+                        "description": "first listing",
+                        "handler": lambda _args: {"version": "first"},
+                    }
+                ],
+                "next_cursor": "page-2",
+            },
+            {
+                "tools": [
+                    {
+                        "name": "dup",
+                        "description": "second listing wins",
+                        "handler": lambda _args: {"version": "second"},
+                    }
+                ],
+            },
+        ]
+    )
+    catalog = ToolCatalog()
+    handle = await register_mcp_server(catalog, name="demo", session=session)
+
+    assert handle.tool_ids == ["demo__dup", "demo__dup"]
+    result = await catalog.invoke("demo__dup", {})
+    assert result == {"version": "second"}

--- a/src/sdk/python/tests/test_mcp.py
+++ b/src/sdk/python/tests/test_mcp.py
@@ -21,14 +21,6 @@ def skip_mcp_import_check(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("ratel_ai.mcp._require_mcp", lambda: None)
 
 
-def _cursor_from_list_tools_params(params: Any) -> str | None:
-    if params is None:
-        return None
-    if isinstance(params, dict):
-        return params.get("cursor")
-    return getattr(params, "cursor", None)
-
-
 class _FakeTool:
     def __init__(self, name, description, input_schema):
         self.name = name
@@ -47,7 +39,7 @@ class _FakeSession:
     def __init__(self):
         self.calls = []
 
-    async def list_tools(self, *, params=None):
+    async def list_tools(self, cursor: str | None = None):
         return _FakeListResult(
             [_FakeTool("create_issue", "Create a GitHub issue.", {"type": "object"})]
         )
@@ -96,8 +88,8 @@ class _PaginatedFakeSession:
                 self._handlers[name] = spec["handler"]
         return out
 
-    async def list_tools(self, *, params=None) -> _FakeListResult:
-        page = self._resolve_page(_cursor_from_list_tools_params(params))
+    async def list_tools(self, cursor: str | None = None) -> _FakeListResult:
+        page = self._resolve_page(cursor)
         tools = self._tools_from_page(page)
         next_cursor = page.get("next_cursor")
         if next_cursor is None and "nextCursor" in page:

--- a/src/sdk/ts/src/index.ts
+++ b/src/sdk/ts/src/index.ts
@@ -59,8 +59,8 @@ export type {
 } from "./compat.js";
 export { SEARCH_TOOLS_ID, searchToolsTool } from "./compat.js";
 export { DimensionMismatchError, EmbedderError } from "./errors.js";
-export type { McpServerHandle, RegisterMcpServerOptions } from "./mcp.js";
-export { registerMcpServer } from "./mcp.js";
+export type { McpServerHandle, McpToolsListErrorCode, RegisterMcpServerOptions } from "./mcp.js";
+export { McpToolsListError, registerMcpServer } from "./mcp.js";
 // The framework-adapter SPI and factory (ADR-0013): `ratel(config).adaptTo(adapter)`.
 export type {
   AdaptedBase,

--- a/src/sdk/ts/src/mcp.test.ts
+++ b/src/sdk/ts/src/mcp.test.ts
@@ -144,10 +144,11 @@ describe("registerMcpServer", () => {
     await handle.close();
   });
 
-  it("embeds during registration; a broken model surfaces the error from registerMcpServer, but metadata persists", async () => {
+  it("surfaces embed errors from registerMcpServer, leaves metadata, and closes the client", async () => {
     // Embedding now happens inside `catalog.register` (RAT-379/async-register),
     // which `registerMcpServer` awaits — so a broken model surfaces the error
     // right out of `registerMcpServer` itself, not from a later, separate build.
+    const closeSpy = vi.spyOn(Client.prototype, "close").mockResolvedValue(undefined);
     const catalog = new ToolCatalog({
       method: "semantic",
       embedding: { local: "/definitely/missing/ratel-embedding-model" },
@@ -160,18 +161,6 @@ describe("registerMcpServer", () => {
     // Metadata registration happens before the embedding pass inside
     // `catalog.register`, so it persists even though the embed itself failed.
     expect(catalog.has("demo__read_file")).toBe(true);
-  });
-
-  it("closes the MCP client when catalog.register fails", async () => {
-    const closeSpy = vi.spyOn(Client.prototype, "close").mockResolvedValue(undefined);
-    const catalog = new ToolCatalog({
-      method: "semantic",
-      embedding: { local: "/definitely/missing/ratel-embedding-model" },
-    });
-
-    await expect(
-      registerMcpServer(catalog, { name: "demo", transport: fake.clientTransport }),
-    ).rejects.toThrow(/failed to load embedding model/);
     expect(closeSpy).toHaveBeenCalled();
     closeSpy.mockRestore();
   });
@@ -447,6 +436,32 @@ describe("registerMcpServer tools/list pagination", () => {
 
     expect(handle.toolIds).toEqual(["demo__after_empty"]);
     expect(catalog.has("demo__after_empty")).toBe(true);
+
+    await handle.close();
+    await paginated.server.close();
+  });
+
+  it("follows nextCursor when it is an empty string (not omitted)", async () => {
+    const paginated = await startPaginatedFakeMcpServer([
+      { tools: [], nextCursor: "" },
+      {
+        tools: [
+          {
+            name: "after_empty_cursor",
+            description: "tool listed after empty-string cursor",
+            handler: () => ({ ok: true }),
+          },
+        ],
+      },
+    ]);
+    const catalog = new ToolCatalog();
+    const handle = await registerMcpServer(catalog, {
+      name: "demo",
+      transport: paginated.clientTransport,
+    });
+
+    expect(handle.toolIds).toEqual(["demo__after_empty_cursor"]);
+    expect(catalog.has("demo__after_empty_cursor")).toBe(true);
 
     await handle.close();
     await paginated.server.close();

--- a/src/sdk/ts/src/mcp.test.ts
+++ b/src/sdk/ts/src/mcp.test.ts
@@ -9,7 +9,7 @@ import {
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { registerMcpServer, ToolCatalog } from "./index.js";
+import { McpToolsListError, registerMcpServer, ToolCatalog } from "./index.js";
 
 interface ServerToolSpec {
   name: string;
@@ -482,9 +482,13 @@ describe("registerMcpServer tools/list pagination", () => {
 
     await expect(
       registerMcpServer(catalog, { name: "demo", transport: paginated.clientTransport }),
-    ).rejects.toMatchObject({
-      code: "RepeatedCursor",
-      message: expect.stringMatching(/repeated nextCursor/i),
+    ).rejects.toSatisfy((err: unknown) => {
+      expect(err).toBeInstanceOf(McpToolsListError);
+      expect(err).toMatchObject({
+        code: "RepeatedCursor",
+        message: expect.stringMatching(/repeated nextCursor/i),
+      });
+      return true;
     });
     expect(catalog.has("demo__stuck")).toBe(false);
 

--- a/src/sdk/ts/src/mcp.test.ts
+++ b/src/sdk/ts/src/mcp.test.ts
@@ -162,6 +162,20 @@ describe("registerMcpServer", () => {
     expect(catalog.has("demo__read_file")).toBe(true);
   });
 
+  it("closes the MCP client when catalog.register fails", async () => {
+    const closeSpy = vi.spyOn(Client.prototype, "close").mockResolvedValue(undefined);
+    const catalog = new ToolCatalog({
+      method: "semantic",
+      embedding: { local: "/definitely/missing/ratel-embedding-model" },
+    });
+
+    await expect(
+      registerMcpServer(catalog, { name: "demo", transport: fake.clientTransport }),
+    ).rejects.toThrow(/failed to load embedding model/);
+    expect(closeSpy).toHaveBeenCalled();
+    closeSpy.mockRestore();
+  });
+
   it("makes upstream tools discoverable via catalog.search using their description", async () => {
     const catalog = new ToolCatalog();
     const handle = await registerMcpServer(catalog, {

--- a/src/sdk/ts/src/mcp.test.ts
+++ b/src/sdk/ts/src/mcp.test.ts
@@ -1,3 +1,4 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
@@ -7,7 +8,7 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerMcpServer, ToolCatalog } from "./index.js";
 
 interface ServerToolSpec {
@@ -23,10 +24,32 @@ interface FakeMcp {
   clientTransport: InMemoryTransport;
 }
 
-async function startFakeMcpServer(
-  tools: ServerToolSpec[],
+interface PaginatedToolsPage {
+  tools: ServerToolSpec[];
+  nextCursor?: string;
+}
+
+async function startPaginatedFakeMcpServer(
+  pages: PaginatedToolsPage[] | ((cursor: string | undefined) => PaginatedToolsPage | Error),
   serverOptions?: { instructions?: string },
 ): Promise<FakeMcp> {
+  const resolvePage = (cursor: string | undefined): PaginatedToolsPage | Error => {
+    if (typeof pages === "function") {
+      return pages(cursor);
+    }
+    if (cursor === undefined) {
+      return pages[0] ?? new Error("paginated fake MCP has no first page");
+    }
+    for (let i = 0; i < pages.length - 1; i++) {
+      if (pages[i].nextCursor === cursor) {
+        return pages[i + 1];
+      }
+    }
+    return new Error(`unexpected tools/list cursor: ${cursor}`);
+  };
+
+  const toolByName = new Map<string, ServerToolSpec>();
+
   const server = new Server(
     { name: "fake-mcp", version: "0.0.0" },
     {
@@ -35,17 +58,28 @@ async function startFakeMcpServer(
     },
   );
 
-  server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: tools.map((t) => ({
-      name: t.name,
-      description: t.description,
-      inputSchema: t.inputSchema ?? { type: "object" },
-      ...(t.outputSchema ? { outputSchema: t.outputSchema } : {}),
-    })),
-  }));
+  server.setRequestHandler(ListToolsRequestSchema, async (req) => {
+    const cursor = req.params?.cursor as string | undefined;
+    const page = resolvePage(cursor);
+    if (page instanceof Error) {
+      throw page;
+    }
+    for (const spec of page.tools) {
+      toolByName.set(spec.name, spec);
+    }
+    return {
+      tools: page.tools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema ?? { type: "object" },
+        ...(t.outputSchema ? { outputSchema: t.outputSchema } : {}),
+      })),
+      ...(page.nextCursor !== undefined ? { nextCursor: page.nextCursor } : {}),
+    };
+  });
 
   server.setRequestHandler(CallToolRequestSchema, async (req) => {
-    const spec = tools.find((t) => t.name === req.params.name);
+    const spec = toolByName.get(req.params.name);
     if (!spec) {
       throw new Error(`unknown tool: ${req.params.name}`);
     }
@@ -60,6 +94,13 @@ async function startFakeMcpServer(
   const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
   await server.connect(serverTransport);
   return { server, clientTransport };
+}
+
+async function startFakeMcpServer(
+  tools: ServerToolSpec[],
+  serverOptions?: { instructions?: string },
+): Promise<FakeMcp> {
+  return startPaginatedFakeMcpServer([{ tools }], serverOptions);
 }
 
 describe("registerMcpServer", () => {
@@ -329,5 +370,236 @@ describe("registerMcpServer", () => {
     expect(result.structuredContent).toEqual({ contents: "contents of /etc/hosts" });
 
     await handle.close();
+  });
+});
+
+describe("registerMcpServer tools/list pagination", () => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    trace.disable();
+  });
+
+  it("registers tools from every page and reports the aggregated tool count", async () => {
+    const paginated = await startPaginatedFakeMcpServer([
+      {
+        tools: [{ name: "page_one", description: "first page tool", handler: () => ({ page: 1 }) }],
+        nextCursor: "page-2",
+      },
+      {
+        tools: [
+          { name: "page_two", description: "second page tool", handler: () => ({ page: 2 }) },
+        ],
+      },
+    ]);
+    const catalog = new ToolCatalog({ trace: { kind: "memory", sessionId: "t" } });
+    const handle = await registerMcpServer(catalog, {
+      name: "demo",
+      transport: paginated.clientTransport,
+    });
+
+    expect(handle.toolIds).toEqual(["demo__page_one", "demo__page_two"]);
+    expect(catalog.has("demo__page_one")).toBe(true);
+    expect(catalog.has("demo__page_two")).toBe(true);
+
+    const hits = catalog.search("second page tool", 5);
+    expect(hits.some((h) => h.toolId === "demo__page_two")).toBe(true);
+
+    const events = catalog.drainTraceEvents() as Array<Record<string, unknown>>;
+    const reg = events.find((e) => e.type === "upstream_register");
+    expect(reg?.tool_count).toBe(2);
+
+    await handle.close();
+    await paginated.server.close();
+  });
+
+  it("follows nextCursor across an empty tools page", async () => {
+    const paginated = await startPaginatedFakeMcpServer([
+      { tools: [], nextCursor: "after-empty" },
+      {
+        tools: [
+          {
+            name: "after_empty",
+            description: "tool listed after an empty page",
+            handler: () => ({ ok: true }),
+          },
+        ],
+      },
+    ]);
+    const catalog = new ToolCatalog();
+    const handle = await registerMcpServer(catalog, {
+      name: "demo",
+      transport: paginated.clientTransport,
+    });
+
+    expect(handle.toolIds).toEqual(["demo__after_empty"]);
+    expect(catalog.has("demo__after_empty")).toBe(true);
+
+    await handle.close();
+    await paginated.server.close();
+  });
+
+  it("rejects when the server repeats the same nextCursor", async () => {
+    const paginated = await startPaginatedFakeMcpServer([
+      {
+        tools: [{ name: "stuck", description: "stuck in pagination", handler: () => ({}) }],
+        nextCursor: "loop",
+      },
+      {
+        tools: [{ name: "again", description: "another page", handler: () => ({}) }],
+        nextCursor: "loop",
+      },
+    ]);
+    const catalog = new ToolCatalog();
+
+    await expect(
+      registerMcpServer(catalog, { name: "demo", transport: paginated.clientTransport }),
+    ).rejects.toMatchObject({
+      code: "RepeatedCursor",
+      message: expect.stringMatching(/repeated nextCursor/i),
+    });
+    expect(catalog.has("demo__stuck")).toBe(false);
+
+    await paginated.server.close();
+  });
+
+  it("rejects when tools/list exceeds the page cap", async () => {
+    let pageNum = 0;
+    const paginated = await startPaginatedFakeMcpServer((cursor) => {
+      if (cursor !== undefined && !cursor.startsWith("cap-page-")) {
+        return new Error(`unexpected cursor: ${cursor}`);
+      }
+      pageNum += 1;
+      return {
+        tools:
+          pageNum === 1
+            ? [{ name: "endless", description: "never finishes", handler: () => ({}) }]
+            : [],
+        nextCursor: `cap-page-${pageNum}`,
+      };
+    });
+    const catalog = new ToolCatalog();
+
+    await expect(
+      registerMcpServer(catalog, { name: "demo", transport: paginated.clientTransport }),
+    ).rejects.toMatchObject({
+      code: "PaginationExceeded",
+      message: expect.stringMatching(/exceeded 64 pages/i),
+    });
+    expect(catalog.has("demo__endless")).toBe(false);
+
+    await paginated.server.close();
+  });
+
+  it("closes the MCP client when a later list page fails", async () => {
+    const closeSpy = vi.spyOn(Client.prototype, "close").mockResolvedValue(undefined);
+    const paginated = await startPaginatedFakeMcpServer((cursor) => {
+      if (cursor === undefined) {
+        return {
+          tools: [{ name: "first_page", description: "page one", handler: () => ({}) }],
+          nextCursor: "page-2",
+        };
+      }
+      return new Error("list page two failed");
+    });
+    const catalog = new ToolCatalog();
+
+    await expect(
+      registerMcpServer(catalog, { name: "demo", transport: paginated.clientTransport }),
+    ).rejects.toThrow(/list page two failed/);
+    expect(closeSpy).toHaveBeenCalled();
+    expect(catalog.has("demo__first_page")).toBe(false);
+
+    await paginated.server.close();
+  });
+
+  it("succeeds with zero tools when the server returns an empty unpaginated list", async () => {
+    const paginated = await startPaginatedFakeMcpServer([{ tools: [] }]);
+    const catalog = new ToolCatalog({ trace: { kind: "memory", sessionId: "t" } });
+    const handle = await registerMcpServer(catalog, {
+      name: "demo",
+      transport: paginated.clientTransport,
+    });
+
+    expect(handle.toolIds).toEqual([]);
+    const reg = (catalog.drainTraceEvents() as Array<Record<string, unknown>>).find(
+      (e) => e.type === "upstream_register",
+    );
+    expect(reg?.tool_count).toBe(0);
+
+    await handle.close();
+    await paginated.server.close();
+  });
+
+  it("does not mutate the catalog when a later list page fails", async () => {
+    const paginated = await startPaginatedFakeMcpServer((cursor) => {
+      if (cursor === undefined) {
+        return {
+          tools: [{ name: "first_page", description: "only on page one", handler: () => ({}) }],
+          nextCursor: "page-2",
+        };
+      }
+      return new Error("list page two failed");
+    });
+    const catalog = new ToolCatalog();
+
+    await expect(
+      registerMcpServer(catalog, { name: "demo", transport: paginated.clientTransport }),
+    ).rejects.toThrow(/list page two failed/);
+    expect(catalog.has("demo__first_page")).toBe(false);
+
+    const retryFake = await startPaginatedFakeMcpServer((cursor) => {
+      if (cursor === undefined) {
+        return {
+          tools: [{ name: "first_page", description: "only on page one", handler: () => ({}) }],
+        };
+      }
+      return new Error("unexpected cursor on retry");
+    });
+    const retry = await registerMcpServer(catalog, {
+      name: "demo",
+      transport: retryFake.clientTransport,
+    });
+    expect(retry.toolIds).toEqual(["demo__first_page"]);
+    await retry.close();
+    await paginated.server.close();
+    await retryFake.server.close();
+  });
+
+  it("resolves duplicate tool names across pages to the last listing (catalog batch semantics)", async () => {
+    const paginated = await startPaginatedFakeMcpServer([
+      {
+        tools: [
+          {
+            name: "dup",
+            description: "first listing",
+            handler: () => ({ version: "first" }),
+          },
+        ],
+        nextCursor: "page-2",
+      },
+      {
+        tools: [
+          {
+            name: "dup",
+            description: "second listing wins",
+            handler: () => ({ version: "second" }),
+          },
+        ],
+      },
+    ]);
+    const catalog = new ToolCatalog();
+    const handle = await registerMcpServer(catalog, {
+      name: "demo",
+      transport: paginated.clientTransport,
+    });
+
+    expect(handle.toolIds).toEqual(["demo__dup", "demo__dup"]);
+    const result = (await catalog.invoke("demo__dup", {})) as {
+      structuredContent?: { version?: string };
+    };
+    expect(result.structuredContent?.version).toBe("second");
+
+    await handle.close();
+    await paginated.server.close();
   });
 });

--- a/src/sdk/ts/src/mcp.ts
+++ b/src/sdk/ts/src/mcp.ts
@@ -7,11 +7,22 @@ import { traceUpstreamRegister } from "./telemetry.js";
 
 const MCP_LIST_MAX_PAGES = 64;
 
+/** Stable discriminant for {@link McpToolsListError} from paginated MCP `tools/list`. */
 export type McpToolsListErrorCode = "RepeatedCursor" | "PaginationExceeded";
 
+/**
+ * Paginated MCP `tools/list` failed — repeated cursor or page cap exceeded.
+ * Thrown by {@link registerMcpServer} when listing upstream tools; mirrors Python's
+ * `McpToolsListError`.
+ */
 export class McpToolsListError extends Error {
+  /** Prefer {@link McpToolsListErrorCode} (or `instanceof`) over parsing {@link Error.message}. */
   readonly code: McpToolsListErrorCode;
 
+  /**
+   * @param message - Human-readable failure description.
+   * @param code - Stable {@link McpToolsListErrorCode} discriminant.
+   */
   constructor(message: string, code: McpToolsListErrorCode) {
     super(message);
     this.name = "McpToolsListError";

--- a/src/sdk/ts/src/mcp.ts
+++ b/src/sdk/ts/src/mcp.ts
@@ -7,9 +7,9 @@ import { traceUpstreamRegister } from "./telemetry.js";
 
 const MCP_LIST_MAX_PAGES = 64;
 
-type McpToolsListErrorCode = "RepeatedCursor" | "PaginationExceeded";
+export type McpToolsListErrorCode = "RepeatedCursor" | "PaginationExceeded";
 
-class McpToolsListError extends Error {
+export class McpToolsListError extends Error {
   readonly code: McpToolsListErrorCode;
 
   constructor(message: string, code: McpToolsListErrorCode) {

--- a/src/sdk/ts/src/mcp.ts
+++ b/src/sdk/ts/src/mcp.ts
@@ -1,8 +1,95 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 
 import type { ExecutableTool, ToolCatalog } from "./catalog.js";
 import { traceUpstreamRegister } from "./telemetry.js";
+
+const MCP_LIST_MAX_PAGES = 64;
+
+type McpToolsListErrorCode = "RepeatedCursor" | "PaginationExceeded";
+
+class McpToolsListError extends Error {
+  readonly code: McpToolsListErrorCode;
+
+  constructor(message: string, code: McpToolsListErrorCode) {
+    super(message);
+    this.name = "McpToolsListError";
+    this.code = code;
+  }
+}
+
+async function listAllMcpTools(client: Client): Promise<Tool[]> {
+  const tools: Tool[] = [];
+  let cursor: string | undefined;
+  const seenCursors = new Set<string>();
+  for (let page = 0; page < MCP_LIST_MAX_PAGES; page++) {
+    const result = await client.listTools(cursor === undefined ? undefined : { cursor });
+    tools.push(...result.tools);
+    // MCP: only absent nextCursor ends pagination ("" is a valid cursor).
+    if (result.nextCursor === undefined) {
+      return tools;
+    }
+    if (seenCursors.has(result.nextCursor)) {
+      throw new McpToolsListError(
+        "MCP tools/list returned a repeated nextCursor",
+        "RepeatedCursor",
+      );
+    }
+    seenCursors.add(result.nextCursor);
+    cursor = result.nextCursor;
+  }
+  throw new McpToolsListError(
+    `MCP tools/list exceeded ${MCP_LIST_MAX_PAGES} pages`,
+    "PaginationExceeded",
+  );
+}
+
+function buildRegisteredMcpTools(
+  catalog: ToolCatalog,
+  client: Client,
+  serverName: string,
+  tools: Tool[],
+): { toolIds: string[]; registered: ExecutableTool[] } {
+  const toolIds: string[] = [];
+  const registered: ExecutableTool[] = [];
+  for (const tool of tools) {
+    const id = `${serverName}__${tool.name}`;
+    registered.push({
+      id,
+      name: tool.name,
+      description: tool.description ?? "",
+      inputSchema: tool.inputSchema,
+      outputSchema: tool.outputSchema ?? { type: "object" },
+      execute: async (args) => {
+        const startedAt = Date.now();
+        try {
+          const result = await client.callTool({
+            name: tool.name,
+            arguments: args as Record<string, unknown>,
+          });
+          catalog.recordEvent({
+            type: "upstream_invoke",
+            server: serverName,
+            tool_id: id,
+            took_ms: Date.now() - startedAt,
+          });
+          return result;
+        } catch (err) {
+          catalog.recordEvent({
+            type: "upstream_error",
+            server: serverName,
+            tool_id: id,
+            error: (err as Error).message ?? String(err),
+          });
+          throw err;
+        }
+      },
+    });
+    toolIds.push(id);
+  }
+  return { toolIds, registered };
+}
 
 /** Options for {@link registerMcpServer}. */
 export interface RegisterMcpServerOptions {
@@ -22,7 +109,10 @@ export interface RegisterMcpServerOptions {
 
 /** What {@link registerMcpServer} returns: the ingested ids plus lifecycle control. */
 export interface McpServerHandle {
-  /** Namespaced ids (`<name>__<toolName>`) of every tool registered, in server order. */
+  /**
+   * Namespaced ids in upstream list order (all pages). Duplicate names may
+   * appear more than once; {@link ToolCatalog.register} keeps the last row.
+   */
   toolIds: string[];
   /**
    * The usage instructions the server declared during the MCP initialize
@@ -39,7 +129,7 @@ export interface McpServerHandle {
 
 /**
  * Ingest an MCP server into a {@link ToolCatalog}: connect over the given
- * transport, list its tools once (no live refresh), and register each as an
+ * transport, list every paginated `tools/list` page (no live refresh), and register each as an
  * {@link ToolCatalog.register | executable tool} whose executor proxies
  * `callTool` on the live client. A missing tool description registers as `""`;
  * a missing output schema as `{ type: "object" }`.
@@ -82,64 +172,33 @@ export async function registerMcpServer(
   // span; per-tool invocations later get their own `execute_tool` spans (ADR-0007).
   return traceUpstreamRegister(name, transportLabel, async (reportToolCount) => {
     const client = new Client({ name: "@ratel-ai/sdk", version: "0.0.0" });
-    await client.connect(transport);
+    try {
+      await client.connect(transport);
 
-    const serverInstructions = client.getInstructions();
+      const serverInstructions = client.getInstructions();
 
-    const { tools } = await client.listTools();
-    reportToolCount(tools.length);
-    catalog.recordEvent({
-      type: "upstream_register",
-      server: name,
-      transport: transportLabel,
-      tool_count: tools.length,
-    });
-    const toolIds: string[] = [];
-    const registered: ExecutableTool[] = [];
-    for (const tool of tools) {
-      const id = `${name}__${tool.name}`;
-      registered.push({
-        id,
-        name: tool.name,
-        description: tool.description ?? "",
-        inputSchema: tool.inputSchema,
-        outputSchema: tool.outputSchema ?? { type: "object" },
-        execute: async (args) => {
-          const startedAt = Date.now();
-          try {
-            const result = await client.callTool({
-              name: tool.name,
-              arguments: args as Record<string, unknown>,
-            });
-            catalog.recordEvent({
-              type: "upstream_invoke",
-              server: name,
-              tool_id: id,
-              took_ms: Date.now() - startedAt,
-            });
-            return result;
-          } catch (err) {
-            catalog.recordEvent({
-              type: "upstream_error",
-              server: name,
-              tool_id: id,
-              error: (err as Error).message ?? String(err),
-            });
-            throw err;
-          }
-        },
+      const tools = await listAllMcpTools(client);
+      reportToolCount(tools.length);
+      catalog.recordEvent({
+        type: "upstream_register",
+        server: name,
+        transport: transportLabel,
+        tool_count: tools.length,
       });
-      toolIds.push(id);
-    }
-    await catalog.register(registered);
+      const { toolIds, registered } = buildRegisteredMcpTools(catalog, client, name, tools);
+      await catalog.register(registered);
 
-    return {
-      toolIds,
-      serverInstructions,
-      close: async () => {
-        await client.close();
-      },
-    };
+      return {
+        toolIds,
+        serverInstructions,
+        close: async () => {
+          await client.close();
+        },
+      };
+    } catch (err) {
+      await client.close().catch(() => {});
+      throw err;
+    }
   });
 }
 


### PR DESCRIPTION
### Summary 

> Follow MCP `tools/list` cursors until exhaustion in both SDKs before reporting registration complete.

**Problem:** registerMcpServer / register_mcp_server only handled the first tools/list page. On paginated upstream servers, tools on later pages were never registered. `upstream_register.tool_count` reflected that first page only, not the full aggregated listing.

TS (`@ratel-ai/sdk`): Loop on nextCursor until absent (empty string is still a valid cursor), aggregate tools, single catalog.register, 64-page cap + repeated-cursor errors. List/register failures close the SDK-owned Client. Pagination + failure cases covered in mcp.test.ts (including empty page, later-page list failure, embed failure + close).

Python (`ratel-ai`): Same listing semantics via _list_all_mcp_tools (PaginatedRequestParams / fake-compatible params.cursor). Caller-owned ClientSession unchanged—no auto on_close on failure. Tests in test_mcp.py mirror TS pagination behavior.

--

### Review notes
Duplicate tool names across pages: ids listed in order; catalog batch keeps last row on invoke (documented on handles).
Python test_register_mcp_server_requires_mcp_when_absent skips when the mcp extra is installed (same as CI).