### PR TITLE
feat(sdk): whole-catalog skill reload via replaceAll

### DIFF
--- a/docs/adr/0015-whole-catalog-skill-reload.md
+++ b/docs/adr/0015-whole-catalog-skill-reload.md
@@ -33,9 +33,14 @@ be a small change rather than an architecture:
 - **The model-facing payload is already pinned.** `ratel()` builds `search_capabilities` with
   `advertiseSkills: true`, so the tool description does not depend on whether the catalog is
   empty. A reload cannot perturb the prompt cache.
-- **The registries are already lock-guarded.** The bindings hold the registry behind a write
-  lock and refuse a mutation while a dense operation is in flight, so a corpus swap is never
-  observed torn and two overlapping reloads cannot interleave.
+- **The registries already refuse a racing mutation.** Each binding rejects a mutation while a
+  dense operation is in flight, so a corpus swap is never observed torn and two overlapping
+  reloads cannot interleave. Where that guard lives differs by surface, and the difference
+  matters to anyone adding a mutation: the napi binding holds the registry in an
+  `Arc<RwLock<_>>` and goes through `write_registry`, which checks the pending-dense counter and
+  takes the lock; the pyo3 binding owns its registry unlocked, and the equivalent check
+  (`_raise_if_busy` against `_dense_pending`) lives in the Python facade above it, not in the
+  native layer.
 
 ## Decision
 

--- a/docs/adr/0015-whole-catalog-skill-reload.md
+++ b/docs/adr/0015-whole-catalog-skill-reload.md
@@ -1,0 +1,121 @@
+# 15. Whole-catalog skill reload: `replaceAll` mutates the catalog in place
+
+Date: 2026-07-27
+
+## Status
+
+Accepted
+
+Implements the catalog-hydration half of [ADR-0003](0003-catalog-source-interface.md), which
+accepted a source loader that "pulls a published catalog and hydrates the local registries" but
+left the mutation primitive unspecified. ADR-0003 is unchanged and remains Accepted; this ADR
+adds the missing primitive and fixes its semantics.
+
+## Context
+
+A catalog source — the managed cloud client first — reloads the full skill catalog periodically
+and hands it to the SDK. ADR-0003 already settled that sync is a whole-catalog pull rather than
+a delta protocol, so what arrives is always the complete set.
+
+The SDK had no way to apply it. `SkillCatalog` was append-only: `register` replaces an id in
+place, and nothing removes one. A reload could only ever grow the corpus, so a skill deleted
+upstream stayed searchable forever — and an agent could still load its body through
+`get_skill_content`.
+
+Replacing the `SkillCatalog` *object* is not available as a fix. `ratel()` creates it once and
+closes over it in `r.skills`, in each `adaptTo` view's `base.skills`, in every capability tool
+returned by `modelTools()`, and in `recall()`; hosts hold `r.skills` directly as the documented
+escape hatch. Rebinding the reference would strand all of them.
+
+Two properties of the existing design make in-place mutation safe, and are the reason this can
+be a small change rather than an architecture:
+
+- **The model-facing payload is already pinned.** `ratel()` builds `search_capabilities` with
+  `advertiseSkills: true`, so the tool description does not depend on whether the catalog is
+  empty. A reload cannot perturb the prompt cache.
+- **The registries are already lock-guarded.** The bindings hold the registry behind a write
+  lock and refuse a mutation while a dense operation is in flight, so a corpus swap is never
+  observed torn and two overlapping reloads cannot interleave.
+
+## Decision
+
+**`SkillCatalog.replaceAll(skills)` / `replace_all(skills)`: the batch becomes the entire
+catalog, applied in place.** Ids absent from the batch are removed; the rest are added or
+updated. Object identity is preserved, so every existing holder observes the reload.
+
+### Replace means replace
+
+Removal is unconditional. Skills registered in-process are dropped like any others, because the
+batch *is* the catalog. A host that wants local skills to survive a remote reload composes the
+batch itself:
+
+```ts
+await r.skills.replaceAll([...localSkills, ...remoteSkills]);
+```
+
+Ownership policy therefore lives in the host, not in the core. The rejected alternative — an
+owner tag per skill so a source only replaces its own partition — pushes the core into
+arbitrating between sources for a need no caller has yet expressed, and can be added later
+without changing this primitive.
+
+### Two-phase, exactly like `register`
+
+The corpus swap commits synchronously; the embedding pass is the returned awaitable. On failure
+the new corpus is live and BM25 ranks it, while semantic search reports `EmbeddingsNotBuilt`
+until a later pass succeeds. This is the contract `register` already has, so there is one rule
+to learn rather than two.
+
+The rejected alternative — staging the corpus, embedding, then committing both together — would
+keep semantic search serving the *old* catalog through a failed reload. It was declined because
+it requires the whole operation to move onto a worker task, which forfeits the property that a
+forgotten `await` can never leave a half-applied change.
+
+### The diff is the point
+
+`replace_all` compares the incoming batch against the live corpus and touches the dense cache
+only where it must: a removed id's vector is dropped, an id whose indexed text
+(`name`/`description`/`tags`) changed is invalidated, and everything else keeps its vector —
+including an id whose `body`, `tools`, or `metadata` changed, since none of those are embedded.
+Reloading an unchanged catalog therefore costs **zero** embedding calls, which is the common
+case for a polling source.
+
+Dropping a removed id's vector is load-bearing rather than tidiness. The dense cache's
+built-ness guard compares *counts*, so a stale vector left behind could offset a new,
+unembedded id, let the guard pass, and make a semantic search silently omit that skill. That
+interacts directly with the two-phase decision above: it is exactly the state a failed embedding
+pass leaves behind.
+
+Churn telemetry falls out of the same diff — `SkillChurn{add}` / `SkillChurn{remove}` for real
+changes only, reusing the existing `ChurnKind::Remove` variant. A no-op reload emits nothing.
+
+The call returns a `ReplaceOutcome` (`added` / `removed` / `updated` / `unchanged`) so a source
+can report what a reload did without draining the trace stream.
+
+### Skills only
+
+`ToolCatalog` keeps no equivalent. A cloud-sourced tool carries no local executor, so
+whole-catalog tool replacement is a separate question and is not answered here.
+
+## Consequences
+
+- A source can keep the catalog honest: upstream deletions actually disappear, from both
+  retrieval and `get_skill_content`.
+- Reload cost scales with what changed, not with catalog size.
+- Hosts that mix in-process and sourced skills must compose the batch on every reload. This is
+  the deliberate cost of keeping ownership out of the core, and it is visible in the method
+  name.
+- A reload that races a dense operation raises rather than applying partially; a periodic source
+  must tolerate that and retry on its next tick.
+- The failure mode of a botched reload is degraded ranking (BM25 only), never an empty catalog —
+  provided the source does not call `replaceAll([])` on a fetch error. Guarding that is the
+  source's job; an empty batch is a legitimate way to clear the catalog.
+
+## Rejected
+
+- **Per-id `upsert`/`remove` as the primitive:** more surface and a diff burden on every source,
+  to express what a whole-catalog pull already delivers in one shot. Nothing in ADR-0003's sync
+  model produces per-id deltas.
+- **Swapping the `SkillCatalog` object:** strands every closure and holder described above, and
+  discards the dense cache wholesale on each reload.
+- **An owner tag per skill so a source replaces only its own partition:** see above; deferred
+  until a caller needs it.

--- a/docs/adr/0015-whole-catalog-skill-reload.md
+++ b/docs/adr/0015-whole-catalog-skill-reload.md
@@ -33,14 +33,24 @@ be a small change rather than an architecture:
 - **The model-facing payload is already pinned.** `ratel()` builds `search_capabilities` with
   `advertiseSkills: true`, so the tool description does not depend on whether the catalog is
   empty. A reload cannot perturb the prompt cache.
-- **The registries already refuse a racing mutation.** Each binding rejects a mutation while a
-  dense operation is in flight, so a corpus swap is never observed torn and two overlapping
-  reloads cannot interleave. Where that guard lives differs by surface, and the difference
-  matters to anyone adding a mutation: the napi binding holds the registry in an
+- **The registries already refuse a racing mutation.** A corpus swap is never observed torn and
+  two overlapping reloads cannot interleave, because a mutation racing an in-flight operation is
+  rejected rather than applied. Two details are worth stating precisely, because both are easy
+  to get wrong:
+
+  *Where the guard lives differs by surface.* The napi binding holds the registry in an
   `Arc<RwLock<_>>` and goes through `write_registry`, which checks the pending-dense counter and
-  takes the lock; the pyo3 binding owns its registry unlocked, and the equivalent check
+  then takes the lock; the pyo3 binding owns its registry unlocked, and the equivalent check
   (`_raise_if_busy` against `_dense_pending`) lives in the Python facade above it, not in the
   native layer.
+
+  *What contends is broader than dense work.* The pending-dense counter covers dense operations,
+  but `write_registry` also fails when any in-flight `search_async` still holds the read lock —
+  including a plain BM25 one, which takes no dense permit. So an ordinary read can refuse a
+  reload, non-deterministically, depending on whether the worker has taken the lock yet. This is
+  inherited, not introduced here: `register` contends the same way and did so before this ADR.
+  It is called out because the retry guidance below depends on it — a source must treat
+  `registry busy` as retryable on any traffic, not just dense traffic.
 
 ## Decision
 
@@ -112,7 +122,8 @@ whole-catalog tool replacement is a separate question and is not answered here.
 - Hosts that mix in-process and sourced skills must compose the batch on every reload. This is
   the deliberate cost of keeping ownership out of the core, and it is visible in the method
   name.
-- A reload that races a dense operation raises rather than applying partially; a periodic source
+- A reload that races an in-flight operation — dense work, but also an ordinary BM25
+  `search_async` holding the read lock — raises rather than applying partially; a periodic source
   must tolerate that and retry on its next tick.
 - The failure mode of a botched reload is degraded ranking (BM25 only), never an empty catalog —
   provided the source does not call `replaceAll([])` on a fetch error. Guarding that is the

--- a/docs/adr/0015-whole-catalog-skill-reload.md
+++ b/docs/adr/0015-whole-catalog-skill-reload.md
@@ -89,7 +89,10 @@ Churn telemetry falls out of the same diff — `SkillChurn{add}` / `SkillChurn{r
 changes only, reusing the existing `ChurnKind::Remove` variant. A no-op reload emits nothing.
 
 The call returns a `ReplaceOutcome` (`added` / `removed` / `updated` / `unchanged`) so a source
-can report what a reload did without draining the trace stream.
+can report what a reload did without draining the trace stream. The counts ride *on* the returned
+awaitable rather than through it: they are final once the swap commits, so they stay readable when
+the embedding pass fails — which is precisely the state a source most needs to report on. Awaiting
+still resolves to the same counts, or raises, exactly as `register` does.
 
 ### Skills only
 

--- a/src/core/src/dense_cache.rs
+++ b/src/core/src/dense_cache.rs
@@ -13,7 +13,8 @@
 //! place: on replace the registry calls [`DenseCache::invalidate`] to drop the
 //! stale vector, and the next [`DenseCache::extend`] re-embeds that id like any
 //! other missing one — so a re-registered id never leaves a stale embedding
-//! behind (RAT-378).
+//! behind (RAT-378). The same keying lets `replace_all` drop the vector of an
+//! id that leaves the corpus outright, which no `extend` then re-embeds.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
@@ -263,8 +264,15 @@ impl DenseCache {
         Ok(())
     }
 
-    /// Drop a cached embedding so the next [`Self::extend`] re-embeds this id.
-    /// Called by a registry's `register` when it replaces an existing id in place.
+    /// Drop a cached embedding for an id whose vector must not survive.
+    ///
+    /// Two callers, for two different reasons: a registry's `register` (and the
+    /// update half of `replace_all`) drops a superseded vector so the next
+    /// [`Self::extend`] re-embeds that id; the removal half of `replace_all`
+    /// drops the vector of an id leaving the corpus entirely, with nothing to
+    /// re-embed. The second case is load-bearing rather than tidiness —
+    /// [`Self::require_built`] compares *counts*, so a vector left behind for a
+    /// departed id could offset a new, unembedded one and let the guard pass.
     pub(crate) fn invalidate(&self, id: &str) {
         self.state
             .lock()

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -95,7 +95,7 @@ pub use embedding::EmbedderError;
 pub use embedding_config::{EmbeddingModel, EmbeddingSpec, Pooling};
 pub use method::{ParseSearchMethodError, SearchMethod};
 pub use skill::Skill;
-pub use skill_registry::{SkillHit, SkillRegistry};
+pub use skill_registry::{ReplaceOutcome, SkillHit, SkillRegistry};
 pub use tool::Tool;
 pub use tool_registry::{AdaptiveRankingStatus, SearchHit, ToolRegistry};
 pub use trace::{

--- a/src/core/src/skill.rs
+++ b/src/core/src/skill.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 /// `{"stacks": ["react"]}` for the push-path ranker to boost/filter by project
 /// context, deliberately *not* matched as query terms. `body` is the dispatch
 /// payload and is also not indexed, so a long body never skews relevance.
+#[derive(PartialEq, Eq)]
 pub struct Skill {
     /// Stable identifier, returned in [`crate::SkillHit::skill_id`].
     /// Registering the same id again replaces the entry in place. Not indexed

--- a/src/core/src/skill_registry.rs
+++ b/src/core/src/skill_registry.rs
@@ -62,6 +62,23 @@ impl Embeddable for Skill {
     }
 }
 
+/// What a whole-corpus [`SkillRegistry::replace_all`] actually changed, counted
+/// by id. `updated` covers any field edit (including a body-only rewrite);
+/// `unchanged` ids are byte-identical and keep their cached embedding. A reload
+/// that changed nothing reports zeros across `added`/`removed`/`updated` — the
+/// cheap case a periodic source hits most of the time.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ReplaceOutcome {
+    /// Ids in the new corpus that were not in the old one.
+    pub added: usize,
+    /// Ids in the old corpus that are absent from the new one.
+    pub removed: usize,
+    /// Ids present in both whose content differs in any field.
+    pub updated: usize,
+    /// Ids present in both with identical content.
+    pub unchanged: usize,
+}
+
 /// Retrieval index over [`Skill`]s — the on-demand analog of
 /// [`crate::ToolRegistry`]. Same selectable BM25/semantic/hybrid engines; a
 /// parallel type keeps the tool path untouched and lets skill telemetry stand on
@@ -316,6 +333,102 @@ impl SkillRegistry {
             kind: ChurnKind::Add,
             skill_id,
         });
+    }
+
+    /// Replace the entire corpus with `skills`: ids absent from the batch are
+    /// removed, ids present are added or updated. The whole-catalog counterpart
+    /// to [`Self::register`], for a source that reloads a catalog rather than
+    /// pushing individual changes. Within one batch a repeated id keeps its last
+    /// entry, exactly as a repeated [`Self::register`] would.
+    ///
+    /// Synchronous and infallible: it swaps the corpus and maintains the dense
+    /// cache, but never embeds. Call [`Self::build_embeddings`] afterwards on a
+    /// semantic/hybrid catalog — it then embeds only the ids this replace
+    /// actually invalidated.
+    ///
+    /// Cache handling is deliberately narrow, so a reload of a mostly-unchanged
+    /// catalog costs no embeddings: a removed id's vector is dropped, an id whose
+    /// indexed text (`name`/`description`/`tags`) changed is invalidated for
+    /// re-embedding, and everything else keeps the vector it already had —
+    /// including an id whose `body`, `tools`, or `metadata` changed, since none
+    /// of those are embedded.
+    ///
+    /// Dropping a removed id's vector is load-bearing, not just tidiness: the
+    /// dense cache's built-ness guard compares *counts*, so a stale vector left
+    /// behind could offset a new, unembedded id and let a semantic search
+    /// silently omit it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ratel_ai_core::{Skill, SkillRegistry};
+    ///
+    /// fn skill(id: &str, description: &str) -> Skill {
+    ///     Skill {
+    ///         id: id.into(),
+    ///         name: id.into(),
+    ///         description: description.into(),
+    ///         tags: vec![],
+    ///         tools: vec![],
+    ///         metadata: std::collections::HashMap::new(),
+    ///         body: String::new(),
+    ///     }
+    /// }
+    ///
+    /// let mut registry = SkillRegistry::new();
+    /// registry.register(skill("api-design", "REST API design patterns"));
+    /// registry.register(skill("slides", "Build HTML presentations"));
+    ///
+    /// // The reloaded catalog no longer carries `slides`.
+    /// let outcome = registry.replace_all(vec![
+    ///     skill("api-design", "REST API design patterns"),
+    ///     skill("migrations", "Write reversible database migrations"),
+    /// ]);
+    ///
+    /// assert_eq!((outcome.added, outcome.removed, outcome.unchanged), (1, 1, 1));
+    /// assert!(registry.search("build HTML presentations", 5).is_empty());
+    /// ```
+    pub fn replace_all(&mut self, skills: Vec<Skill>) -> ReplaceOutcome {
+        let mut next: IndexMap<String, Skill> = IndexMap::with_capacity(skills.len());
+        for skill in skills {
+            next.insert(skill.id.clone(), skill);
+        }
+
+        let mut outcome = ReplaceOutcome::default();
+
+        for id in self.skills.keys() {
+            if !next.contains_key(id) {
+                self.dense.invalidate(id);
+                self.sink.record(TraceEvent::SkillChurn {
+                    kind: ChurnKind::Remove,
+                    skill_id: id.clone(),
+                });
+                outcome.removed += 1;
+            }
+        }
+
+        for (id, skill) in &next {
+            match self.skills.get(id) {
+                Some(current) if current == skill => {
+                    outcome.unchanged += 1;
+                    continue;
+                }
+                Some(current) => {
+                    if searchable_text(current) != searchable_text(skill) {
+                        self.dense.invalidate(id);
+                    }
+                    outcome.updated += 1;
+                }
+                None => outcome.added += 1,
+            }
+            self.sink.record(TraceEvent::SkillChurn {
+                kind: ChurnKind::Add,
+                skill_id: id.clone(),
+            });
+        }
+
+        self.skills = next;
+        outcome
     }
 
     /// Number of registered skills (distinct ids).
@@ -809,6 +922,192 @@ mod tests {
             hits[0].score > 0.9,
             "ranks with the re-embedded frontend vector"
         );
+    }
+
+    #[test]
+    fn replace_all_drops_ids_absent_from_the_batch() {
+        let mut reg = catalog();
+        let outcome = reg.replace_all(vec![skill(
+            "api-design",
+            "api-design",
+            "REST API design patterns: resource naming, status codes, pagination",
+            &["backend", "api"],
+        )]);
+        assert_eq!(reg.len(), 1);
+        assert_eq!(outcome.removed, 1);
+        assert!(
+            reg.search("animation-rich HTML presentations", 5)
+                .is_empty(),
+            "a dropped skill must leave the corpus, not linger in the index"
+        );
+    }
+
+    #[test]
+    fn replace_all_with_an_empty_batch_clears_the_corpus() {
+        let mut reg = catalog();
+        reg.replace_all(Vec::new());
+        assert!(reg.is_empty());
+        assert!(reg.search("anything", 5).is_empty());
+    }
+
+    #[test]
+    fn replace_all_keeps_the_last_of_duplicate_ids() {
+        // Parity with `register`, which replaces an id in place: within one
+        // batch the later entry wins and the corpus holds a single entry.
+        let mut reg = SkillRegistry::new();
+        reg.replace_all(vec![
+            skill("s", "s", "REST API design", &["api"]),
+            skill("s", "s", "HTML slides frontend", &["frontend"]),
+        ]);
+        assert_eq!(reg.len(), 1);
+        let hits = reg.search("html slides frontend", 5);
+        assert_eq!(hits.first().map(|h| h.skill_id.as_str()), Some("s"));
+    }
+
+    #[test]
+    fn replace_all_reports_what_changed() {
+        let mut reg = SkillRegistry::new();
+        reg.register(skill("keep", "keep", "REST API design", &["api"]));
+        reg.register(skill("edit", "edit", "HTML slides", &["frontend"]));
+        reg.register(skill("drop", "drop", "database migrations", &["data"]));
+
+        let outcome = reg.replace_all(vec![
+            skill("keep", "keep", "REST API design", &["api"]),
+            skill("edit", "edit", "HTML slides and animations", &["frontend"]),
+            skill("add", "add", "queue consumers", &["backend"]),
+        ]);
+
+        assert_eq!(
+            outcome,
+            ReplaceOutcome {
+                added: 1,
+                removed: 1,
+                updated: 1,
+                unchanged: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn replace_all_embeds_only_what_changed() {
+        let counter = Arc::new(CountingEmbedder::new());
+        let mut reg = with_embedder(counter.clone());
+        reg.register(skill("a", "a", "REST API design", &["api"]));
+        reg.register(skill("b", "b", "HTML slides", &["frontend"]));
+        reg.build_embeddings().unwrap();
+        assert_eq!(counter.doc_calls(), 2);
+
+        // `a` is byte-identical, `b` is dropped, `c` is new.
+        reg.replace_all(vec![
+            skill("a", "a", "REST API design", &["api"]),
+            skill("c", "c", "database migrations", &["data"]),
+        ]);
+        reg.build_embeddings().unwrap();
+        assert_eq!(
+            counter.doc_calls(),
+            3,
+            "an unchanged id keeps its vector; only the new skill is embedded"
+        );
+    }
+
+    #[test]
+    fn replace_all_keeps_the_vector_when_only_the_body_changed() {
+        // The body is never embedded (`searchable_text` excludes it), so a
+        // body-only edit must not cost an embedding on the next build.
+        let counter = Arc::new(CountingEmbedder::new());
+        let mut reg = with_embedder(counter.clone());
+        reg.register(skill("a", "a", "REST API design", &["api"]));
+        reg.build_embeddings().unwrap();
+        assert_eq!(counter.doc_calls(), 1);
+
+        let mut rewritten = skill("a", "a", "REST API design", &["api"]);
+        rewritten.body = "# a\n\nrewritten instructions".into();
+        reg.replace_all(vec![rewritten]);
+        reg.build_embeddings().unwrap();
+        assert_eq!(counter.doc_calls(), 1);
+    }
+
+    #[test]
+    fn replace_all_re_embeds_a_skill_whose_indexed_text_changed() {
+        let mut reg = with_embedder(Arc::new(StubEmbedder));
+        reg.register(skill("s", "s", "REST API design", &["api"])); // dense: api bucket
+        reg.build_embeddings().unwrap();
+
+        reg.replace_all(vec![skill("s", "s", "HTML slides frontend", &["frontend"])]); // → frontend bucket
+        reg.build_embeddings().unwrap();
+
+        let hits = reg
+            .search_with_method("frontend slides", 5, Origin::Direct, SearchMethod::Semantic)
+            .unwrap();
+        assert_eq!(hits.first().map(|h| h.skill_id.as_str()), Some("s"));
+        assert!(hits[0].score > 0.9, "ranks with the re-embedded vector");
+    }
+
+    #[test]
+    fn replace_all_drops_the_vector_of_a_removed_id() {
+        // The dense guard is a count (`vectors.len() < corpus_len`), so leaving a
+        // removed id's vector in the cache would let a *new*, unembedded id slip
+        // past `require_built` and be silently skipped in ranking. Removal must
+        // drop the vector, not just the corpus entry.
+        let mut reg = with_embedder(Arc::new(StubEmbedder));
+        reg.register(skill(
+            "api-design",
+            "api-design",
+            "REST API design",
+            &["api"],
+        ));
+        reg.register(skill("frontend", "frontend", "HTML slides", &["frontend"]));
+        reg.build_embeddings().unwrap();
+
+        reg.replace_all(vec![
+            skill("api-design", "api-design", "REST API design", &["api"]),
+            skill("db", "db", "database migrations", &["data"]),
+        ]);
+
+        assert!(
+            matches!(
+                reg.search_with_method("database", 5, Origin::Direct, SearchMethod::Semantic),
+                Err(EmbedderError::EmbeddingsNotBuilt)
+            ),
+            "a removed id's stale vector must not mask an unembedded new id"
+        );
+
+        reg.build_embeddings().unwrap();
+        let hits = reg
+            .search_with_method(
+                "database migrations",
+                5,
+                Origin::Direct,
+                SearchMethod::Semantic,
+            )
+            .unwrap();
+        assert_eq!(hits.first().map(|h| h.skill_id.as_str()), Some("db"));
+    }
+
+    #[test]
+    fn replace_all_emits_churn_only_for_real_changes() {
+        let sink = Arc::new(MemorySink::new("test-session"));
+        let mut reg = SkillRegistry::with_trace_sink(sink.clone());
+        reg.register(skill("keep", "keep", "REST API design", &["api"]));
+        reg.register(skill("drop", "drop", "HTML slides", &["frontend"]));
+        sink.drain();
+
+        reg.replace_all(vec![
+            skill("keep", "keep", "REST API design", &["api"]),
+            skill("add", "add", "database migrations", &["data"]),
+        ]);
+
+        let churn: Vec<(ChurnKind, String)> = sink
+            .drain()
+            .into_iter()
+            .filter_map(|envelope| match envelope.event {
+                TraceEvent::SkillChurn { kind, skill_id } => Some((kind, skill_id)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(churn.len(), 2, "an unchanged id emits nothing: {churn:?}");
+        assert!(churn.contains(&(ChurnKind::Remove, "drop".to_string())));
+        assert!(churn.contains(&(ChurnKind::Add, "add".to_string())));
     }
 
     #[test]

--- a/src/core/src/trace/event.rs
+++ b/src/core/src/trace/event.rs
@@ -157,7 +157,9 @@ pub enum TraceEvent {
         took_ms: u64,
     },
     /// The skill corpus changed — the skill-side twin of
-    /// [`TraceEvent::IndexChurn`], emitted by [`crate::SkillRegistry::register`].
+    /// [`TraceEvent::IndexChurn`]. [`crate::SkillRegistry::register`] emits
+    /// [`ChurnKind::Add`] only; [`crate::SkillRegistry::replace_all`] emits
+    /// either kind, and is the only source of [`ChurnKind::Remove`] for skills.
     SkillChurn {
         /// Whether the id was added or removed.
         kind: ChurnKind,

--- a/src/sdk/python/README.md
+++ b/src/sdk/python/README.md
@@ -32,6 +32,15 @@ async def retrieve(tools):
 
 `register()` is async for every method (BM25 too); `search()` stays synchronous for BM25 only, and `search_async()` covers all three. To change the endpoint's model or vector dimension, construct a new catalog and re-register.
 
+A `SkillCatalog` also takes a whole reloaded catalog at once with `replace_all()`, for a source that fetches the full set rather than individual changes ([ADR 0014](../../../docs/adr/0014-whole-catalog-skill-reload.md)). The batch *is* the catalog: ids missing from it are removed, including ones registered in-process, so a host that mixes local and remote skills composes the batch itself. It mutates in place, so every holder of the catalog sees the reload without being rebuilt.
+
+```python
+outcome = await catalog.replace_all([*local_skills, *await fetch_remote_skills()])
+print(f"reload: +{outcome.added} -{outcome.removed} ~{outcome.updated}")
+```
+
+Only new and re-worded skills are embedded — reloading an unchanged catalog costs no embedding calls — and a reload that races a dense operation raises rather than applying half of itself.
+
 ## Install
 
 ```bash

--- a/src/sdk/python/README.md
+++ b/src/sdk/python/README.md
@@ -32,7 +32,7 @@ async def retrieve(tools):
 
 `register()` is async for every method (BM25 too); `search()` stays synchronous for BM25 only, and `search_async()` covers all three. To change the endpoint's model or vector dimension, construct a new catalog and re-register.
 
-A `SkillCatalog` also takes a whole reloaded catalog at once with `replace_all()`, for a source that fetches the full set rather than individual changes ([ADR 0014](../../../docs/adr/0014-whole-catalog-skill-reload.md)). The batch *is* the catalog: ids missing from it are removed, including ones registered in-process, so a host that mixes local and remote skills composes the batch itself. It mutates in place, so every holder of the catalog sees the reload without being rebuilt.
+A `SkillCatalog` also takes a whole reloaded catalog at once with `replace_all()`, for a source that fetches the full set rather than individual changes ([ADR 0015](../../../docs/adr/0015-whole-catalog-skill-reload.md)). The batch *is* the catalog: ids missing from it are removed, including ones registered in-process, so a host that mixes local and remote skills composes the batch itself. It mutates in place, so every holder of the catalog sees the reload without being rebuilt.
 
 ```python
 outcome = await catalog.replace_all([*local_skills, *await fetch_remote_skills()])

--- a/src/sdk/python/README.md
+++ b/src/sdk/python/README.md
@@ -39,6 +39,16 @@ outcome = await catalog.replace_all([*local_skills, *await fetch_remote_skills()
 print(f"reload: +{outcome.added} -{outcome.removed} ~{outcome.updated}")
 ```
 
+The corpus swap is the synchronous half of that call, so the counts are already final when it returns — read them without awaiting and a reload whose embedding pass fails still reports what it changed:
+
+```python
+reload = catalog.replace_all(batch)  # corpus is live; counts are final
+try:
+    await reload  # drives the embedding pass
+except EmbedderError:
+    log.warning("applied +%d -%d, embeddings pending", reload.added, reload.removed)
+```
+
 Only new and re-worded skills are embedded — reloading an unchanged catalog costs no embedding calls — and a reload that races a dense operation raises rather than applying half of itself.
 
 ## Install

--- a/src/sdk/python/README.md
+++ b/src/sdk/python/README.md
@@ -49,7 +49,7 @@ except EmbedderError:
     log.warning("applied +%d -%d, embeddings pending", reload.added, reload.removed)
 ```
 
-Only new and re-worded skills are embedded — reloading an unchanged catalog costs no embedding calls — and a reload that races a dense operation raises rather than applying half of itself.
+Only new and re-worded skills are embedded — reloading an unchanged catalog costs no embedding calls — and a reload that races an in-flight operation — dense work, but also an ordinary BM25 `search_async` holding the read lock — raises rather than applying half of itself.
 
 ## Install
 

--- a/src/sdk/python/native/src/lib.rs
+++ b/src/sdk/python/native/src/lib.rs
@@ -712,6 +712,36 @@ impl SkillRegistry {
         }
     }
 
+    /// Replace the whole corpus: ids absent from `skills` are removed, the rest
+    /// are added or updated. Embeds nothing — the caller builds after, which then
+    /// embeds only what this replace invalidated. Returns the
+    /// `(added, removed, updated, unchanged)` counts; the Python facade wraps
+    /// them in its `ReplaceOutcome` dataclass, as it does for `Skill`.
+    fn _replace_all(&mut self, skills: Vec<SkillBatchItem>) -> (u32, u32, u32, u32) {
+        let outcome = self.inner.replace_all(
+            skills
+                .into_iter()
+                .map(
+                    |(id, name, description, tags, tools, metadata, body)| core::Skill {
+                        id,
+                        name,
+                        description,
+                        tags,
+                        tools,
+                        metadata,
+                        body,
+                    },
+                )
+                .collect(),
+        );
+        (
+            outcome.added as u32,
+            outcome.removed as u32,
+            outcome.updated as u32,
+            outcome.unchanged as u32,
+        )
+    }
+
     /// Lexical BM25 search over the skill corpus — see [`ToolRegistry::search`].
     fn search(&self, query: String, top_k: u32) -> Vec<SkillHit> {
         self.inner

--- a/src/sdk/python/ratel_ai/__init__.py
+++ b/src/sdk/python/ratel_ai/__init__.py
@@ -44,7 +44,7 @@ from .catalog import (
 from .compat import SEARCH_TOOLS_ID, search_tools_tool
 from .exceptions import DimensionMismatchError, EmbedderError
 from .mcp import McpServerHandle, register_mcp_server
-from .skill_catalog import Skill, SkillCatalog, SkillRegistry
+from .skill_catalog import ReplaceOutcome, Skill, SkillCatalog, SkillRegistry
 from .skill_tools import GET_SKILL_CONTENT_ID, get_skill_content_tool
 
 # OpenTelemetry export of the ratel.*/gen_ai.* funnel (ADR-0007). The SDK always
@@ -72,6 +72,7 @@ __all__ = [
     "McpServerHandle",
     "OnUnauthorized",
     "OllamaEmbeddingConfig",
+    "ReplaceOutcome",
     "SearchHit",
     "SearchMethod",
     "SearchOrigin",

--- a/src/sdk/python/ratel_ai/__init__.py
+++ b/src/sdk/python/ratel_ai/__init__.py
@@ -44,7 +44,7 @@ from .catalog import (
 from .compat import SEARCH_TOOLS_ID, search_tools_tool
 from .exceptions import DimensionMismatchError, EmbedderError
 from .mcp import McpServerHandle, register_mcp_server
-from .skill_catalog import ReplaceOutcome, Skill, SkillCatalog, SkillRegistry
+from .skill_catalog import PendingReplace, ReplaceOutcome, Skill, SkillCatalog, SkillRegistry
 from .skill_tools import GET_SKILL_CONTENT_ID, get_skill_content_tool
 
 # OpenTelemetry export of the ratel.*/gen_ai.* funnel (ADR-0007). The SDK always
@@ -72,6 +72,7 @@ __all__ = [
     "McpServerHandle",
     "OnUnauthorized",
     "OllamaEmbeddingConfig",
+    "PendingReplace",
     "ReplaceOutcome",
     "SearchHit",
     "SearchMethod",

--- a/src/sdk/python/ratel_ai/_native.pyi
+++ b/src/sdk/python/ratel_ai/_native.pyi
@@ -320,6 +320,22 @@ class SkillRegistry:
     ) -> None:
         """Atomically convert, then register a skill metadata batch."""
 
+    def _replace_all(
+        self,
+        skills: list[
+            tuple[
+                str,
+                str,
+                str,
+                list[str],
+                list[str],
+                dict[str, list[str]],
+                str,
+            ]
+        ],
+    ) -> tuple[int, int, int, int]:
+        """Replace the whole corpus; returns (added, removed, updated, unchanged)."""
+
     def search(self, query: str, top_k: int) -> list[SkillHit]:
         """Lexical BM25 search over the skill corpus — see `ToolRegistry.search`."""
 

--- a/src/sdk/python/ratel_ai/skill_catalog.py
+++ b/src/sdk/python/ratel_ai/skill_catalog.py
@@ -582,7 +582,9 @@ class SkillCatalog:
 
         Raises:
             EmbedderError: on a semantic/hybrid catalog, if embedding fails (when awaited).
-            RuntimeError: if a dense operation already owns the registry.
+            RuntimeError: if another operation already owns the registry —
+                dense work, but also an in-flight BM25 `search_async` holding
+                the read lock. `registry busy` is retryable, not fatal.
         """
         batch = [skills] if isinstance(skills, Skill) else list(skills)
         self._registry._register_items(batch)
@@ -621,7 +623,9 @@ class SkillCatalog:
         Raises:
             TypeError: if any item is not a `Skill`.
             EmbedderError: on a semantic/hybrid catalog, if embedding fails (when awaited).
-            RuntimeError: if a dense operation already owns the registry.
+            RuntimeError: if another operation already owns the registry —
+                dense work, but also an in-flight BM25 `search_async` holding
+                the read lock. `registry busy` is retryable, not fatal.
         """
         batch = list(skills)
         awaitable = self._registry.replace_all(batch)

--- a/src/sdk/python/ratel_ai/skill_catalog.py
+++ b/src/sdk/python/ratel_ai/skill_catalog.py
@@ -30,7 +30,7 @@ from .catalog import (
 )
 from .telemetry import SEARCH_TARGET_SKILL, trace_search, trace_search_async, trace_skill_load
 
-__all__ = ["Skill", "SkillCatalog", "SkillHit", "SkillRegistry"]
+__all__ = ["ReplaceOutcome", "Skill", "SkillCatalog", "SkillHit", "SkillRegistry"]
 
 _DenseResult = TypeVar("_DenseResult")
 
@@ -52,6 +52,21 @@ class Skill:
     # {"stacks": ["react"]} for the push ranker to boost by project context.
     metadata: dict[str, list[str]] = field(default_factory=dict)
     body: str = ""
+
+
+@dataclass(frozen=True)
+class ReplaceOutcome:
+    """What a `replace_all` changed, counted by id.
+
+    `updated` covers any field edit (including a body-only rewrite);
+    `unchanged` ids are identical to what was registered and keep their cached
+    embedding, so a reload that changed nothing costs no embedding calls.
+    """
+
+    added: int = 0
+    removed: int = 0
+    updated: int = 0
+    unchanged: int = 0
 
 
 class SkillRegistry:
@@ -218,6 +233,19 @@ class SkillRegistry:
                 raise TypeError("register requires Skill items")
         self._register_items(skills)
         return self._build_tracked(bool(skills))
+
+    def replace_all(self, skills: Iterable[Skill]) -> Awaitable[ReplaceOutcome]:
+        """Make `skills` the entire corpus — see `SkillCatalog.replace_all`.
+
+        The corpus swap lands **synchronously** (a forgotten `await` never
+        leaves a half-applied reload); the returned awaitable drives only the
+        embedding pass and resolves to the counts. Always `await` the result.
+        """
+        batch = list(skills)
+        if not all(isinstance(skill, Skill) for skill in batch):
+            raise TypeError("replace_all requires Skill items")
+        outcome = self._replace_all_items(batch)
+        return self._outcome_tracked(outcome, bool(batch))
 
     def search(self, query: str, top_k: int) -> list[SkillHit]:
         """Run synchronous, model-free BM25 retrieval."""
@@ -449,6 +477,39 @@ class SkillRegistry:
                 ]
             )
 
+    def _replace_all_items(self, skills: Iterable[Skill]) -> ReplaceOutcome:
+        """Swap the corpus without embedding — the metadata half of `replace_all`."""
+        skills = list(skills)
+        with self._dense_state:
+            self._raise_if_busy()
+            added, removed, updated, unchanged = self._native._replace_all(
+                [
+                    (
+                        skill.id,
+                        skill.name,
+                        skill.description,
+                        skill.tags,
+                        skill.tools,
+                        skill.metadata,
+                        skill.body,
+                    )
+                    for skill in skills
+                ]
+            )
+        return ReplaceOutcome(added, removed, updated, unchanged)
+
+    def _outcome_tracked(
+        self, outcome: ReplaceOutcome, has_items: bool
+    ) -> Awaitable[ReplaceOutcome]:
+        """`_build_tracked`, resolving to the already-computed replace counts."""
+        driver = self._build_tracked(has_items)
+
+        async def _drive() -> ReplaceOutcome:
+            await driver
+            return outcome
+
+        return _drive()
+
     def _raise_if_busy(self) -> None:
         if self._dense_pending:
             raise RuntimeError(_REGISTRY_BUSY)
@@ -506,6 +567,42 @@ class SkillCatalog:
         for skill in batch:
             self._skills[skill.id] = skill
         return self._registry._build_tracked(bool(batch))
+
+    def replace_all(self, skills: Iterable[Skill]) -> Awaitable[ReplaceOutcome]:
+        """Make `skills` the entire content of the catalog.
+
+        Ids absent from the batch are removed, the rest are added or updated —
+        the whole-catalog counterpart to `register`, for a source that reloads a
+        catalog rather than pushing individual changes. Mutates in place, so
+        every holder of this catalog observes the reload without being rebuilt.
+
+        **Removal is unconditional.** Skills registered in-process are dropped
+        just like any others, since the batch *is* the catalog. A host that keeps
+        local skills alongside a remote source composes the batch itself:
+        `await catalog.replace_all([*local_skills, *remote_skills])`.
+
+        Like `register`, the corpus swap lands synchronously and the returned
+        awaitable drives only the embedding pass — which embeds just the new and
+        re-worded skills, so reloading an unchanged catalog costs nothing. If it
+        fails, the new corpus is already live and BM25 still ranks it; semantic
+        search raises until a later pass succeeds. **Always `await` the result.**
+
+        Args:
+            skills: the complete catalog contents. A repeated id keeps its last
+                entry; an empty iterable clears the catalog.
+
+        Returns:
+            An awaitable resolving to the `ReplaceOutcome` counts.
+
+        Raises:
+            TypeError: if any item is not a `Skill`.
+            EmbedderError: on a semantic/hybrid catalog, if embedding fails (when awaited).
+            RuntimeError: if a dense operation already owns the registry.
+        """
+        batch = list(skills)
+        awaitable = self._registry.replace_all(batch)
+        self._skills = {skill.id: skill for skill in batch}
+        return awaitable
 
     def search(
         self,

--- a/src/sdk/python/ratel_ai/skill_catalog.py
+++ b/src/sdk/python/ratel_ai/skill_catalog.py
@@ -81,13 +81,20 @@ class PendingReplace(ReplaceOutcome):
     """What `replace_all` returns: final counts over a pending embedding pass.
 
     The corpus swap commits synchronously, so the counts are already final when
-    `replace_all` returns — read them without awaiting. Awaiting drives the
-    embedding pass and resolves to the plain `ReplaceOutcome`, or raises if
-    embedding fails, so a source can report what a reload changed even when the
-    embedding pass failed.
+    `replace_all` returns and can be read before the embedding pass settles — a
+    source can report what a reload changed even when that pass fails. **Always**
+    `await` **the result** regardless, so the embedding pass runs and its failure
+    is raised rather than swallowed.
+
+    Note that this compares unequal to a bare `ReplaceOutcome` with the same
+    counts: a dataclass `__eq__` requires both sides to be the same class, so no
+    field configuration changes that. Await first — the awaited value *is* a
+    plain `ReplaceOutcome` — and compare that.
     """
 
-    _driver: Awaitable[None] | None = None
+    # Excluded from repr so it doesn't print the coroutine. Excluding it from
+    # __eq__ would buy nothing: the class check above already decides equality.
+    _driver: Awaitable[None] | None = field(default=None, repr=False)
 
     def __await__(self) -> Generator[Any, None, ReplaceOutcome]:
         """Drive the embedding pass, then resolve to the plain counts."""

--- a/src/sdk/python/ratel_ai/skill_catalog.py
+++ b/src/sdk/python/ratel_ai/skill_catalog.py
@@ -11,7 +11,7 @@ import asyncio
 import threading
 import time
 import warnings
-from collections.abc import Awaitable, Callable, Iterable
+from collections.abc import Awaitable, Callable, Generator, Iterable
 from dataclasses import dataclass, field
 from typing import Any, Literal, TypeVar, overload
 
@@ -67,6 +67,25 @@ class ReplaceOutcome:
     removed: int = 0
     updated: int = 0
     unchanged: int = 0
+
+
+@dataclass(frozen=True)
+class PendingReplace(ReplaceOutcome):
+    """What `replace_all` returns: final counts over a pending embedding pass.
+
+    The corpus swap commits synchronously, so the counts are already final when
+    `replace_all` returns — read them without awaiting. Awaiting drives the
+    embedding pass and resolves to the plain `ReplaceOutcome`, or raises if
+    embedding fails, so a source can report what a reload changed even when the
+    embedding pass failed.
+    """
+
+    _driver: Awaitable[None] | None = None
+
+    def __await__(self) -> Generator[Any, None, ReplaceOutcome]:
+        if self._driver is not None:
+            yield from self._driver.__await__()
+        return ReplaceOutcome(self.added, self.removed, self.updated, self.unchanged)
 
 
 class SkillRegistry:
@@ -234,12 +253,13 @@ class SkillRegistry:
         self._register_items(skills)
         return self._build_tracked(bool(skills))
 
-    def replace_all(self, skills: Iterable[Skill]) -> Awaitable[ReplaceOutcome]:
+    def replace_all(self, skills: Iterable[Skill]) -> PendingReplace:
         """Make `skills` the entire corpus — see `SkillCatalog.replace_all`.
 
         The corpus swap lands **synchronously** (a forgotten `await` never
-        leaves a half-applied reload); the returned awaitable drives only the
-        embedding pass and resolves to the counts. Always `await` the result.
+        leaves a half-applied reload); the returned `PendingReplace` already
+        carries the counts and drives only the embedding pass when awaited.
+        Always `await` the result.
         """
         batch = list(skills)
         if not all(isinstance(skill, Skill) for skill in batch):
@@ -498,17 +518,19 @@ class SkillRegistry:
             )
         return ReplaceOutcome(added, removed, updated, unchanged)
 
-    def _outcome_tracked(
-        self, outcome: ReplaceOutcome, has_items: bool
-    ) -> Awaitable[ReplaceOutcome]:
-        """`_build_tracked`, resolving to the already-computed replace counts."""
-        driver = self._build_tracked(has_items)
+    def _outcome_tracked(self, outcome: ReplaceOutcome, has_items: bool) -> PendingReplace:
+        """`_build_tracked`, carrying the already-computed replace counts.
 
-        async def _drive() -> ReplaceOutcome:
-            await driver
-            return outcome
-
-        return _drive()
+        The counts ride on the awaitable rather than through it, so a failed
+        embedding pass still reports what the (already committed) swap changed.
+        """
+        return PendingReplace(
+            outcome.added,
+            outcome.removed,
+            outcome.updated,
+            outcome.unchanged,
+            self._build_tracked(has_items),
+        )
 
     def _raise_if_busy(self) -> None:
         if self._dense_pending:
@@ -568,7 +590,7 @@ class SkillCatalog:
             self._skills[skill.id] = skill
         return self._registry._build_tracked(bool(batch))
 
-    def replace_all(self, skills: Iterable[Skill]) -> Awaitable[ReplaceOutcome]:
+    def replace_all(self, skills: Iterable[Skill]) -> PendingReplace:
         """Make `skills` the entire content of the catalog.
 
         Ids absent from the batch are removed, the rest are added or updated —
@@ -592,7 +614,9 @@ class SkillCatalog:
                 entry; an empty iterable clears the catalog.
 
         Returns:
-            An awaitable resolving to the `ReplaceOutcome` counts.
+            A `PendingReplace`: the counts, already final, over the pending
+            embedding pass. Read them without awaiting; `await` the result to
+            drive the embedding pass.
 
         Raises:
             TypeError: if any item is not a `Skill`.

--- a/src/sdk/python/ratel_ai/skill_catalog.py
+++ b/src/sdk/python/ratel_ai/skill_catalog.py
@@ -30,7 +30,14 @@ from .catalog import (
 )
 from .telemetry import SEARCH_TARGET_SKILL, trace_search, trace_search_async, trace_skill_load
 
-__all__ = ["ReplaceOutcome", "Skill", "SkillCatalog", "SkillHit", "SkillRegistry"]
+__all__ = [
+    "PendingReplace",
+    "ReplaceOutcome",
+    "Skill",
+    "SkillCatalog",
+    "SkillHit",
+    "SkillRegistry",
+]
 
 _DenseResult = TypeVar("_DenseResult")
 
@@ -83,6 +90,7 @@ class PendingReplace(ReplaceOutcome):
     _driver: Awaitable[None] | None = None
 
     def __await__(self) -> Generator[Any, None, ReplaceOutcome]:
+        """Drive the embedding pass, then resolve to the plain counts."""
         if self._driver is not None:
             yield from self._driver.__await__()
         return ReplaceOutcome(self.added, self.removed, self.updated, self.unchanged)

--- a/src/sdk/python/tests/test_skill_catalog.py
+++ b/src/sdk/python/tests/test_skill_catalog.py
@@ -5,7 +5,7 @@ import threading
 
 import pytest
 
-from ratel_ai import ReplaceOutcome, Skill, SkillCatalog, SkillRegistry
+from ratel_ai import EmbedderError, ReplaceOutcome, Skill, SkillCatalog, SkillRegistry
 
 
 async def _catalog(*skills: Skill) -> SkillCatalog:
@@ -292,3 +292,24 @@ async def test_replace_all_on_semantic_embeds_the_new_skills(
 
     hits = await catalog.search_async("deploy", 5, method="semantic")
     assert [hit.skill_id for hit in hits] == ["deploy"]
+
+
+async def test_replace_all_reports_counts_when_the_embedding_pass_fails() -> None:
+    catalog = SkillCatalog(method="semantic", embedding={"local": "/missing/ratel-model"})
+
+    reload = catalog.replace_all(
+        [
+            Skill(id="slides", name="slides", description="Build decks."),
+            Skill(id="api-design", name="api-design", description="REST API design patterns."),
+        ]
+    )
+
+    # The swap commits before the embedding pass is driven, so the counts are
+    # final at call time. A reload that fails to embed still reports what it
+    # changed — the corpus is live and BM25 ranks it, which is exactly the
+    # state ADR-0015 tells a periodic source to expect and report on.
+    assert (reload.added, reload.removed) == (2, 0)
+
+    with pytest.raises(EmbedderError):
+        await reload
+    assert catalog.has("slides")

--- a/src/sdk/python/tests/test_skill_catalog.py
+++ b/src/sdk/python/tests/test_skill_catalog.py
@@ -294,6 +294,36 @@ async def test_replace_all_on_semantic_embeds_the_new_skills(
     assert [hit.skill_id for hit in hits] == ["deploy"]
 
 
+async def test_replace_all_refuses_a_second_reload_while_the_first_embeds(
+    controlled_embedding_endpoint: tuple[str, threading.Event, threading.Event],
+) -> None:
+    # The TS twin can fire both reloads in one tick, because napi takes the
+    # dense permit synchronously. Here `_dense_pending` only rises once the
+    # embedding request is actually in flight, so the endpoint holds the first
+    # reload open to create the overlap.
+    endpoint, request_started, send_response = controlled_embedding_endpoint
+    catalog = SkillCatalog(method="semantic", embedding={"url": endpoint, "model": "test-model"})
+
+    first = asyncio.ensure_future(
+        catalog.replace_all([Skill(id="slides", name="slides", description="Build decks.")])
+    )
+    await asyncio.to_thread(request_started.wait)
+    try:
+        # Refused outright — not queued behind the first, not merged into it.
+        with pytest.raises(RuntimeError, match=r"^registry busy; await the active operation$"):
+            catalog.replace_all(
+                [Skill(id="api-design", name="api-design", description="REST API patterns.")]
+            )
+    finally:
+        send_response.set()
+    await first
+
+    # The corpus is exactly the first batch, never a blend of the two.
+    assert catalog.has("slides")
+    assert not catalog.has("api-design")
+    assert catalog.size() == 1
+
+
 async def test_replace_all_reports_counts_when_the_embedding_pass_fails() -> None:
     catalog = SkillCatalog(method="semantic", embedding={"local": "/missing/ratel-model"})
 

--- a/src/sdk/python/tests/test_skill_catalog.py
+++ b/src/sdk/python/tests/test_skill_catalog.py
@@ -5,7 +5,7 @@ import threading
 
 import pytest
 
-from ratel_ai import Skill, SkillCatalog, SkillRegistry
+from ratel_ai import ReplaceOutcome, Skill, SkillCatalog, SkillRegistry
 
 
 async def _catalog(*skills: Skill) -> SkillCatalog:
@@ -202,3 +202,93 @@ async def test_nonempty_skill_async_search_and_busy_registration(
 
     hits = await catalog.search_async("authentication", 5)
     assert hits[0].skill_id == "auth"
+
+
+async def test_replace_all_drops_ids_absent_from_the_batch() -> None:
+    catalog = await _catalog(
+        Skill(id="slides", name="slides", description="Build animation-rich presentations."),
+        Skill(id="api-design", name="api-design", description="REST API design patterns."),
+    )
+
+    outcome = await catalog.replace_all(
+        [
+            Skill(id="api-design", name="api-design", description="REST API design patterns."),
+            Skill(
+                id="migrations",
+                name="migrations",
+                description="Reversible database migrations.",
+            ),
+        ]
+    )
+
+    assert outcome == ReplaceOutcome(added=1, removed=1, updated=0, unchanged=1)
+    assert catalog.size() == 2
+    assert not catalog.has("slides")
+    assert catalog.get("slides") is None
+    assert catalog.search("animation-rich presentations", 5) == []
+    assert catalog.search("reversible database migrations", 5)[0].skill_id == "migrations"
+
+
+async def test_replace_all_makes_a_dropped_skill_unloadable() -> None:
+    catalog = await _catalog(Skill(id="slides", name="slides", description="Build decks."))
+
+    await catalog.replace_all([])
+
+    assert catalog.size() == 0
+    # The capability-tool boundary turns this into a structured error for the agent.
+    with pytest.raises(ValueError, match=r"unknown skillId: slides"):
+        catalog.invoke("slides")
+
+
+async def test_replace_all_serves_the_reloaded_content_for_a_kept_id() -> None:
+    catalog = await _catalog(
+        Skill(id="slides", name="slides", description="Build decks.", body="# old")
+    )
+
+    outcome = await catalog.replace_all(
+        [Skill(id="slides", name="slides", description="Build static HTML decks.", body="# new")]
+    )
+
+    assert outcome == ReplaceOutcome(added=0, removed=0, updated=1, unchanged=0)
+    assert catalog.get("slides").description == "Build static HTML decks."
+    assert catalog.invoke("slides") == "# new"
+    assert catalog.search("static HTML decks", 5)[0].skill_id == "slides"
+
+
+async def test_replace_all_keeps_the_last_of_duplicate_ids() -> None:
+    catalog = SkillCatalog()
+
+    await catalog.replace_all(
+        [
+            Skill(id="slides", name="slides", description="First."),
+            Skill(id="slides", name="slides", description="Second wins."),
+        ]
+    )
+
+    assert catalog.size() == 1
+    assert catalog.get("slides").description == "Second wins."
+
+
+async def test_replace_all_rejects_non_skill_items_before_touching_the_corpus() -> None:
+    catalog = await _catalog(Skill(id="slides", name="slides", description="Build decks."))
+
+    with pytest.raises(TypeError, match=r"replace_all requires Skill items"):
+        await catalog.replace_all(["not-a-skill"])  # type: ignore[list-item]
+
+    assert catalog.has("slides"), "a rejected batch must leave the corpus untouched"
+
+
+async def test_replace_all_on_semantic_embeds_the_new_skills(
+    controlled_embedding_endpoint: tuple[str, threading.Event, threading.Event],
+) -> None:
+    endpoint, _request_started, send_response = controlled_embedding_endpoint
+    send_response.set()
+    catalog = SkillCatalog(method="semantic", embedding={"url": endpoint, "model": "test-model"})
+    await catalog.register(Skill(id="auth", name="auth", description="Set up authentication"))
+
+    await catalog.replace_all(
+        [Skill(id="deploy", name="deploy", description="Deploy an app to production")]
+    )
+
+    hits = await catalog.search_async("deploy", 5, method="semantic")
+    assert [hit.skill_id for hit in hits] == ["deploy"]

--- a/src/sdk/python/tests/test_telemetry.py
+++ b/src/sdk/python/tests/test_telemetry.py
@@ -199,11 +199,16 @@ async def test_real_mcp_result_is_normalized_for_span_and_event(
         "structuredContent": {"ok": True},
         "isError": False,
     }
-    assert json.loads(span.attributes["gen_ai.tool.call.result"]) == normalized
+    span_result = json.loads(span.attributes["gen_ai.tool.call.result"])
+    # mcp >= 2.0 always serializes resultType ("complete" here); mcp 1.x omits it.
+    assert span_result.pop("resultType", "complete") == "complete"
+    assert span_result == normalized
     event = _log_events_named("ratel.tool.execution.details")[0]
     event_result = event.attributes["gen_ai.tool.call.result"]
     assert not isinstance(event_result, str)
-    assert json.loads(json.dumps(event_result)) == normalized
+    event_result = json.loads(json.dumps(event_result))
+    assert event_result.pop("resultType", "complete") == "complete"
+    assert event_result == normalized
 
 
 @pytest.mark.asyncio

--- a/src/sdk/ts/README.md
+++ b/src/sdk/ts/README.md
@@ -31,7 +31,7 @@ const hits = await catalog.searchAsync("deploy the service", 5);
 
 `register()` returns a promise for every method (BM25 too); `search()` stays synchronous for BM25 only, and `searchAsync()` covers all three. To change the endpoint's model or vector dimension, construct a new catalog and re-register.
 
-A `SkillCatalog` also takes a whole reloaded catalog at once with `replaceAll()`, for a source that fetches the full set rather than individual changes ([ADR 0014](../../../docs/adr/0014-whole-catalog-skill-reload.md)). The batch *is* the catalog: ids missing from it are removed, including ones registered in-process, so a host that mixes local and remote skills composes the batch itself. It mutates in place, so `r.skills`, every adapted view, and the capability tools already handed to the model all see the reload without being rebuilt.
+A `SkillCatalog` also takes a whole reloaded catalog at once with `replaceAll()`, for a source that fetches the full set rather than individual changes ([ADR 0015](../../../docs/adr/0015-whole-catalog-skill-reload.md)). The batch *is* the catalog: ids missing from it are removed, including ones registered in-process, so a host that mixes local and remote skills composes the batch itself. It mutates in place, so `r.skills`, every adapted view, and the capability tools already handed to the model all see the reload without being rebuilt.
 
 ```ts
 const outcome = await r.skills.replaceAll([...localSkills, ...(await fetchRemoteSkills())]);

--- a/src/sdk/ts/README.md
+++ b/src/sdk/ts/README.md
@@ -31,6 +31,15 @@ const hits = await catalog.searchAsync("deploy the service", 5);
 
 `register()` returns a promise for every method (BM25 too); `search()` stays synchronous for BM25 only, and `searchAsync()` covers all three. To change the endpoint's model or vector dimension, construct a new catalog and re-register.
 
+A `SkillCatalog` also takes a whole reloaded catalog at once with `replaceAll()`, for a source that fetches the full set rather than individual changes ([ADR 0014](../../../docs/adr/0014-whole-catalog-skill-reload.md)). The batch *is* the catalog: ids missing from it are removed, including ones registered in-process, so a host that mixes local and remote skills composes the batch itself. It mutates in place, so `r.skills`, every adapted view, and the capability tools already handed to the model all see the reload without being rebuilt.
+
+```ts
+const outcome = await r.skills.replaceAll([...localSkills, ...(await fetchRemoteSkills())]);
+console.log(`reload: +${outcome.added} -${outcome.removed} ~${outcome.updated}`);
+```
+
+Only new and re-worded skills are embedded — reloading an unchanged catalog costs no embedding calls — and a reload that races a dense operation throws rather than applying half of itself.
+
 Embedding failures from `register()`/`searchAsync()` are typed `EmbedderError`s (with a stable `.code` such as `"Load"`, `"NotCached"`, or `"DimensionMismatch"`); a dimension mismatch is a `DimensionMismatchError` subclass — the parity of Python's `EmbedderError`/`DimensionMismatchError`. Invalid embedding config still throws at construction.
 
 ```ts

--- a/src/sdk/ts/README.md
+++ b/src/sdk/ts/README.md
@@ -49,7 +49,7 @@ try {
 }
 ```
 
-Only new and re-worded skills are embedded — reloading an unchanged catalog costs no embedding calls — and a reload that races a dense operation throws rather than applying half of itself.
+Only new and re-worded skills are embedded — reloading an unchanged catalog costs no embedding calls — and a reload that races an in-flight operation — dense work, but also an ordinary BM25 `searchAsync` holding the read lock — throws rather than applying half of itself.
 
 Embedding failures from `register()`/`searchAsync()` are typed `EmbedderError`s (with a stable `.code` such as `"Load"`, `"NotCached"`, or `"DimensionMismatch"`); a dimension mismatch is a `DimensionMismatchError` subclass — the parity of Python's `EmbedderError`/`DimensionMismatchError`. Invalid embedding config still throws at construction.
 

--- a/src/sdk/ts/README.md
+++ b/src/sdk/ts/README.md
@@ -38,6 +38,17 @@ const outcome = await r.skills.replaceAll([...localSkills, ...(await fetchRemote
 console.log(`reload: +${outcome.added} -${outcome.removed} ~${outcome.updated}`);
 ```
 
+The corpus swap is the synchronous half of that call, so the counts are already final when it returns — read them without awaiting and a reload whose embedding pass fails still reports what it changed:
+
+```ts
+const reload = r.skills.replaceAll(batch); // corpus is live; counts are final
+try {
+  await reload; // drives the embedding pass
+} catch {
+  console.warn(`applied +${reload.added} -${reload.removed}, embeddings pending`);
+}
+```
+
 Only new and re-worded skills are embedded — reloading an unchanged catalog costs no embedding calls — and a reload that races a dense operation throws rather than applying half of itself.
 
 Embedding failures from `register()`/`searchAsync()` are typed `EmbedderError`s (with a stable `.code` such as `"Load"`, `"NotCached"`, or `"DimensionMismatch"`); a dimension mismatch is a `DimensionMismatchError` subclass — the parity of Python's `EmbedderError`/`DimensionMismatchError`. Invalid embedding config still throws at construction.

--- a/src/sdk/ts/native/src/lib.rs
+++ b/src/sdk/ts/native/src/lib.rs
@@ -889,6 +889,21 @@ pub struct SkillHit {
     pub fused: bool,
 }
 
+/// What a `SkillRegistry.replaceAll` changed, counted by id. `updated` covers
+/// any field edit (including a body-only rewrite); `unchanged` ids are identical
+/// to what was registered and keep their cached embedding.
+#[napi(object)]
+pub struct ReplaceOutcome {
+    /// Ids in the new corpus that were not in the old one.
+    pub added: u32,
+    /// Ids in the old corpus that are absent from the new one.
+    pub removed: u32,
+    /// Ids present in both whose content differs in any field.
+    pub updated: u32,
+    /// Ids present in both with identical content.
+    pub unchanged: u32,
+}
+
 /// Node binding over the `ratel-ai-core` skill registry — the skill twin of
 /// `ToolRegistry`, ranking registered skills against a natural-language query.
 /// Skill bodies are stored but never indexed; fetch them a layer up (the SDK's
@@ -961,6 +976,36 @@ impl SkillRegistry {
             });
         }
         Ok(())
+    }
+
+    /// Replace the whole corpus under one registry write lock: ids absent from
+    /// `skills` are removed, the rest are added or updated. Embeds nothing —
+    /// call `buildEmbeddings()` after on a semantic/hybrid registry, which then
+    /// embeds only what this replace invalidated. Rejects while a dense
+    /// operation owns the registry, exactly as `registerMany` does.
+    #[napi]
+    pub fn replace_all(&self, skills: Vec<Skill>) -> napi::Result<ReplaceOutcome> {
+        let mut registry = write_registry(&self.inner, &self.pending_dense)?;
+        let outcome = registry.replace_all(
+            skills
+                .into_iter()
+                .map(|skill| core::Skill {
+                    id: skill.id,
+                    name: skill.name,
+                    description: skill.description,
+                    tags: skill.tags.unwrap_or_default(),
+                    tools: skill.tools.unwrap_or_default(),
+                    metadata: skill.metadata.unwrap_or_default(),
+                    body: skill.body.unwrap_or_default(),
+                })
+                .collect(),
+        );
+        Ok(ReplaceOutcome {
+            added: outcome.added as u32,
+            removed: outcome.removed as u32,
+            updated: outcome.updated as u32,
+            unchanged: outcome.unchanged as u32,
+        })
     }
 
     /// Lexical BM25 search over skills — see `ToolRegistry.search` for the

--- a/src/sdk/ts/src/errors.ts
+++ b/src/sdk/ts/src/errors.ts
@@ -52,11 +52,12 @@ export class DimensionMismatchError extends EmbedderError {
   }
 }
 
-/** Appended to a "not built" error — the signature of a forgotten `await register(...)`. */
-const AWAIT_REGISTER_HINT =
-  " — if you called register(...) without awaiting it, the embedding pass was " +
-  "skipped; `await catalog.register(...)` (or `registry.register(...)`) before a " +
-  "semantic/hybrid search";
+/** Appended to a "not built" error — the signature of a forgotten `await` on a
+ * corpus mutation. Both mutations embed on await, so both can leave this state. */
+const AWAIT_MUTATION_HINT =
+  " — if you called register(...) or replaceAll(...) without awaiting it, the " +
+  "embedding pass was skipped; await the call (`await catalog.register(...)` / " +
+  "`await catalog.replaceAll(...)`) before a semantic/hybrid search";
 
 /**
  * Classify a native error message by matching the core `EmbedderError` display
@@ -89,7 +90,7 @@ export function mapEmbedderError(error: unknown): unknown {
   const code = embedderCode(error.message);
   if (code === undefined) return error;
   const message =
-    code === "EmbeddingsNotBuilt" ? error.message + AWAIT_REGISTER_HINT : error.message;
+    code === "EmbeddingsNotBuilt" ? error.message + AWAIT_MUTATION_HINT : error.message;
   return code === "DimensionMismatch"
     ? new DimensionMismatchError(message)
     : new EmbedderError(message, code);

--- a/src/sdk/ts/src/index.ts
+++ b/src/sdk/ts/src/index.ts
@@ -14,7 +14,14 @@
 // The catalog's JSON-Schema spelling, re-exported so framework adapters type
 // their CatalogRegistration schemas without a cast.
 export type { JSONSchema7 } from "json-schema";
-export type { AdaptiveRankingStatus, SearchHit, Skill, SkillHit, Tool } from "../native/index.cjs";
+export type {
+  AdaptiveRankingStatus,
+  ReplaceOutcome,
+  SearchHit,
+  Skill,
+  SkillHit,
+  Tool,
+} from "../native/index.cjs";
 export type {
   CapabilitiesSearchOptions,
   CapabilitySkillHit,

--- a/src/sdk/ts/src/index.ts
+++ b/src/sdk/ts/src/index.ts
@@ -83,7 +83,7 @@ export type {
 export { ratel } from "./ratel.js";
 /** Adaptive usage ranking: the shared read model of what users invoke (ADR-0014). */
 export { IntentGraph, SkillRegistry, ToolRegistry } from "./registry.js";
-export type { SkillCatalogOptions } from "./skill-catalog.js";
+export type { PendingReplace, SkillCatalogOptions } from "./skill-catalog.js";
 export { SkillCatalog } from "./skill-catalog.js";
 export { GET_SKILL_CONTENT_ID, getSkillContentTool } from "./skill-tools.js";
 // OpenTelemetry emission of the ratel.*/gen_ai.* funnel. The SDK emits to whatever OTel

--- a/src/sdk/ts/src/ratel.test.ts
+++ b/src/sdk/ts/src/ratel.test.ts
@@ -146,6 +146,52 @@ describe("ratel() standalone core", () => {
     expect(r.modelTools()[SEARCH_CAPABILITIES_ID]?.description).toBe(before);
   });
 
+  it("propagates a skills.replaceAll() reload through the capability tools taken earlier", async () => {
+    const r = ratel();
+    await r.skills.register([
+      {
+        id: "deploy",
+        name: "deploy",
+        description: "Deploy playbook: rollbacks.",
+        body: "# Deploy",
+      },
+      { id: "auth", name: "auth", description: "Set up login and sessions.", body: "# Auth" },
+    ]);
+    // Taken once, as a host would, and reused across turns.
+    const out = r.modelTools();
+    const before = out[SEARCH_CAPABILITIES_ID]?.description;
+
+    await r.skills.replaceAll([
+      { id: "auth", name: "auth", description: "Set up login and sessions.", body: "# Auth" },
+      {
+        id: "migrations",
+        name: "migrations",
+        description: "Reversible DB migrations.",
+        body: "# M",
+      },
+    ]);
+
+    // The already-exposed tools read the live catalog: no rebuild, no cache bust.
+    expect(r.modelTools()[SEARCH_CAPABILITIES_ID]?.description).toBe(before);
+
+    const dropped = (await out[GET_SKILL_CONTENT_ID]?.execute({ skillId: "deploy" })) as {
+      body?: string;
+      error?: string;
+      isError?: boolean;
+    };
+    expect(dropped.isError).toBe(true);
+    expect(dropped.body).toBeUndefined();
+    expect(dropped.error).toMatch(/unknown skillId: deploy/);
+
+    const added = (await out[GET_SKILL_CONTENT_ID]?.execute({ skillId: "migrations" })) as {
+      body?: string;
+    };
+    expect(added.body).toBe("# M");
+
+    const recalled = await r.recall("roll back a deploy");
+    expect(recalled?.skills.map((skill) => skill.skillId) ?? []).not.toContain("deploy");
+  });
+
   it("throws when a tool shadows a reserved capability-tool id", () => {
     for (const id of CAPABILITY_IDS) {
       expect(() => ratel().tools.register(native(id, "impostor"))).toThrow(/reserved/);

--- a/src/sdk/ts/src/registry.ts
+++ b/src/sdk/ts/src/registry.ts
@@ -4,6 +4,7 @@ import {
   type EmbeddingConfig as NativeEmbeddingConfig,
   SkillRegistry as NativeSkillRegistry,
   ToolRegistry as NativeToolRegistry,
+  type ReplaceOutcome,
   type SearchHit,
   type Skill,
   type SkillHit,
@@ -301,6 +302,20 @@ export class SkillRegistry {
   registerItems(item: Skill | readonly Skill[]): void {
     const items = Array.isArray(item) ? item : [item];
     this.native.registerMany([...items]);
+  }
+
+  /**
+   * Swap the whole corpus for `items` without embedding — the metadata half of
+   * {@link SkillCatalog.replaceAll}, the sibling of
+   * {@link SkillRegistry.registerItems}. Ids absent from `items` are removed
+   * along with their cached embeddings; ids whose indexed text changed are
+   * invalidated for re-embedding, and unchanged ids keep the vector they have,
+   * so the following {@link SkillRegistry.buildDense} only embeds real changes.
+   *
+   * @internal
+   */
+  replaceAllItems(items: readonly Skill[]): ReplaceOutcome {
+    return this.native.replaceAll([...items]);
   }
 
   /**

--- a/src/sdk/ts/src/skill-catalog.test.ts
+++ b/src/sdk/ts/src/skill-catalog.test.ts
@@ -271,14 +271,34 @@ describe("SkillCatalog.replaceAll", () => {
       await catalog.register(slides);
 
       const search = catalog.searchAsync("slides", 5);
-      // Two reloads must not interleave: the second is refused, not applied
-      // half-way, so the corpus is never a blend of both.
-      await expect(catalog.replaceAll([apiDesign])).rejects.toThrow(/registry busy; await/);
+      // A reload racing an in-flight dense operation is refused outright rather
+      // than applied half-way. The swap is the synchronous half of the call, so
+      // the refusal throws at the call site instead of rejecting the promise.
+      expect(() => catalog.replaceAll([apiDesign])).toThrow(/registry busy; await/);
       await search;
       expect(catalog.has("frontend-slides")).toBe(true);
     } finally {
       await server.close();
     }
+  });
+
+  it("reports the committed counts even when the embedding pass fails", async () => {
+    const catalog = new SkillCatalog({
+      method: "semantic",
+      embedding: { local: "/definitely/missing/ratel-embedding-model" },
+    });
+
+    const reload = catalog.replaceAll([slides, apiDesign]);
+
+    // The swap commits before the embedding pass is driven, so the counts are
+    // final at call time. A reload that fails to embed still reports what it
+    // changed — the corpus is live and BM25 ranks it, which is exactly the
+    // state ADR-0015 tells a periodic source to expect and report on.
+    expect(reload.added).toBe(2);
+    expect(reload.removed).toBe(0);
+
+    await expect(reload).rejects.toThrow(/failed to load embedding model/);
+    expect(catalog.has("frontend-slides")).toBe(true);
   });
 });
 

--- a/src/sdk/ts/src/skill-catalog.test.ts
+++ b/src/sdk/ts/src/skill-catalog.test.ts
@@ -158,6 +158,130 @@ describe("SkillCatalog", () => {
   });
 });
 
+const migrations: Skill = {
+  id: "migrations",
+  name: "migrations",
+  description: "Write reversible database migrations.",
+  tags: ["backend", "data"],
+  body: "# Migrations\n\nAlways ship a down step.",
+};
+
+describe("SkillCatalog.replaceAll", () => {
+  it("drops ids absent from the batch and reports what changed", async () => {
+    const catalog = new SkillCatalog();
+    await catalog.register([slides, apiDesign]);
+
+    const outcome = await catalog.replaceAll([apiDesign, migrations]);
+
+    expect(outcome).toEqual({ added: 1, removed: 1, updated: 0, unchanged: 1 });
+    expect(catalog.size()).toBe(2);
+    expect(catalog.has("frontend-slides")).toBe(false);
+    expect(catalog.get("frontend-slides")).toBeUndefined();
+    expect(catalog.search("animation-rich HTML presentations", 5)).toEqual([]);
+    expect(catalog.search("reversible database migrations", 5)[0]?.skillId).toBe("migrations");
+  });
+
+  it("makes a dropped skill unloadable", async () => {
+    const catalog = new SkillCatalog();
+    await catalog.register([slides, apiDesign]);
+    await catalog.replaceAll([apiDesign]);
+
+    // The capability-tool boundary turns this into a structured error for the agent.
+    expect(() => catalog.invoke("frontend-slides")).toThrow(/unknown skillId: frontend-slides/);
+  });
+
+  it("clears the catalog when given an empty batch", async () => {
+    const catalog = new SkillCatalog();
+    await catalog.register([slides, apiDesign]);
+
+    const outcome = await catalog.replaceAll([]);
+
+    expect(outcome).toEqual({ added: 0, removed: 2, updated: 0, unchanged: 0 });
+    expect(catalog.size()).toBe(0);
+    expect(catalog.search("anything", 5)).toEqual([]);
+  });
+
+  it("serves the reloaded body and description for an id it kept", async () => {
+    const catalog = new SkillCatalog();
+    await catalog.register(slides);
+
+    const outcome = await catalog.replaceAll([
+      { ...slides, description: "Build static HTML decks.", body: "# Slides\n\nRewritten." },
+    ]);
+
+    expect(outcome).toEqual({ added: 0, removed: 0, updated: 1, unchanged: 0 });
+    expect(catalog.get("frontend-slides")?.description).toBe("Build static HTML decks.");
+    expect(catalog.invoke("frontend-slides")).toContain("Rewritten");
+    expect(catalog.search("static HTML decks", 5)[0]?.skillId).toBe("frontend-slides");
+  });
+
+  it("keeps the last of duplicate ids in one batch", async () => {
+    const catalog = new SkillCatalog();
+    await catalog.replaceAll([slides, { ...slides, description: "Second wins." }]);
+
+    expect(catalog.size()).toBe(1);
+    expect(catalog.get("frontend-slides")?.description).toBe("Second wins.");
+  });
+
+  it("embeds nothing when the reloaded catalog is byte-identical", async () => {
+    const server = await startDelayedEmbeddingServer();
+    try {
+      const catalog = new SkillCatalog({
+        method: "semantic",
+        embedding: { url: server.url, model: "test-model" },
+      });
+      await catalog.register([slides, apiDesign]);
+      const afterRegister = server.requests.length;
+      expect(afterRegister).toBeGreaterThan(0);
+
+      const outcome = await catalog.replaceAll([slides, apiDesign]);
+
+      expect(outcome).toEqual({ added: 0, removed: 0, updated: 0, unchanged: 2 });
+      expect(server.requests.length).toBe(afterRegister);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("embeds a reload's new skills and keeps them rankable", async () => {
+    const server = await startDelayedEmbeddingServer();
+    try {
+      const catalog = new SkillCatalog({
+        method: "semantic",
+        embedding: { url: server.url, model: "test-model" },
+      });
+      await catalog.register([slides, apiDesign]);
+
+      await catalog.replaceAll([apiDesign, migrations]);
+
+      const hits = await catalog.searchAsync("database", 5);
+      expect(hits.map((hit) => hit.skillId).sort()).toEqual(["api-design", "migrations"]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects while a dense operation owns the registry", async () => {
+    const server = await startDelayedEmbeddingServer();
+    try {
+      const catalog = new SkillCatalog({
+        method: "semantic",
+        embedding: { url: server.url, model: "test-model" },
+      });
+      await catalog.register(slides);
+
+      const search = catalog.searchAsync("slides", 5);
+      // Two reloads must not interleave: the second is refused, not applied
+      // half-way, so the corpus is never a blend of both.
+      await expect(catalog.replaceAll([apiDesign])).rejects.toThrow(/registry busy; await/);
+      await search;
+      expect(catalog.has("frontend-slides")).toBe(true);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
 describe("SkillCatalog removed methods", () => {
   it("registerMany / buildEmbeddings / rebuildEmbeddings are gone at runtime", () => {
     // Folded into the variadic, self-embedding `register` (RAT-379/async-register).

--- a/src/sdk/ts/src/skill-catalog.test.ts
+++ b/src/sdk/ts/src/skill-catalog.test.ts
@@ -282,6 +282,34 @@ describe("SkillCatalog.replaceAll", () => {
     }
   });
 
+  it("refuses a second reload while the first is still embedding", async () => {
+    const server = await startDelayedEmbeddingServer();
+    try {
+      const catalog = new SkillCatalog({
+        method: "semantic",
+        embedding: { url: server.url, model: "test-model" },
+      });
+
+      // The first reload's swap has committed and its embedding pass now owns
+      // the registry (the dense permit is taken synchronously, before the call
+      // returns).
+      const first = catalog.replaceAll([slides]);
+
+      // So the second is refused outright — not queued behind the first, not
+      // merged into it.
+      expect(() => catalog.replaceAll([apiDesign])).toThrow(/registry busy; await/);
+
+      await first;
+
+      // The corpus is exactly the first batch, never a blend of the two.
+      expect(catalog.has("frontend-slides")).toBe(true);
+      expect(catalog.has("api-design")).toBe(false);
+      expect(catalog.size()).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+
   it("reports the committed counts even when the embedding pass fails", async () => {
     const catalog = new SkillCatalog({
       method: "semantic",

--- a/src/sdk/ts/src/skill-catalog.ts
+++ b/src/sdk/ts/src/skill-catalog.ts
@@ -1,10 +1,10 @@
 import { SearchTarget } from "@ratel-ai/telemetry";
-import type { Skill, SkillHit } from "../native/index.cjs";
+import type { ReplaceOutcome, Skill, SkillHit } from "../native/index.cjs";
 import type { EmbeddingSpec, SearchMethod, SearchOrigin, TraceSinkConfig } from "./catalog.js";
 import { type IntentGraph, SkillRegistry } from "./registry.js";
 import { traceSearch, traceSearchAsync, traceSkillLoad } from "./telemetry.js";
 
-export type { Skill, SkillHit };
+export type { ReplaceOutcome, Skill, SkillHit };
 
 /** Construction options for {@link SkillCatalog}. */
 export interface SkillCatalogOptions {
@@ -65,6 +65,45 @@ export class SkillCatalog {
       this.skills.set(skill.id, skill);
     }
     await this.registry.buildDense();
+  }
+
+  /**
+   * Make `skills` the entire content of the catalog: ids absent from the batch
+   * are removed, the rest are added or updated. The whole-catalog counterpart
+   * to {@link SkillCatalog.register}, for a source that reloads a catalog
+   * rather than pushing individual changes. Mutates in place, so every holder
+   * of this catalog — `ratel()`'s `r.skills`, each adapted view, and the
+   * capability tools taken from `modelTools()` — observes the reload without
+   * being rebuilt.
+   *
+   * **Removal is unconditional.** Skills registered in-process are dropped just
+   * like any others, since the batch *is* the catalog. A host that keeps local
+   * skills alongside a remote source composes the batch itself:
+   * `await catalog.replaceAll([...localSkills, ...remoteSkills])`.
+   *
+   * Embedding follows the same two-phase contract as
+   * {@link SkillCatalog.register}: the corpus swap lands first, then the batch
+   * is embedded. Only genuinely new or re-worded skills are embedded — an
+   * unchanged id keeps its vector, so reloading an unchanged catalog costs no
+   * embedding calls at all. If the embedding pass fails, the new corpus is
+   * already live and BM25 still ranks it; semantic search reports
+   * `EmbeddingsNotBuilt` until a later pass succeeds.
+   *
+   * A concurrent dense operation rejects the call outright rather than applying
+   * it half-way, so two overlapping reloads can never blend into one corpus.
+   *
+   * @param skills - The complete catalog contents. A repeated id keeps its last
+   *   entry. An empty array clears the catalog.
+   * @returns What the reload changed, counted by id.
+   */
+  async replaceAll(skills: readonly Skill[]): Promise<ReplaceOutcome> {
+    const outcome = this.registry.replaceAllItems(skills);
+    this.skills.clear();
+    for (const skill of skills) {
+      this.skills.set(skill.id, skill);
+    }
+    await this.registry.buildDense();
+    return outcome;
   }
 
   /**

--- a/src/sdk/ts/src/skill-catalog.ts
+++ b/src/sdk/ts/src/skill-catalog.ts
@@ -101,10 +101,12 @@ export class SkillCatalog {
    * already live and BM25 still ranks it; semantic search reports
    * `EmbeddingsNotBuilt` until a later pass succeeds.
    *
-   * A concurrent dense operation refuses the call outright rather than applying
-   * it half-way, so two overlapping reloads can never blend into one corpus.
+   * A concurrent operation refuses the call outright rather than applying it
+   * half-way, so two overlapping reloads can never blend into one corpus.
    * Because the swap is the synchronous half, that refusal throws at the call
-   * site rather than rejecting the returned promise.
+   * site rather than rejecting the returned promise. Note that any in-flight
+   * {@link SkillCatalog.searchAsync} can trigger it, including a plain BM25 one
+   * — `registry busy` is retryable and not exclusive to dense work.
    *
    * @param skills - The complete catalog contents. A repeated id keeps its last
    *   entry. An empty array clears the catalog.

--- a/src/sdk/ts/src/skill-catalog.ts
+++ b/src/sdk/ts/src/skill-catalog.ts
@@ -11,10 +11,24 @@ export type { ReplaceOutcome, Skill, SkillHit };
  * counts, readable immediately, over a promise for the embedding pass.
  *
  * The corpus swap commits synchronously, so the counts are final the moment
- * `replaceAll` returns — read them without awaiting. Awaiting drives the
- * embedding pass and resolves to the same counts, or rejects if embedding
- * fails; a source that must report what a reload changed can therefore do so
- * even when the embedding pass failed.
+ * `replaceAll` returns and can be read before the embedding pass settles — a
+ * source that must report what a reload changed can therefore do so even when
+ * that pass fails.
+ *
+ * **Always `await` (or `.catch()`) the value, even when you only want the
+ * counts.** It is a real promise for the embedding pass, so leaving it
+ * unhandled turns an embedding failure into an unhandled rejection — which
+ * terminates the process under Node's default `--unhandled-rejections=throw`.
+ * Reading the counts is not a substitute for handling it:
+ *
+ * ```ts
+ * const reload = catalog.replaceAll(batch); // corpus live, counts final
+ * try {
+ *   await reload;
+ * } catch {
+ *   log.warn(`applied +${reload.added} -${reload.removed}, embeddings pending`);
+ * }
+ * ```
  */
 export type PendingReplace = Promise<ReplaceOutcome> & ReplaceOutcome;
 
@@ -111,8 +125,9 @@ export class SkillCatalog {
    * @param skills - The complete catalog contents. A repeated id keeps its last
    *   entry. An empty array clears the catalog.
    * @returns The counts, already final, over a promise for the embedding pass —
-   *   see {@link PendingReplace}. Read `.added`/`.removed` without awaiting;
-   *   `await` to drive the embedding pass.
+   *   see {@link PendingReplace}. `.added`/`.removed` can be read before that
+   *   pass settles, but the value must still always be awaited (or
+   *   `.catch()`-ed), or an embedding failure becomes an unhandled rejection.
    */
   replaceAll(skills: readonly Skill[]): PendingReplace {
     const outcome = this.registry.replaceAllItems(skills);

--- a/src/sdk/ts/src/skill-catalog.ts
+++ b/src/sdk/ts/src/skill-catalog.ts
@@ -6,6 +6,18 @@ import { traceSearch, traceSearchAsync, traceSkillLoad } from "./telemetry.js";
 
 export type { ReplaceOutcome, Skill, SkillHit };
 
+/**
+ * What {@link SkillCatalog.replaceAll} returns: the {@link ReplaceOutcome}
+ * counts, readable immediately, over a promise for the embedding pass.
+ *
+ * The corpus swap commits synchronously, so the counts are final the moment
+ * `replaceAll` returns — read them without awaiting. Awaiting drives the
+ * embedding pass and resolves to the same counts, or rejects if embedding
+ * fails; a source that must report what a reload changed can therefore do so
+ * even when the embedding pass failed.
+ */
+export type PendingReplace = Promise<ReplaceOutcome> & ReplaceOutcome;
+
 /** Construction options for {@link SkillCatalog}. */
 export interface SkillCatalogOptions {
   /** Local trace stream destination (default: discard). See {@link TraceSinkConfig}. */
@@ -89,21 +101,27 @@ export class SkillCatalog {
    * already live and BM25 still ranks it; semantic search reports
    * `EmbeddingsNotBuilt` until a later pass succeeds.
    *
-   * A concurrent dense operation rejects the call outright rather than applying
+   * A concurrent dense operation refuses the call outright rather than applying
    * it half-way, so two overlapping reloads can never blend into one corpus.
+   * Because the swap is the synchronous half, that refusal throws at the call
+   * site rather than rejecting the returned promise.
    *
    * @param skills - The complete catalog contents. A repeated id keeps its last
    *   entry. An empty array clears the catalog.
-   * @returns What the reload changed, counted by id.
+   * @returns The counts, already final, over a promise for the embedding pass —
+   *   see {@link PendingReplace}. Read `.added`/`.removed` without awaiting;
+   *   `await` to drive the embedding pass.
    */
-  async replaceAll(skills: readonly Skill[]): Promise<ReplaceOutcome> {
+  replaceAll(skills: readonly Skill[]): PendingReplace {
     const outcome = this.registry.replaceAllItems(skills);
     this.skills.clear();
     for (const skill of skills) {
       this.skills.set(skill.id, skill);
     }
-    await this.registry.buildDense();
-    return outcome;
+    // The counts ride on the promise itself, so a failed embedding pass still
+    // reports what the (already committed) swap changed.
+    const embedded = this.registry.buildDense().then(() => outcome);
+    return Object.assign(embedded, outcome);
   }
 
   /**


### PR DESCRIPTION
## Why

A catalog source — the cloud client first — reloads the full skill catalog and hands it to the SDK. There was no way to apply it: `SkillCatalog` was append-only (`register` replaces an id in place, nothing removes one), so a reload could only ever grow the corpus. A skill deleted upstream stayed searchable forever, and an agent could still load its body through `get_skill_content`.

## What

`SkillCatalog.replaceAll(skills)` / `replace_all(skills)` — the batch becomes the entire catalog.

- **Replace means replace.** Ids absent from the batch are removed, including ones registered in-process. A host mixing local and remote skills composes the batch itself: `replaceAll([...local, ...remote])`. Ownership policy stays in the host, not the core.
- **Mutates in place.** `ratel()` closes over one `SkillCatalog` in `r.skills`, each `adaptTo` view, and every capability tool from `modelTools()`; rebinding the reference would strand all of them. `advertiseSkills: true` already pins the `search_capabilities` description, so a reload can't bust the prompt cache.
- **Two-phase, like `register`.** The corpus swap commits synchronously; the embedding pass is the awaitable. On failure the new corpus is live and BM25 ranks it, while semantic search reports `EmbeddingsNotBuilt` until a later pass succeeds. One rule to learn, not two.
- **The diff is the point.** Only removed ids' vectors are dropped and only re-worded ids invalidated; a body-only edit keeps its vector (bodies aren't embedded). Reloading an unchanged catalog costs **zero** embedding calls.
- Returns `ReplaceOutcome` (`added`/`removed`/`updated`/`unchanged`) so a source can report a reload without draining the trace stream.
- Churn telemetry falls out of the same diff — `add`/`remove` for real changes only, reusing the existing `ChurnKind::Remove`. A no-op reload emits nothing.

Tools are deliberately out of scope: a cloud-sourced tool carries no local executor, which is a separate question.

### One subtle constraint

Dropping a removed id's vector is load-bearing rather than tidiness. The dense cache's built-ness guard compares *counts*, so a stale vector left behind could offset a new, unembedded id, let the guard pass, and make a semantic search **silently omit** that skill. That is exactly the state a failed embedding pass leaves behind, so it interacts directly with the two-phase decision. Pinned by `replace_all_drops_the_vector_of_a_removed_id`.

## Layers

| | |
|---|---|
| `src/core` | `SkillRegistry::replace_all -> ReplaceOutcome`; `Skill` derives `PartialEq` |
| bindings | `replaceAll` (napi, via `write_registry` so it inherits the registry-busy guard); `_replace_all` (pyo3) + `.pyi` |
| `src/sdk/ts` | `SkillCatalog.replaceAll`, internal `replaceAllItems`, `ReplaceOutcome` exported |
| `src/sdk/python` | `replace_all` on catalog + registry facade, `ReplaceOutcome` dataclass |
| docs | ADR-0014, plus a section in both SDK READMEs |

ADR-0014 implements the hydration half of ADR-0003, which accepted a loader that "pulls a published catalog and hydrates the local registries" but left the mutation primitive unspecified. **ADR-0003 is unchanged and stays Accepted.**

## Verification

| | |
|---|---|
| `cargo test --workspace` | 171 pass |
| `cargo clippy -D warnings` / `fmt --check` / `doc` | clean |
| `pnpm -r build` / `typecheck` / `lint` / `test` | 446 pass, 1 skipped |
| `ruff` / `mypy` / `pytest` | clean; 147 pass, 2 skipped |

23 new tests. The core ones went red→green properly (9 failed to compile first). Beyond unit coverage, `ratel.test.ts` pins the end-to-end story: take `modelTools()` once, reload, then assert the `search_capabilities` description is byte-identical, a dropped skill returns the structured error through the already-exposed `get_skill_content`, a new one loads, and the dropped skill is gone from `recall()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)