### PR TITLE
feat(adapters): join experiment telemetry + instrument passthrough execution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -567,7 +567,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src/sdk/ts/native
-      # Build the adapter and its @ratel-ai/sdk workspace dependency (topo order).
+      # Build the adapter and its @ratel-ai/sdk + @ratel-ai/telemetry workspace
+      # dependencies (topo order).
       - name: Build TS
         run: pnpm --filter "@ratel-ai/mastra..." run build
       # npm keeps `workspace:` specifiers verbatim, so pin the @ratel-ai/sdk peer AND
@@ -586,6 +587,18 @@ jobs:
           # vercel-ai-sdk job: publish sdk-ts first or fail before the immutable publish.
           npm view "@ratel-ai/sdk@^${sdk_ver}" version >/dev/null 2>&1 \
             || { echo "::error::@ratel-ai/sdk@^${sdk_ver} is not on npm — publish sdk-ts before mastra"; exit 1; }
+      # Pin the new @ratel-ai/telemetry runtime dependency too. npm publishes a
+      # directory's literal `workspace:^`, so leaving it unchanged would make
+      # every registry install fail even though the local dry-run succeeds.
+      - name: Pin the @ratel-ai/telemetry runtime dependency for publish
+        shell: bash
+        run: |
+          set -e
+          tele_ver=$(node -p "require('./src/telemetry/ts/package.json').version")
+          TELE_VER="$tele_ver" node -e "const fs=require('fs'); const f='./src/adapters/ts-mastra/package.json'; const p=require(f); p.dependencies['@ratel-ai/telemetry']='^'+process.env.TELE_VER; fs.writeFileSync(f, JSON.stringify(p, null, 2) + '\n')"
+          echo "pinned @ratel-ai/telemetry -> $(node -p "require('./src/adapters/ts-mastra/package.json').dependencies['@ratel-ai/telemetry']") (runtime)"
+          npm view "@ratel-ai/telemetry@^${tele_ver}" version >/dev/null 2>&1 \
+            || { echo "::error::@ratel-ai/telemetry@^${tele_ver} is not on npm — publish telemetry-ts before mastra"; exit 1; }
       # Preflight dry-run BEFORE the real (immutable) publish, mirroring the SDK job.
       - name: Preflight — dry-run npm publish
         shell: bash

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,10 @@ importers:
         version: 5.9.3
 
   src/adapters/ts-mastra:
+    dependencies:
+      '@ratel-ai/telemetry':
+        specifier: workspace:^
+        version: link:../../telemetry/ts
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.13
@@ -154,6 +158,12 @@ importers:
       '@mastra/core':
         specifier: 1.51.0
         version: 1.51.0(ai@7.0.37(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
+      '@opentelemetry/context-async-hooks':
+        specifier: ^2.9.0
+        version: 2.9.0(@opentelemetry/api@1.9.1)
       '@ratel-ai/sdk':
         specifier: workspace:^
         version: link:../../sdk/ts

--- a/src/adapters/README.md
+++ b/src/adapters/README.md
@@ -1,13 +1,13 @@
 # `src/adapters/`
 
-Framework adapter packages: one complementary package per host framework that plugs into the `@ratel-ai/sdk` framework-adapter SPI (`ratel(config).adaptTo(adapter)`, [ADR-0013](../../docs/adr/0013-framework-adapter-spi.md)) so Ratel speaks that framework's native tool and message shapes. The core owns all state and guards; each adapter is three pure codecs plus the framework's idioms.
+Framework adapter packages: one complementary package per host framework that plugs into the `@ratel-ai/sdk` framework-adapter SPI (`ratel(config).adaptTo(adapter)`, [ADR-0013](../../docs/adr/0013-framework-adapter-spi.md)) so Ratel speaks that framework's native tool and message shapes. The core owns all state and guards; each adapter has three required codecs, optional extension hooks, and the framework's idioms.
 
 Directories are language-prefixed (`ts-*`, `py-*`) since a framework gets one adapter per SDK language.
 
 ## Layout
 
 - `ts-vercel-ai-sdk/` — [`@ratel-ai/vercel-ai-sdk`](ts-vercel-ai-sdk/README.md): the [Vercel AI SDK](https://sdk.vercel.ai) (`ai@^5 || ^6 || ^7`) adapter, plus `RatelOtelIntegration` on a separate `./otel` entrypoint (`ai@7` telemetry).
-- `ts-mastra/` — [`@ratel-ai/mastra`](ts-mastra/README.md): the [Mastra](https://mastra.ai) (`@mastra/core`) adapter.
+- `ts-mastra/` — [`@ratel-ai/mastra`](ts-mastra/README.md): the [Mastra](https://mastra.ai) (`@mastra/core`) adapter, plus experimental retrieval-experiment joins on its separate `./observability` entrypoint.
 
 ## Build & test
 

--- a/src/adapters/ts-mastra/CHANGELOG.md
+++ b/src/adapters/ts-mastra/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.3.0-rc.0] - 2026-07-30
+
+### Added
+
+- `@ratel-ai/mastra/observability` now exports `experimentalRatelSpanOutputProcessor()`, which copies the active retrieval experiment's five controlled baggage fields onto Mastra's private spans for exact cross-stream joins while preserving Mastra's independent telemetry pipeline.
+
 ## [0.2.0] - 2026-07-28
 
 ### Changed

--- a/src/adapters/ts-mastra/CHANGELOG.md
+++ b/src/adapters/ts-mastra/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.3.0-rc.1] - 2026-08-07
+
+### Changed
+
+- Re-cut of `0.3.0-rc.0` on top of `@ratel-ai/sdk@0.7.1-rc.0` and `@ratel-ai/telemetry@0.3.0-rc.1`, which carry the 0.7.0 core (cached BM25 index, adaptive usage ranking). No adapter API or behaviour change from rc.0; the earlier tarball predates that core and is not an ancestor of this one.
+
 ## [0.3.0-rc.0] - 2026-07-30
 
 ### Added

--- a/src/adapters/ts-mastra/README.md
+++ b/src/adapters/ts-mastra/README.md
@@ -73,19 +73,58 @@ What is specific to Mastra is that the two streams do **not** share a pipeline. 
 tracing is a private one: it never registers a global provider — so there is no fight with the
 host's `NodeSDK` — but its spans never pass through the host's span processors either, leaving
 over its exporter's own socket instead. Two parallel egress paths, and no shared trace ids unless
-Mastra's own OTel bridge joins the trees. How to wire any of that is Mastra's documentation to
-give, not this adapter's; the one thing worth saying here is that nothing is ambient — an
-un-instrumented Mastra emits nothing to OpenTelemetry, so until its side is wired up, Ratel's
-spans are all a host gets.
+Mastra's own OTel bridge joins the trees. An un-instrumented Mastra emits no private spans, so
+until its side is configured, Ratel's spans are all a host gets.
 
-Ratel adds nothing to Mastra's stream today. There is no `./otel` entrypoint on this package —
-the `ai@7` integration is specific to the Vercel AI SDK — and no `ratel.*` overlay lands on
-Mastra's spans; Mastra's `spanOutputProcessors` seam is where a processor would stamp one.
+The opt-in `@ratel-ai/mastra/observability` entrypoint adds experiment joins to that private
+stream:
+
+```bash
+pnpm add @mastra/observability @opentelemetry/api @opentelemetry/context-async-hooks
+```
+
+```ts
+import { Mastra } from "@mastra/core/mastra";
+import { Observability } from "@mastra/observability";
+import { context } from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import { experimentalRatelSpanOutputProcessor } from "@ratel-ai/mastra/observability";
+
+// Required even when no exporter is configured: baggage propagation depends on it.
+context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
+
+const observability = new Observability({
+  configs: {
+    default: {
+      serviceName: "my-agent",
+      exporters: [/* the host's Mastra exporters */],
+      spanOutputProcessors: [experimentalRatelSpanOutputProcessor()],
+    },
+  },
+});
+
+export const mastra = new Mastra({ observability });
+```
+
+Add the processor to every Mastra observability config that should carry experiment joins. It
+captures the active arm on a span's first processor pass and copies the five controlled
+`ratel.experiment.*` fields (`id`, `selection_id`, `arm`, `role`, `unit`) onto that span. Baggage
+values win collisions; unrelated Mastra attributes remain. Put it after any custom processor
+that rewrites those keys. Mastra sampling and internal/excluded-span filters still decide which
+spans reach processors.
+
+The Mastra operation must **start inside the experiment arm callback**. Calling
+`agent.generate()` after `experiment.select()` returns is too late: the arm context has ended.
+Without a Mastra OTel bridge, the SDK and Mastra streams keep separate trace ids; join them by the
+five experiment attributes. The processor neither installs a bridge nor changes exporters.
+Executable Mastra tools already traverse Ratel's invocation funnel through `invoke_tool`.
+Provider/client tools with no `execute` remain outside that SDK funnel, although any private
+Mastra span they produce can still receive the experiment join.
 
 ## Package shape
 
 - Package name: `@ratel-ai/mastra`
-- Pure TypeScript, **zero runtime dependencies** — the adapter is glue. `@mastra/core@>=1.11.0 <2`, `zod@^3.25.0 || ^4.0.0` (matching Mastra's own zod peer), and `@ratel-ai/sdk` are peers the host already installs.
+- Pure TypeScript. The root adapter remains glue over host peers: `@mastra/core@>=1.11.0 <2`, `zod@^3.25.0 || ^4.0.0` (matching Mastra's own zod peer), and `@ratel-ai/sdk`. The package carries only the OTel-free `@ratel-ai/telemetry` vocabulary; the opt-in `./observability` entrypoint additionally peers optionally on `@opentelemetry/api`.
 - Live context forwarding spans this adapter and `@ratel-ai/sdk`; upgrade their RCs together. An older SDK silently drops the adapter's opaque context before catalog execution.
 - Requires Node.js 22.13 or newer, matching Mastra's own requirement.
 - MIT ([ADR-0009](../../../docs/adr/0009-licensing.md)); member of the pnpm workspace; `publishConfig` provenance on.
@@ -94,7 +133,7 @@ Mastra's spans; Mastra's `spanOutputProcessors` seam is where a processor would 
 
 The supported range is `@mastra/core@>=1.11.0 <2`. Version 1.11 is the floor because it is the first 1.x release where `createTool()` normalizes zod and raw JSON schemas to the Standard Schema surface that `ingest` reads.
 
-There is no runtime version detection. The adapter stays on the common public tool, message, processor, and `ToolExecutionContext` shapes and owns two tiny compatibility details locally: the direct-call no-op observer fallback and the structural validation-error check. This avoids imports that Mastra only exported later (`isValidationError` in 1.18 and `noopObserve` in 1.37) while preserving their behavior. CI runs the adapter build, suite, and type tests against exact 1.11.0, 1.31.0, and 1.51.0; the worked Mastra example also drives a real 1.51 Agent loop.
+There is no runtime version detection. The adapter stays on the common public tool, message, processor, `SpanOutputProcessor`, and `ToolExecutionContext` shapes and owns small compatibility details locally: the direct-call no-op observer fallback, structural validation-error check, and structural span-output processor type. The latter avoids importing `@mastra/core/observability`, a subpath that Mastra 1.11 did not export even though the processor contract already existed. This also avoids imports that Mastra only exported later (`isValidationError` in 1.18 and `noopObserve` in 1.37) while preserving their behavior. CI runs the adapter build, suite, and type tests against exact 1.11.0, 1.31.0, and 1.51.0; the worked Mastra example also drives a real 1.51 Agent loop.
 
 ## Build & test
 
@@ -107,4 +146,4 @@ pnpm --filter @ratel-ai/mastra lint
 pnpm --filter @ratel-ai/mastra test
 ```
 
-The suite covers the three codecs, the recall processor (including id economy on the no-op paths), a mock-model integration test that drives the real Mastra `Agent` loop, a compile-only type-test locking the supported `@mastra/core` surface, and the `@ratel-ai/sdk/testkit` conformance battery (22 cases, 0 skipped). CI repeats it against the minimum Mastra release.
+The suite covers the three codecs, the recall processor (including id economy on the no-op paths), experiment joins through a real SDK arm context, a mock-model integration test that drives the real Mastra `Agent` loop, a compile-only type-test locking the supported `@mastra/core` surface, and the `@ratel-ai/sdk/testkit` conformance battery (22 cases, 0 skipped). CI repeats it against the minimum Mastra release.

--- a/src/adapters/ts-mastra/package.json
+++ b/src/adapters/ts-mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/mastra",
-  "version": "0.3.0-rc.0",
+  "version": "0.3.0-rc.1",
   "description": "Mastra adapter for Ratel — adapts the context-engineering core to @mastra/core tool and message shapes, with a per-turn recall input processor.",
   "private": false,
   "type": "module",

--- a/src/adapters/ts-mastra/package.json
+++ b/src/adapters/ts-mastra/package.json
@@ -1,11 +1,23 @@
 {
   "name": "@ratel-ai/mastra",
-  "version": "0.2.0",
+  "version": "0.3.0-rc.0",
   "description": "Mastra adapter for Ratel — adapts the context-engineering core to @mastra/core tool and message shapes, with a per-turn recall input processor.",
   "private": false,
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./observability": {
+      "types": "./dist/observability.d.ts",
+      "default": "./dist/observability.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "license": "MIT",
   "author": "Agentified",
   "homepage": "https://github.com/ratel-ai/ratel",
@@ -44,14 +56,25 @@
     "access": "public",
     "provenance": true
   },
+  "dependencies": {
+    "@ratel-ai/telemetry": "workspace:^"
+  },
   "peerDependencies": {
     "@mastra/core": ">=1.11.0 <2",
+    "@opentelemetry/api": "^1.9.0",
     "@ratel-ai/sdk": "workspace:^",
     "zod": "^3.25.0 || ^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@opentelemetry/api": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.13",
     "@mastra/core": "1.51.0",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/context-async-hooks": "^2.9.0",
     "@ratel-ai/sdk": "workspace:^",
     "typescript": "^5.6.0",
     "vitest": "^4.1.5",

--- a/src/adapters/ts-mastra/src/mastra.type-test.ts
+++ b/src/adapters/ts-mastra/src/mastra.type-test.ts
@@ -2,9 +2,19 @@
 // surface, so a drift in Mastra's types fails `tsc -p tsconfig.type-tests.json`
 // rather than at a host's call site.
 import { Agent, type ToolsInput } from "@mastra/core/agent";
+import type { Config } from "@mastra/core/mastra";
 import type { InputProcessor, Processor } from "@mastra/core/processors";
 import { ratel } from "@ratel-ai/sdk";
 import { mastra } from "./mastra.js";
+import { experimentalRatelSpanOutputProcessor } from "./observability.js";
+
+type MastraObservability = NonNullable<Config["observability"]>;
+type MastraObservabilityInstance = NonNullable<
+  ReturnType<MastraObservability["getDefaultInstance"]>
+>;
+type MastraSpanOutputProcessor = ReturnType<
+  MastraObservabilityInstance["getSpanOutputProcessors"]
+>[number];
 
 const view = ratel().adaptTo(mastra());
 
@@ -15,6 +25,8 @@ const tools: ToolsInput = view.modelTools();
 // `InputProcessor` (id + processInput), so it drops into `inputProcessors`.
 const processor: Processor = view.recallProcessor();
 const inputProcessor: InputProcessor = view.recallProcessor();
+const spanOutputProcessor: MastraSpanOutputProcessor = experimentalRatelSpanOutputProcessor();
+const absentSpan = experimentalRatelSpanOutputProcessor().process();
 
 // Both slot into a real Agent construction with no cast.
 const agent = new Agent({
@@ -29,4 +41,6 @@ const agent = new Agent({
 void tools;
 void processor;
 void inputProcessor;
+void spanOutputProcessor;
+void absentSpan;
 void agent;

--- a/src/adapters/ts-mastra/src/observability.test.ts
+++ b/src/adapters/ts-mastra/src/observability.test.ts
@@ -1,0 +1,127 @@
+import { context, propagation } from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import { experimentalDefineExperiment } from "@ratel-ai/sdk";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { experimentalRatelSpanOutputProcessor } from "./observability.js";
+
+describe("experimentalRatelSpanOutputProcessor", () => {
+  beforeEach(() => {
+    context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
+  });
+
+  afterEach(() => {
+    context.disable();
+  });
+
+  it("leaves spans unchanged outside an experiment", async () => {
+    const processor = experimentalRatelSpanOutputProcessor();
+    const span = { attributes: { model: "gpt-5" } };
+
+    expect(processor.process(span)).toBe(span);
+    expect(span.attributes).toEqual({ model: "gpt-5" });
+    expect(processor.process()).toBeUndefined();
+    await expect(processor.shutdown()).resolves.toBeUndefined();
+  });
+
+  it("copies the active experiment join onto a Mastra span", () => {
+    const span = {
+      attributes: {
+        model: "gpt-5",
+        "ratel.experiment.id": "counterfeit",
+      },
+    };
+    const experimentContext = propagation.setBaggage(
+      context.active(),
+      propagation.createBaggage({
+        "ratel.experiment.id": { value: "retrieval-v2" },
+        "ratel.experiment.selection_id": { value: "selection-42" },
+        "ratel.experiment.arm": { value: "hybrid" },
+        "ratel.experiment.role": { value: "serving" },
+        "ratel.experiment.unit": { value: "0123456789abcdef" },
+      }),
+    );
+
+    const processed = context.with(experimentContext, () =>
+      experimentalRatelSpanOutputProcessor().process(span),
+    );
+
+    expect(processed?.attributes).toEqual({
+      model: "gpt-5",
+      "ratel.experiment.id": "retrieval-v2",
+      "ratel.experiment.selection_id": "selection-42",
+      "ratel.experiment.arm": "hybrid",
+      "ratel.experiment.role": "serving",
+      "ratel.experiment.unit": "0123456789abcdef",
+    });
+  });
+
+  it("keeps the experiment captured on the span's first processor pass", () => {
+    const processor = experimentalRatelSpanOutputProcessor();
+    const span = { attributes: { model: "gpt-5" } };
+    const servingContext = propagation.setBaggage(
+      context.active(),
+      propagation.createBaggage({
+        "ratel.experiment.id": { value: "retrieval-v2" },
+        "ratel.experiment.selection_id": { value: "selection-serving" },
+        "ratel.experiment.arm": { value: "hybrid" },
+        "ratel.experiment.role": { value: "serving" },
+        "ratel.experiment.unit": { value: "0123456789abcdef" },
+      }),
+    );
+    const shadowContext = propagation.setBaggage(
+      context.active(),
+      propagation.createBaggage({
+        "ratel.experiment.id": { value: "retrieval-v2" },
+        "ratel.experiment.selection_id": { value: "selection-shadow" },
+        "ratel.experiment.arm": { value: "semantic" },
+        "ratel.experiment.role": { value: "shadow" },
+        "ratel.experiment.unit": { value: "fedcba9876543210" },
+      }),
+    );
+
+    context.with(servingContext, () => processor.process(span));
+    context.with(shadowContext, () => processor.process(span));
+
+    expect(span.attributes).toEqual({
+      model: "gpt-5",
+      "ratel.experiment.id": "retrieval-v2",
+      "ratel.experiment.selection_id": "selection-serving",
+      "ratel.experiment.arm": "hybrid",
+      "ratel.experiment.role": "serving",
+      "ratel.experiment.unit": "0123456789abcdef",
+    });
+  });
+
+  it("copies a real experiment arm's join to a processor span", async () => {
+    const processor = experimentalRatelSpanOutputProcessor();
+    let mastraSpan: { attributes?: unknown } | undefined;
+    const experiment = experimentalDefineExperiment({
+      id: "retrieval-v2",
+      arms: {
+        hybrid: {
+          select: async () => {
+            mastraSpan = { attributes: { model: "gpt-5" } };
+            processor.process(mastraSpan);
+            return { ids: ["deploy"] };
+          },
+        },
+      },
+      ranking: (result: { ids: string[] }) => result.ids.map((id) => ({ id })),
+      evaluation: { references: ["peer-selection"] },
+    });
+
+    const selection = await experiment.select(
+      { query: "ship app" },
+      { arm: "hybrid", unitId: "user-1" },
+    );
+
+    expect(mastraSpan?.attributes).toEqual({
+      model: "gpt-5",
+      "ratel.experiment.id": "retrieval-v2",
+      "ratel.experiment.selection_id": selection.selectionId,
+      "ratel.experiment.arm": "hybrid",
+      "ratel.experiment.role": "serving",
+      "ratel.experiment.unit": "c6c289e49e9c05b2",
+    });
+  });
+});

--- a/src/adapters/ts-mastra/src/observability.ts
+++ b/src/adapters/ts-mastra/src/observability.ts
@@ -1,0 +1,83 @@
+import { context, propagation } from "@opentelemetry/api";
+import {
+  RATEL_EXPERIMENT_ARM,
+  RATEL_EXPERIMENT_ARM_BAGGAGE_KEY,
+  RATEL_EXPERIMENT_ID,
+  RATEL_EXPERIMENT_ID_BAGGAGE_KEY,
+  RATEL_EXPERIMENT_ROLE,
+  RATEL_EXPERIMENT_ROLE_BAGGAGE_KEY,
+  RATEL_EXPERIMENT_SELECTION_ID,
+  RATEL_EXPERIMENT_SELECTION_ID_BAGGAGE_KEY,
+  RATEL_EXPERIMENT_UNIT,
+  RATEL_EXPERIMENT_UNIT_BAGGAGE_KEY,
+} from "@ratel-ai/telemetry";
+
+/** The mutable Mastra span surface used by its span-output processor contract. */
+export interface RatelMastraSpan {
+  attributes?: unknown;
+}
+
+/** A structural Mastra span-output processor, compatible across Mastra 1.x. */
+export interface RatelExperimentSpanOutputProcessor {
+  readonly name: string;
+  process<T extends RatelMastraSpan | undefined = undefined>(span?: T): T;
+  shutdown(): Promise<void>;
+}
+
+const PROCESSOR_NAME = "ratel-experiment-context";
+const EXPERIMENT_JOIN_FIELDS = [
+  [RATEL_EXPERIMENT_ID_BAGGAGE_KEY, RATEL_EXPERIMENT_ID],
+  [RATEL_EXPERIMENT_SELECTION_ID_BAGGAGE_KEY, RATEL_EXPERIMENT_SELECTION_ID],
+  [RATEL_EXPERIMENT_ARM_BAGGAGE_KEY, RATEL_EXPERIMENT_ARM],
+  [RATEL_EXPERIMENT_ROLE_BAGGAGE_KEY, RATEL_EXPERIMENT_ROLE],
+  [RATEL_EXPERIMENT_UNIT_BAGGAGE_KEY, RATEL_EXPERIMENT_UNIT],
+] as const;
+
+/**
+ * Create a Mastra span-output processor that stamps the active retrieval
+ * experiment's five controlled join fields onto Mastra's private spans.
+ */
+export function experimentalRatelSpanOutputProcessor(): RatelExperimentSpanOutputProcessor {
+  const joinsBySpan = new WeakMap<RatelMastraSpan, Record<string, string> | null>();
+  return {
+    name: PROCESSOR_NAME,
+    process<T extends RatelMastraSpan | undefined = undefined>(span?: T): T {
+      if (span === undefined) {
+        return span as T;
+      }
+      let join = joinsBySpan.get(span);
+      if (!joinsBySpan.has(span)) {
+        join = activeExperimentJoin() ?? null;
+        joinsBySpan.set(span, join);
+      }
+      if (join !== null && join !== undefined) {
+        span.attributes = { ...attributesOf(span), ...join };
+      }
+      return span;
+    },
+    shutdown: () => Promise.resolve(),
+  };
+}
+
+function activeExperimentJoin(): Record<string, string> | undefined {
+  const baggage = propagation.getBaggage(context.active());
+  if (baggage === undefined) {
+    return undefined;
+  }
+  const attributes: Record<string, string> = {};
+  for (const [baggageKey, attributeKey] of EXPERIMENT_JOIN_FIELDS) {
+    const entry = baggage.getEntry(baggageKey);
+    if (entry !== undefined) {
+      attributes[attributeKey] = entry.value;
+    }
+  }
+  return Object.keys(attributes).length === 0 ? undefined : attributes;
+}
+
+function attributesOf(span: RatelMastraSpan): Record<string, unknown> {
+  return span.attributes !== null &&
+    typeof span.attributes === "object" &&
+    !Array.isArray(span.attributes)
+    ? (span.attributes as Record<string, unknown>)
+    : {};
+}

--- a/src/adapters/ts-mastra/src/package-layout.test.ts
+++ b/src/adapters/ts-mastra/src/package-layout.test.ts
@@ -7,19 +7,26 @@ interface PackageManifest {
   engines?: Record<string, string>;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
+  exports?: Record<string, unknown>;
   peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
   publishConfig?: { access?: string; provenance?: boolean };
 }
 
 const manifest = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf8"),
 ) as PackageManifest;
+const releaseWorkflow = readFileSync(
+  new URL("../../../../.github/workflows/release.yml", import.meta.url),
+  "utf8",
+);
 
 describe("published mastra dependency layout", () => {
-  it("carries no runtime dependencies — the adapter is pure glue", () => {
-    // Everything the adapter touches (`@mastra/core`, `zod`, `@ratel-ai/sdk`) is
-    // the host's to provide, so it ships as peers with zero runtime `dependencies`.
-    expect(manifest.dependencies ?? {}).toEqual({});
+  it("depends only on the vocabulary its observability subpath imports", () => {
+    // Mastra, zod, the SDK, and OTel are host-owned peers. The OTel-free
+    // vocabulary is the one unconditional package import the published
+    // observability module must always resolve.
+    expect(manifest.dependencies ?? {}).toEqual({ "@ratel-ai/telemetry": "workspace:^" });
   });
 
   it("supports @mastra/core from 1.11 through 1.x", () => {
@@ -29,6 +36,34 @@ describe("published mastra dependency layout", () => {
     // zod peer so a Mastra app on zod 3.25.x resolves cleanly.
     expect(manifest.peerDependencies?.zod).toBe("^3.25.0 || ^4.0.0");
     expect(manifest.peerDependencies?.["@ratel-ai/sdk"]).toBe("workspace:^");
+  });
+
+  it("keeps experiment enrichment on an opt-in subpath with an optional OTel peer", () => {
+    expect(manifest.peerDependencies?.["@opentelemetry/api"]).toBe("^1.9.0");
+    expect(manifest.peerDependenciesMeta?.["@opentelemetry/api"]?.optional).toBe(true);
+    expect(manifest.exports).toMatchObject({
+      ".": {
+        types: "./dist/index.d.ts",
+        default: "./dist/index.js",
+      },
+      "./observability": {
+        types: "./dist/observability.d.ts",
+        default: "./dist/observability.js",
+      },
+      "./dist/*": "./dist/*",
+    });
+
+    const rootSource = readFileSync(new URL("./index.ts", import.meta.url), "utf8");
+    expect(rootSource).not.toContain("./observability.js");
+  });
+
+  it("pins the telemetry workspace dependency before publishing", () => {
+    const jobStart = releaseWorkflow.indexOf("\n  publish-mastra:");
+    const jobEnd = releaseWorkflow.indexOf("\n  publish-vercel-ai-sdk:", jobStart);
+    const publishJob = releaseWorkflow.slice(jobStart, jobEnd);
+
+    expect(publishJob).toContain("p.dependencies['@ratel-ai/telemetry']='^'+process.env.TELE_VER");
+    expect(publishJob).toContain(`npm view "@ratel-ai/telemetry@^\${tele_ver}" version`);
   });
 
   it("dev-pins a concrete @mastra/core release and the workspace SDK", () => {

--- a/src/adapters/ts-vercel-ai-sdk/CHANGELOG.md
+++ b/src/adapters/ts-vercel-ai-sdk/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.4.0-rc.2] - 2026-08-07
+
+### Changed
+
+- Re-cut of `0.4.0-rc.1` on top of `@ratel-ai/sdk@0.7.1-rc.0` and `@ratel-ai/telemetry@0.3.0-rc.1`, which carry the 0.7.0 core (cached BM25 index, adaptive usage ranking). No adapter API or behaviour change from rc.1; the earlier tarball predates that core and is not an ancestor of this one.
+
 ## [0.4.0-rc.1] - 2026-07-30
 
 ### Fixed

--- a/src/adapters/ts-vercel-ai-sdk/CHANGELOG.md
+++ b/src/adapters/ts-vercel-ai-sdk/CHANGELOG.md
@@ -6,6 +6,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.4.0-rc.1] - 2026-07-30
+
+### Fixed
+
+- Passthrough exposure of a class-backed tool no longer throws when a member other than `execute` reads private (`#`) instance state. The 0.4.0-rc.0 wrapper cloned the tool with `Object.create`, which carries the prototype but not the class's private-field brand, so an inherited getter, `needsApproval`, or `toModelOutput` invoked through the exposed tool raised `Cannot read private member`. Inherited accessors and methods now run against the original instance; own members stay carried by identity, so the frozen-tool contract and native member references are unchanged (correcting the rc.0 note that `this` remained intact).
+
+## [0.4.0-rc.0] - 2026-07-30
+
+### Added
+
+- `RatelOtelIntegration` copies the active retrieval experiment's five-field baggage stamp onto every AI SDK `gen_ai.*` span, giving generic and vendor destinations the exact experiment/selection join plus arm, role, and unit context.
+- Client-executed passthrough tools now enter Ratel's `execute_tool` funnel through a descriptor-preserving exposure wrapper. Native lifecycle hooks, metadata, `this`, execution options, and scalar/promise/stream return shapes remain intact; provider/host-executed tools without `execute` remain unobservable.
+
 ## [0.3.0] - 2026-07-28
 
 ### Changed

--- a/src/adapters/ts-vercel-ai-sdk/README.md
+++ b/src/adapters/ts-vercel-ai-sdk/README.md
@@ -2,7 +2,7 @@
 
 The [Vercel AI SDK](https://sdk.vercel.ai) (`ai@^5 || ^6 || ^7`) adapter for [Ratel](https://github.com/ratel-ai/ratel). `ratel(config).adaptTo(aiSdk())` layers a framework-shaped view over the framework-neutral core (ADR-0013), so an AI SDK agent registers its own `tool()`s, hands the model Ratel's capability funnel, and gets per-turn recall — all in the SDK's native `Tool` and `ModelMessage` shapes, with no glue in app code.
 
-Ratel keeps the model's tool list small and stable: instead of advertising every tool, it exposes three capability tools (`search_capabilities` / `invoke_tool` / `get_skill_content`) and injects a ranked, per-turn `search_capabilities` result for the current user message. The core owns all state and every guard (reserved ids, top-K clamp, first-registration-wins, recall-id counter); the adapter is just three codecs plus two recall idioms.
+Ratel keeps the model's tool list small and stable: instead of advertising every tool, it exposes three capability tools (`search_capabilities` / `invoke_tool` / `get_skill_content`) and injects a ranked, per-turn `search_capabilities` result for the current user message. The core owns all state and every guard (reserved ids, top-K clamp, first-registration-wins, recall-id counter); the adapter has three required codecs, the experimental passthrough exposure hook, and two recall idioms.
 
 ## Install
 
@@ -176,10 +176,15 @@ range declared in this package can see that.
   never touched by it — including when they carry `gen_ai.*` attributes of their own, which
   `execute_tool` does. Selecting spans by attribute prefix and expecting the overlay on them
   is asserting something untrue; select by scope.
-- **What lands on each span, for now, is `ratel.origin`.** Not a limit of the hook: the AI
-  SDK hands `enrichSpan` the `spanType`, `operationId`, `callId`, and `runtimeContext` at
-  span creation, so per-span-kind and per-call attributes are already reachable. It's a
-  deliberate baseline — the richer experiment vocabulary lands with the work that defines it.
+- **Every span gets `ratel.origin`; active retrieval experiments add their full join.**
+  When AI SDK work starts inside an `experimentalDefineExperiment` arm callback, the integration
+  copies the five controlled baggage fields — experiment id, selection id, arm, role, and
+  pseudonymous unit hash — onto every emitted `gen_ai.*` span. The selection id is the exact join
+  to the value returned by `select()`. Register a ContextManager unconditionally: without one,
+  the experiment arm's direct attributes survive but descendant baggage does not. Starting
+  `generateText()` only after `select()` returns is also too late; the arm context has been
+  restored by then. Ratel-owned values land after a host `enrichSpan`, so that hook cannot
+  counterfeit them.
 - **`origin` is selectable, and your `enrichSpan` composes.**
   `new RatelOtelIntegration({ origin: Origin.Direct })` overrides the `agent` default. `Origin`
   is re-exported from this entrypoint, so you don't need `@ratel-ai/telemetry` on your own
@@ -190,14 +195,16 @@ range declared in this package can see that.
   instance, so a host doing both passes a second integration per call via
   `telemetry: { integrations: [...] }` rather than re-registering globally.
   Every other option passes through to the embedded emitter, including an `enrichSpan` of your
-  own: it is called and its attributes merged *under* Ratel's, so everything you return lands
-  except `ratel.origin` itself, which the overlay keeps. If your hook throws, you lose your own
-  attributes for that span and nothing else — `ratel.origin` still lands.
+  own: it is called and its attributes merged *under* Ratel's. `ratel.origin` is always a
+  controlled overlay; during an active experiment the five experiment id, selection id, arm,
+  role, and unit keys are controlled too. Host attributes on every other key land unchanged. If
+  your hook throws, you lose your own attributes for that span and nothing else — Ratel's
+  controlled overlays still land.
 
 ## Limitations
 
 - **Persist the response messages** (`await result.responseMessages` on `ai@7`; `(await result.response).messages` on `ai@5`/`ai@6`, which have no `responseMessages`). Recall fires only when the last message is the user's turn. If you drop the accumulated response messages between turns, turn *N+1* loses turn *N*'s tool calls and results — standard AI SDK message hygiene, load-bearing here.
-- **`modelTools()` snapshots passthrough tools.** Plain function tools enter the shared catalog and may register after a snapshot because the model still reaches them through the stable capability tools. Provider-defined/dynamic tools, tools without an `execute`, and tools with AI SDK-only model metadata or lifecycle behavior (`contextSchema`, approval/input hooks, `toModelOutput`, provider options/metadata, strict mode, input examples, or title) pass through directly so the adapter never weakens those semantics. Register passthroughs before taking the snapshot, or call `modelTools()` again and replace the model-facing set.
+- **`modelTools()` snapshots passthrough tools.** Plain function tools enter the shared catalog and may register after a snapshot because the model still reaches them through the stable capability tools. Provider-defined/dynamic tools, tools without an `execute`, and tools with AI SDK-only model metadata or lifecycle behavior (`contextSchema`, approval/input hooks, `toModelOutput`, provider options/metadata, strict mode, input examples, or title) stay native. At each snapshot, a client-executed passthrough gets a descriptor-preserving execution wrapper that leaves its lifecycle hooks, metadata, registered-tool `this`, options, and scalar/promise/stream return shape intact while sending the call through Ratel's `execute_tool` funnel; the registered tool object is never mutated. A passthrough with no client-side `execute` is provider- or host-executed, so Ratel cannot observe its invocation and emits no SDK tool span for it. Register passthroughs before taking the snapshot, or call `modelTools()` again and replace the model-facing set.
 - **Cataloged executable schemas must resolve synchronously.** Registration synchronously rejects a cataloged executable tool whose `inputSchema` or `outputSchema` converts to a Promise. The whole registration batch remains unchanged. Native passthrough tools never enter this conversion path. Use a synchronous Zod schema or static JSON Schema wrapper for cataloged tools.
 - **Live execution options thread through `invoke_tool`; direct catalog calls fall back.** When the model runs a cataloged tool through `invoke_tool`, the adapter forwards the AI SDK's complete live execution options unchanged — `toolCallId`, `messages`, `abortSignal`, and the outer capability's context field (`experimental_context` on `ai@6`/late `ai@5`, `context` on `ai@7`). A tool declaring its own `contextSchema` stays native, so the host validates and routes its named context normally. The driver-level escape hatch `r.tools.catalog.invoke(id, args)` has no AI SDK invocation to thread, so it validates the original input schema and uses a fabricated fallback (`toolCallId: "ratel_<id>"`, `messages: []`, both context spellings `undefined`). Live-option forwarding spans this adapter and `@ratel-ai/sdk` — upgrade their RCs together; an older SDK (before `0.5.1-rc.1`) drops the opaque context before catalog execution.
 - **`appendRecall` is async.** Core recall is asynchronous (unlike the sync prototype this was extracted from) — `await` it.
@@ -209,6 +216,13 @@ Peer range: **`ai@^5.0.0 || ^6.0.0 || ^7.0.0`** — one shared code path, no per
 
 Approval (`needsApproval`) is available on AI SDK 6+, while per-tool `contextSchema` is AI
 SDK 7-only. When present, both stay on the native passthrough path.
+
+Experiment joins degrade explicitly on older majors: `ai@5` has no telemetry-integration seam,
+and `ai@6` has a different legacy seam that `RatelOtelIntegration` does not implement. Their
+framework-emitted `gen_ai.*` spans therefore receive no direct Ratel experiment overlay. The
+adapter still routes every client-executed passthrough through the SDK's own `execute_tool` span
+(cataloged tools already use it), preserving active baggage for a host
+`BaggageSpanProcessor`; passthroughs without `execute` remain invisible as described above.
 
 Each supported major is verified in CI at two exact releases — its floor and its latest verified release — as `ai@5.0.0`, `5.0.217`, `6.0.0`, `6.0.232`, `7.0.0`, `7.0.37` (the `ai-sdk-compat` matrix in `.github/workflows/ci.yml`): every row builds, typechecks, tests, packs, and typechecks a packed-tarball consumer against that exact `ai`. Every row also asserts that consumer resolved **no** `@ai-sdk/otel`; the v7 rows additionally install it and typecheck `RatelOtelIntegration` against the real `ai@7` `Telemetry` interface. Releases between floor and latest are covered by the range, not row-verified.
 

--- a/src/adapters/ts-vercel-ai-sdk/package.json
+++ b/src/adapters/ts-vercel-ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/vercel-ai-sdk",
-  "version": "0.3.0",
+  "version": "0.4.0-rc.1",
   "description": "Vercel AI SDK adapter for Ratel — adapts the context-engineering core to the AI SDK's (ai@5-7) tool and message shapes, with per-turn recall helpers.",
   "private": false,
   "type": "module",

--- a/src/adapters/ts-vercel-ai-sdk/package.json
+++ b/src/adapters/ts-vercel-ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/vercel-ai-sdk",
-  "version": "0.4.0-rc.1",
+  "version": "0.4.0-rc.2",
   "description": "Vercel AI SDK adapter for Ratel — adapts the context-engineering core to the AI SDK's (ai@5-7) tool and message shapes, with per-turn recall helpers.",
   "private": false,
   "type": "module",

--- a/src/adapters/ts-vercel-ai-sdk/src/aisdk.test.ts
+++ b/src/adapters/ts-vercel-ai-sdk/src/aisdk.test.ts
@@ -355,21 +355,142 @@ describe("live execution context", () => {
 });
 
 describe("passthrough end-to-end", () => {
-  it("exposes a provider tool by identity and never catalogs it", () => {
+  it("wraps a frozen client-executed provider without changing its native call contract", async () => {
     const view = ratel().adaptTo(aiSdk());
-    const providerTool = {
+    let receiver: unknown;
+    let receivedOptions: unknown;
+    const originalExecute = function (this: unknown, input: unknown, options: unknown) {
+      receiver = this;
+      receivedOptions = options;
+      return { input, ran: true };
+    };
+    const providerTool = Object.freeze({
       type: "provider",
       id: "acme.shell",
       args: {},
       isProviderExecuted: false,
       inputSchema: { type: "object" },
-      execute: async () => ({ ran: true }),
-    } as unknown as Tool;
-    view.tools.register({ shell: providerTool });
-    // Exposed untouched, in native provider shape...
-    expect(view.modelTools().shell).toBe(providerTool);
-    // ...and never funneled into the catalog.
+      execute: originalExecute,
+    }) as unknown as Tool;
+    await view.tools.register({ shell: providerTool });
+    const exposed = view.modelTools().shell;
+    const options = { toolCallId: "shell-0", messages: [] };
+    const result = (exposed.execute as (input: unknown, options: unknown) => unknown)(
+      { command: "pwd" },
+      options,
+    );
+
+    expect(exposed).not.toBe(providerTool);
+    expect(result).toEqual({ input: { command: "pwd" }, ran: true });
+    expect(receiver).toBe(providerTool);
+    expect(receivedOptions).toBe(options);
+    expect(providerTool.execute).toBe(originalExecute);
+    expect((exposed as { id?: string }).id).toBe("acme.shell");
     expect(view.tools.catalog.has("shell")).toBe(false);
+  });
+
+  it("preserves promise and AsyncIterable return shapes", async () => {
+    const view = ratel().adaptTo(aiSdk());
+    await view.tools.register({
+      promised: {
+        type: "provider",
+        id: "acme.promised",
+        args: {},
+        inputSchema: { type: "object" },
+        execute: () => Promise.resolve({ done: true }),
+      } as unknown as Tool,
+      streamed: {
+        type: "provider",
+        id: "acme.streamed",
+        args: {},
+        inputSchema: { type: "object" },
+        execute: async function* () {
+          yield { step: 1 };
+          yield { step: 2 };
+        },
+      } as unknown as Tool,
+    });
+    const tools = view.modelTools();
+    const options = { toolCallId: "shape-0", messages: [] };
+
+    const promise = (
+      tools.promised.execute as (input: unknown, options: unknown) => PromiseLike<unknown>
+    )({}, options);
+    const stream = (
+      tools.streamed.execute as (
+        input: unknown,
+        options: unknown,
+      ) => AsyncIterable<{ step: number }>
+    )({}, options);
+
+    expect(promise).toBeInstanceOf(Promise);
+    await expect(promise).resolves.toEqual({ done: true });
+    expect(typeof stream[Symbol.asyncIterator]).toBe("function");
+    const values: Array<{ step: number }> = [];
+    for await (const value of stream) values.push(value);
+    expect(values).toEqual([{ step: 1 }, { step: 2 }]);
+  });
+
+  it("executes a class-backed passthrough against its registered private state", async () => {
+    class StatefulProviderTool {
+      readonly type = "provider";
+      readonly id = "acme.stateful";
+      readonly args = {};
+      readonly isProviderExecuted = false;
+      readonly inputSchema = { type: "object" };
+      #calls = 0;
+
+      execute() {
+        return { calls: ++this.#calls };
+      }
+
+      get calls() {
+        return this.#calls;
+      }
+    }
+
+    const view = ratel().adaptTo(aiSdk());
+    const providerTool = new StatefulProviderTool();
+    await view.tools.register({ stateful: providerTool as unknown as Tool });
+    const exposed = view.modelTools().stateful;
+
+    expect((exposed.execute as () => unknown)()).toEqual({ calls: 1 });
+    expect(providerTool.calls).toBe(1);
+  });
+
+  it("reads private state through a class-backed passthrough's getters and methods", async () => {
+    class StatefulProviderTool {
+      readonly type = "provider";
+      readonly id = "acme.stateful-members";
+      readonly args = {};
+      readonly isProviderExecuted = false;
+      readonly inputSchema = { type: "object" };
+      #calls = 0;
+
+      execute() {
+        return { calls: ++this.#calls };
+      }
+
+      get calls() {
+        return this.#calls;
+      }
+
+      snapshot() {
+        return { calls: this.#calls };
+      }
+    }
+
+    const view = ratel().adaptTo(aiSdk());
+    const providerTool = new StatefulProviderTool();
+    await view.tools.register({ stateful: providerTool as unknown as Tool });
+    const exposed = view.modelTools().stateful as unknown as StatefulProviderTool;
+
+    expect((exposed.execute as () => unknown)()).toEqual({ calls: 1 });
+    // Members other than execute must resolve their private state against the
+    // original instance, not the wrapper: a getter and a method invoked through
+    // the exposed tool read #calls without a private-brand TypeError.
+    expect(exposed.calls).toBe(1);
+    expect(exposed.snapshot()).toEqual({ calls: 1 });
   });
 });
 

--- a/src/adapters/ts-vercel-ai-sdk/src/aisdk.ts
+++ b/src/adapters/ts-vercel-ai-sdk/src/aisdk.ts
@@ -1,5 +1,6 @@
 import type {
   CatalogRegistration,
+  ExperimentalPassthroughToolExposure,
   JSONSchema7,
   RatelAdapter,
   RecallRef,
@@ -76,9 +77,9 @@ export interface AiSdkExt {
  * The Vercel AI SDK adapter: `ratel(config).adaptTo(aiSdk())` gives the
  * framework-neutral core the AI SDK's native {@link Tool} and
  * {@link ModelMessage} shapes, across `ai@5`, `ai@6`, and `ai@7`. The core owns every guard (reserved ids, top-K clamp,
- * first-registration-wins, recall-id counter), so the adapter is just the three
- * codecs — `ingest` / `expose` / `recallMessages` — plus the {@link AiSdkExt}
- * recall helpers.
+ * first-registration-wins, recall-id counter), so the adapter is the three
+ * required codecs — `ingest` / `expose` / `recallMessages` — the experimental
+ * passthrough exposure hook, plus the {@link AiSdkExt} recall helpers.
  *
  * @returns A {@link RatelAdapter} over the AI SDK's tool and message types.
  */
@@ -148,6 +149,10 @@ export function aiSdk(): RatelAdapter<Tool, ModelMessage, AiSdkExt> {
       });
     },
 
+    experimentalExposePassthrough(t, exposure) {
+      return wrapPassthrough(t, exposure);
+    },
+
     recallMessages(ref: RecallRef, recall: SearchCapabilitiesResult): ModelMessage[] {
       return [
         {
@@ -215,6 +220,73 @@ export function aiSdk(): RatelAdapter<Tool, ModelMessage, AiSdkExt> {
       };
     },
   };
+}
+
+function wrapPassthrough(t: Tool, exposure: ExperimentalPassthroughToolExposure): Tool {
+  const execute = t.execute;
+  if (typeof execute !== "function") {
+    return t;
+  }
+  const descriptors = Object.getOwnPropertyDescriptors(t);
+  const executeDescriptor = Object.getOwnPropertyDescriptor(t, "execute");
+  let exposed: Tool;
+  descriptors.execute = {
+    configurable: executeDescriptor?.configurable ?? true,
+    enumerable: executeDescriptor?.enumerable ?? true,
+    writable:
+      executeDescriptor !== undefined && "writable" in executeDescriptor
+        ? executeDescriptor.writable
+        : true,
+    value: function (this: unknown, input: unknown, options: unknown) {
+      const receiver = this === exposed ? t : this;
+      return exposure.invoke(input, () => Reflect.apply(execute, receiver, [input, options]));
+    },
+  };
+  // The clone shares t's prototype but not its private-field brand, so any
+  // inherited member reading instance state — a class-backed tool's getter,
+  // needsApproval, or toModelOutput — would resolve #private against the clone
+  // and throw. Re-expose each inherited member bound to the original instance.
+  // Own members (the object-literal `tool()` shape) stay carried above by
+  // identity, so their references and the frozen-tool contract are preserved.
+  redirectInheritedMembers(t, descriptors);
+  exposed = Object.create(Object.getPrototypeOf(t), descriptors) as Tool;
+  return exposed;
+}
+
+// Redirect the receiver of every prototype-chain accessor and method to the
+// original instance so private-field reads resolve against its brand. Keys
+// already carried as own descriptors are left untouched.
+function redirectInheritedMembers(
+  t: Tool,
+  descriptors: Record<PropertyKey, PropertyDescriptor>,
+): void {
+  let proto: object | null = Object.getPrototypeOf(t);
+  while (proto !== null && proto !== Object.prototype) {
+    for (const key of Reflect.ownKeys(proto)) {
+      if (key === "constructor" || key === "execute" || Object.hasOwn(descriptors, key)) {
+        continue;
+      }
+      const inherited = Object.getOwnPropertyDescriptor(proto, key);
+      if (inherited === undefined) continue;
+      if (inherited.get !== undefined || inherited.set !== undefined) {
+        const { get, set } = inherited;
+        descriptors[key] = {
+          configurable: true,
+          enumerable: inherited.enumerable ?? false,
+          get: get ? () => get.call(t) : undefined,
+          set: set ? (value: unknown) => set.call(t, value) : undefined,
+        };
+      } else if (typeof inherited.value === "function") {
+        descriptors[key] = {
+          configurable: true,
+          enumerable: inherited.enumerable ?? false,
+          writable: inherited.writable ?? false,
+          value: (inherited.value as (...args: unknown[]) => unknown).bind(t),
+        };
+      }
+    }
+    proto = Object.getPrototypeOf(proto);
+  }
 }
 
 function rethrowTargetFailure(result: unknown): unknown {

--- a/src/adapters/ts-vercel-ai-sdk/src/coexistence.test.ts
+++ b/src/adapters/ts-vercel-ai-sdk/src/coexistence.test.ts
@@ -10,8 +10,17 @@ import {
   type SpanExporter,
   type SpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
-import { ratel } from "@ratel-ai/sdk";
-import { EXECUTE_TOOL, RATEL_ORIGIN, RATEL_SEARCH } from "@ratel-ai/telemetry";
+import { experimentalDefineExperiment, ratel } from "@ratel-ai/sdk";
+import {
+  EXECUTE_TOOL,
+  RATEL_EXPERIMENT_ARM,
+  RATEL_EXPERIMENT_ID,
+  RATEL_EXPERIMENT_ROLE,
+  RATEL_EXPERIMENT_SELECTION_ID,
+  RATEL_EXPERIMENT_UNIT,
+  RATEL_ORIGIN,
+  RATEL_SEARCH,
+} from "@ratel-ai/telemetry";
 import * as ai from "ai";
 import { generateText, type LanguageModel, tool } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -233,6 +242,27 @@ async function driveMixedWorkInHostSpan(): Promise<void> {
   });
 }
 
+async function driveExperimentWork(): Promise<string> {
+  const experiment = experimentalDefineExperiment({
+    id: "retrieval-v2",
+    arms: {
+      hybrid: {
+        select: async () => {
+          await driveMixedWork();
+          return { ids: ["deploy_app"] };
+        },
+      },
+    },
+    ranking: (result) => result.ids.map((id) => ({ id })),
+    evaluation: { references: ["peer-selection"] },
+  });
+  const selection = await experiment.select(
+    { query: "deploy to production" },
+    { arm: "hybrid", unitId: "unit-a" },
+  );
+  return selection.selectionId;
+}
+
 describe("telemetry coexistence", () => {
   it("fans the SDK's own spans to every processor on the host's provider", async () => {
     const langfuse = langfuseDestination(ACCEPT_ALL);
@@ -290,6 +320,33 @@ describe("telemetry coexistence", () => {
     // `ratel.` name prefix also catches `execute_tool`, whose name carries no
     // hint of who emitted it.
     expect(langfuse.names()).toEqual([`${EXECUTE_TOOL} deploy_app`, RATEL_SEARCH]);
+  });
+
+  it("funnels a client-executed passthrough through the SDK tool span", async () => {
+    const generic = inMemoryDestination();
+    hostProvider(generic);
+    const view = ratel({ trace: { kind: "memory", sessionId: "passthrough" } }).adaptTo(aiSdk());
+    await view.tools.register({
+      shell: {
+        type: "provider",
+        id: "acme.shell",
+        args: {},
+        isProviderExecuted: false,
+        inputSchema: { type: "object" },
+        execute: (input: unknown) => ({ input, ran: true }),
+      } as unknown as Tool,
+    });
+    const exposed = view.modelTools().shell;
+    const run = exposed.execute as (input: unknown, options: unknown) => unknown;
+
+    const result = run({ command: "pwd" }, { toolCallId: "shell-0", messages: [] });
+    await provider?.forceFlush();
+
+    expect(result).toEqual({ input: { command: "pwd" }, ran: true });
+    expect(scopedNames(generic.spans(), SDK_SCOPE)).toContain(`${EXECUTE_TOOL} shell`);
+    expect(
+      (view.tools.catalog.drainTraceEvents() as Array<{ type: string }>).map((event) => event.type),
+    ).toEqual(["invoke_start", "invoke_end"]);
   });
 });
 
@@ -351,6 +408,34 @@ describe.skipIf(aiSdkMajor < 7)("telemetry coexistence with the AI SDK integrati
       for (const span of emitted) {
         expect(span.attributes[RATEL_ORIGIN]).toBe("agent");
         expect(span.attributes["deployment.environment"]).toBe("staging");
+      }
+    }
+    expect(scopedNames(generic.spans(), AI_SDK_SCOPE)).toEqual(
+      scopedNames(langfuse.spans(), AI_SDK_SCOPE),
+    );
+  });
+
+  it("carries a real experiment join to every destination", async () => {
+    const langfuse = langfuseDestination(ACCEPT_ALL);
+    const generic = inMemoryDestination();
+    hostProvider(langfuse, generic);
+    registerTelemetry?.(new RatelOtelIntegration());
+
+    const selectionId = await driveExperimentWork();
+    await provider?.forceFlush();
+
+    const expectedJoin = {
+      [RATEL_EXPERIMENT_ID]: "retrieval-v2",
+      [RATEL_EXPERIMENT_SELECTION_ID]: selectionId,
+      [RATEL_EXPERIMENT_ARM]: "hybrid",
+      [RATEL_EXPERIMENT_ROLE]: "serving",
+      [RATEL_EXPERIMENT_UNIT]: "d7bce2267437426d",
+    };
+    for (const seen of [generic.spans(), langfuse.spans()]) {
+      const emitted = fromScope(seen, AI_SDK_SCOPE);
+      expect(emitted.length).toBeGreaterThan(0);
+      for (const span of emitted) {
+        expect(span.attributes).toMatchObject(expectedJoin);
       }
     }
     expect(scopedNames(generic.spans(), AI_SDK_SCOPE)).toEqual(

--- a/src/adapters/ts-vercel-ai-sdk/src/generate-text.test.ts
+++ b/src/adapters/ts-vercel-ai-sdk/src/generate-text.test.ts
@@ -99,7 +99,10 @@ describe("AI SDK loop integration", () => {
       prompt: "read the tenant",
     });
 
-    expect(tools.tenant_probe).toBe(tenantProbe);
+    expect(tools.tenant_probe).not.toBe(tenantProbe);
+    expect((tools.tenant_probe as typeof tenantProbe).contextSchema).toBe(
+      tenantProbe.contextSchema,
+    );
     expect(receivedContext).toEqual({ tenantId: "ACME" });
   });
 
@@ -144,7 +147,8 @@ describe("AI SDK loop integration", () => {
     ).responseMessages;
     const toolMessage = responseMessages.find((message) => message.role === "tool");
 
-    expect(tools.render_status).toBe(rendered);
+    expect(tools.render_status).not.toBe(rendered);
+    expect((tools.render_status as typeof rendered).toModelOutput).toBe(rendered.toModelOutput);
     expect(toolMessage?.content[0]?.output).toEqual({
       type: "text",
       value: "STATUS:ready",

--- a/src/adapters/ts-vercel-ai-sdk/src/otel.test.ts
+++ b/src/adapters/ts-vercel-ai-sdk/src/otel.test.ts
@@ -1,5 +1,5 @@
 import { OpenTelemetry } from "@ai-sdk/otel";
-import { context, trace } from "@opentelemetry/api";
+import { context, propagation, trace } from "@opentelemetry/api";
 import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
 import {
   BasicTracerProvider,
@@ -7,7 +7,20 @@ import {
   type ReadableSpan,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
-import { Origin, RATEL_ORIGIN } from "@ratel-ai/telemetry";
+import {
+  Origin,
+  RATEL_EXPERIMENT_ARM,
+  RATEL_EXPERIMENT_ARM_BAGGAGE_KEY,
+  RATEL_EXPERIMENT_ID,
+  RATEL_EXPERIMENT_ID_BAGGAGE_KEY,
+  RATEL_EXPERIMENT_ROLE,
+  RATEL_EXPERIMENT_ROLE_BAGGAGE_KEY,
+  RATEL_EXPERIMENT_SELECTION_ID,
+  RATEL_EXPERIMENT_SELECTION_ID_BAGGAGE_KEY,
+  RATEL_EXPERIMENT_UNIT,
+  RATEL_EXPERIMENT_UNIT_BAGGAGE_KEY,
+  RATEL_ORIGIN,
+} from "@ratel-ai/telemetry";
 import * as ai from "ai";
 import { generateText, type LanguageModel, tool } from "ai";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -196,6 +209,51 @@ describe.skipIf(aiSdkMajor < 7)("RatelOtelIntegration", () => {
     expect(produced.length).toBeGreaterThan(0);
     for (const span of produced) {
       expect(span.attributes[RATEL_ORIGIN]).toBe("agent");
+    }
+  });
+
+  it("stamps the active experiment join on every span the AI SDK emits", async () => {
+    const experimentJoin = {
+      [RATEL_EXPERIMENT_ID]: "retrieval-v2",
+      [RATEL_EXPERIMENT_SELECTION_ID]: "selection-42",
+      [RATEL_EXPERIMENT_ARM]: "hybrid",
+      [RATEL_EXPERIMENT_ROLE]: "serving",
+      [RATEL_EXPERIMENT_UNIT]: "0123456789abcdef",
+    };
+    let baggage = propagation.createBaggage();
+    for (const [key, value] of [
+      [RATEL_EXPERIMENT_ID_BAGGAGE_KEY, experimentJoin[RATEL_EXPERIMENT_ID]],
+      [RATEL_EXPERIMENT_SELECTION_ID_BAGGAGE_KEY, experimentJoin[RATEL_EXPERIMENT_SELECTION_ID]],
+      [RATEL_EXPERIMENT_ARM_BAGGAGE_KEY, experimentJoin[RATEL_EXPERIMENT_ARM]],
+      [RATEL_EXPERIMENT_ROLE_BAGGAGE_KEY, experimentJoin[RATEL_EXPERIMENT_ROLE]],
+      [RATEL_EXPERIMENT_UNIT_BAGGAGE_KEY, experimentJoin[RATEL_EXPERIMENT_UNIT]],
+    ] as const) {
+      baggage = baggage.setEntry(key, { value });
+    }
+    const experimentContext = propagation.setBaggage(context.active(), baggage);
+
+    await context.with(experimentContext, () =>
+      generateText({
+        model: new MockLanguageModelV2([textReply("hi")]) as unknown as LanguageModel,
+        prompt: "hello",
+        telemetry: {
+          integrations: [
+            new RatelOtelIntegration({
+              enrichSpan: () => ({
+                [RATEL_EXPERIMENT_ID]: "counterfeit",
+                [RATEL_EXPERIMENT_SELECTION_ID]: "counterfeit",
+              }),
+            }),
+          ],
+        },
+      }),
+    );
+
+    const produced = spans();
+    expect(produced.length).toBeGreaterThan(0);
+    for (const span of produced) {
+      // Controlled baggage wins over a host hook that writes Ratel-owned keys.
+      expect(span.attributes).toMatchObject(experimentJoin);
     }
   });
 

--- a/src/adapters/ts-vercel-ai-sdk/src/otel.ts
+++ b/src/adapters/ts-vercel-ai-sdk/src/otel.ts
@@ -1,5 +1,19 @@
 import { type EnrichSpan, OpenTelemetry, type OpenTelemetryOptions } from "@ai-sdk/otel";
-import { Origin, RATEL_ORIGIN } from "@ratel-ai/telemetry";
+import { type Attributes, context, propagation } from "@opentelemetry/api";
+import {
+  Origin,
+  RATEL_EXPERIMENT_ARM,
+  RATEL_EXPERIMENT_ARM_BAGGAGE_KEY,
+  RATEL_EXPERIMENT_ID,
+  RATEL_EXPERIMENT_ID_BAGGAGE_KEY,
+  RATEL_EXPERIMENT_ROLE,
+  RATEL_EXPERIMENT_ROLE_BAGGAGE_KEY,
+  RATEL_EXPERIMENT_SELECTION_ID,
+  RATEL_EXPERIMENT_SELECTION_ID_BAGGAGE_KEY,
+  RATEL_EXPERIMENT_UNIT,
+  RATEL_EXPERIMENT_UNIT_BAGGAGE_KEY,
+  RATEL_ORIGIN,
+} from "@ratel-ai/telemetry";
 
 /**
  * Re-exported so `origin` is spellable without depending on `@ratel-ai/telemetry`
@@ -11,7 +25,8 @@ export { Origin };
 
 /**
  * {@link RatelOtelIntegration} options: every `@ai-sdk/otel` knob, plus the
- * `ratel.origin` the overlay stamps.
+ * `ratel.origin` the overlay stamps. An active retrieval experiment contributes
+ * its five controlled join fields from OTel baggage automatically.
  *
  * `enrichSpan` is composed with, not taken over. Owning it outright would cost
  * a host every attribute its own hook adds, silently and unrecoverably — the
@@ -59,9 +74,18 @@ type EmittingTelemetry = Pick<
   | "onError"
 >;
 
+const EXPERIMENT_JOIN_FIELDS = [
+  [RATEL_EXPERIMENT_ID_BAGGAGE_KEY, RATEL_EXPERIMENT_ID],
+  [RATEL_EXPERIMENT_SELECTION_ID_BAGGAGE_KEY, RATEL_EXPERIMENT_SELECTION_ID],
+  [RATEL_EXPERIMENT_ARM_BAGGAGE_KEY, RATEL_EXPERIMENT_ARM],
+  [RATEL_EXPERIMENT_ROLE_BAGGAGE_KEY, RATEL_EXPERIMENT_ROLE],
+  [RATEL_EXPERIMENT_UNIT_BAGGAGE_KEY, RATEL_EXPERIMENT_UNIT],
+] as const;
+
 /**
  * An `ai@7` telemetry integration that emits the AI SDK's standard `gen_ai.*`
- * spans and adds Ratel's `ratel.*` overlay.
+ * spans and adds Ratel's `ratel.*` overlay: `ratel.origin`, plus the active
+ * retrieval experiment's id, selection id, arm, role, and unit hash.
  *
  * It **creates** spans onto whatever OTel provider the host has registered; it
  * never registers a provider and never exports. Delivery is the host's: every
@@ -89,6 +113,8 @@ type EmittingTelemetry = Pick<
  * integration's embedded emitter creates (scope `gen_ai`). The SDK's own
  * `ratel.*` and `execute_tool <tool>` spans come from a different tracer and are
  * never enriched here, `gen_ai.*` attributes on them notwithstanding.
+ * Experiment baggage propagates only when the host registers a ContextManager
+ * and starts AI SDK work inside the experiment arm callback.
  *
  * **Register exactly one emitting integration.** This one, Langfuse's, and the
  * bare `OpenTelemetry` from `@ai-sdk/otel` all embed the same emitter, so
@@ -108,9 +134,13 @@ export class RatelOtelIntegration implements EmittingTelemetry {
   constructor({ origin = Origin.Agent, enrichSpan, ...options }: RatelOtelIntegrationOptions = {}) {
     this.#emitter = new OpenTelemetry({
       ...options,
-      // Ratel's keys land last: `ratel.origin` is Ratel vocabulary, so a host
-      // hook that writes it too must not decide what the overlay reports.
-      enrichSpan: (event) => ({ ...hostAttributes(enrichSpan, event), [RATEL_ORIGIN]: origin }),
+      // Ratel's keys land last, so a host hook cannot counterfeit controlled
+      // origin or experiment vocabulary.
+      enrichSpan: (event) => ({
+        ...hostAttributes(enrichSpan, event),
+        ...activeExperimentJoin(),
+        [RATEL_ORIGIN]: origin,
+      }),
     });
   }
 
@@ -225,4 +255,20 @@ function hostAttributes(enrichSpan: EnrichSpan | undefined, event: Parameters<En
   } catch {
     return undefined;
   }
+}
+
+/** Controlled experiment baggage copied onto descendant AI SDK spans for exact joins. */
+function activeExperimentJoin(): Attributes | undefined {
+  const baggage = propagation.getBaggage(context.active());
+  if (baggage === undefined) {
+    return undefined;
+  }
+  const attributes: Attributes = {};
+  for (const [baggageKey, attributeKey] of EXPERIMENT_JOIN_FIELDS) {
+    const entry = baggage.getEntry(baggageKey);
+    if (entry !== undefined) {
+      attributes[attributeKey] = entry.value;
+    }
+  }
+  return attributes;
 }


### PR DESCRIPTION
**Stacked on #140** — review/merge after it. Base is \`feat/retrieval-experiments\`, not \`main\`, so the diff below is exactly the adapter changes.

Splits the framework-adapter work out of #140 so that PR stays scoped to the SDK core, telemetry vocabulary, and ADRs.

## What's here
- **Vercel AI SDK + Mastra adapters** implement `experimentalExposePassthrough`, routing client-executed passthrough tools through the core invocation funnel so they emit the same OTel span + local trace events as catalog tool invocations.
- **Mastra** adds observability wiring (`observability.ts`) and an `@ratel-ai/telemetry` runtime dependency; the release workflow pins that dependency before the immutable npm publish.
- Adapters join retrieval-experiment telemetry.

The passthrough-exposure **SPI type + core invocation funnel** (`ExperimentalPassthroughToolExposure`) and the **ADR-0013** amendment land in the base PR (#140); this PR is the adapter-side implementation that consumes them.