### PR TITLE
perf(core): cache BM25 index across searches, rebuild only on catalog mutation

### DIFF
--- a/docs/adr/0011-selectable-retrieval-methods.md
+++ b/docs/adr/0011-selectable-retrieval-methods.md
@@ -28,10 +28,11 @@ is chosen per catalog (a construction-time default) or per call (an explicit ove
 override wins. Across the SDKs the identifier is the string `"bm25" | "semantic" | "hybrid"`,
 parallel to `SearchOrigin`.
 
-- **BM25** is unchanged from ADR-0004 (`bm25_search`, `k1 = 0.9`, `b = 0.4`) and stays the
-  default. The legacy `search` / `search_with_origin` entry points keep their infallible
+- **BM25** is unchanged from ADR-0004 (`Bm25Index::search`, `k1 = 0.9`, `b = 0.4`) and stays
+  the default. The legacy `search` / `search_with_origin` entry points keep their infallible
   `Vec<SearchHit>` signature and BM25 behavior byte-for-byte — upgrading callers need no code
-  change.
+  change. The index is cached per registry (`Bm25Cache`) and rebuilt in full on the first
+  search after a corpus mutation, so scores always equal a fresh build's.
 - **Semantic** embeds the query with a local `BAAI/bge-small-en-v1.5` model (pure-Rust Candle,
   pinned revision, CLS-pool + L2-normalize) and cosine-ranks it against embedded tool/skill
   text (`dense_search`). The same `searchable_text` projection feeds it. (The model is the

--- a/docs/adr/0014-adaptive-usage-ranking.md
+++ b/docs/adr/0014-adaptive-usage-ranking.md
@@ -221,7 +221,7 @@ LLM-extracted intents populate the same `members` field.
   when the ranker was wrong. The tool author's vocabulary stops being the only lever
   (ADR-0004).
 - **Ranking becomes order-dependent.** The same events in a different order produce a
-  different graph. This is a real reversal of the determinism posture `bm25_search` and
+  different graph. This is a real reversal of the determinism posture `Bm25Index::search` and
   `sort_and_truncate` hold elsewhere, accepted as the cost of learning without a build
   step; replaying the JSONL trace log is the escape hatch when a reproducible artifact is
   needed (CI, benchmarks, bug reports).

--- a/src/core/src/fusion.rs
+++ b/src/core/src/fusion.rs
@@ -22,7 +22,7 @@ pub(crate) type WeightedArm<'a> = (&'a [String], f32);
 /// Reciprocal Rank Fusion with a **per-arm weight**:
 /// `score(id) = Σ_arms w_arm · 1 / (k + rank_in_arm)`.
 ///
-/// [`rrf_fuse`] is this at `w = 1.0` for every arm. The weight exists for the
+/// Plain RRF is this at `w = 1.0` for every arm. The weight exists for the
 /// usage-ranking arm (ADR-0014), which is deliberately sub-unit: at the same rank
 /// a capability the query lexically matched outranks one only usage history
 /// supports. A sub-unit arm still promotes a deeply-ranked id past another arm's
@@ -54,7 +54,7 @@ pub(crate) fn rrf_fuse_weighted(lists: &[WeightedArm<'_>], k: f32) -> Vec<(Strin
 
 /// The shared `(score desc, id asc)` ordering, then truncate to `top_k`. Ranking
 /// the full set before the cut keeps top-K *membership* stable when a tie
-/// straddles the boundary — see the rationale in [`crate::search::bm25_search`].
+/// straddles the boundary — see the rationale in [`crate::search::Bm25Index::search`].
 pub(crate) fn sort_and_truncate(ranked: &mut Vec<(String, f32)>, top_k: usize) {
     ranked.sort_by(|a, b| {
         b.1.partial_cmp(&a.1)

--- a/src/core/src/search.rs
+++ b/src/core/src/search.rs
@@ -1,64 +1,167 @@
-use bm25::{Document, Language, SearchEngineBuilder};
+use std::sync::{Arc, Mutex, PoisonError};
+
+use bm25::{Document, Language, SearchEngine, SearchEngineBuilder};
 
 // Tuned for short tool/skill descriptions; see ADR-0004.
 pub(crate) const BM25_K1: f32 = 0.9;
 pub(crate) const BM25_B: f32 = 0.4;
 
-/// Build a one-shot BM25 index over `(id, searchable_text)` documents and
-/// return the top-`top_k` matches as `(id, score)`, ordered best-first with
-/// ties broken by `id` so the result is deterministic across processes.
-///
-/// The index is rebuilt per call (no persistence) — the same strategy the tool
-/// registry has always used. Empty input yields an empty result without
-/// touching the engine.
-pub(crate) fn bm25_search<I>(docs: I, query: &str, top_k: usize) -> Vec<(String, f32)>
-where
-    I: IntoIterator<Item = (String, String)>,
-{
-    let pairs: Vec<(String, String)> = docs.into_iter().collect();
-    if pairs.is_empty() {
-        return Vec::new();
+/// A prebuilt BM25 index over `(id, searchable_text)` documents: build once
+/// per corpus state, query many times. Building tokenizes and stems the whole
+/// corpus — ~100x the cost of one query — so the registries cache one of these
+/// (see [`Bm25Cache`]) and rebuild only after a corpus mutation, instead of the
+/// historical build-per-search. Every query ranks the full corpus in
+/// `(score desc, id asc)` order and then cuts to `top_k`.
+pub(crate) struct Bm25Index {
+    /// `None` when the corpus is empty — the engine is never built for zero
+    /// documents (its `avgdl` fit has no corpus to fit).
+    engine: Option<SearchEngine<String>>,
+    doc_count: usize,
+}
+
+impl Bm25Index {
+    /// Tokenize and index `docs`. Corpus statistics (`avgdl`, IDF) come from a
+    /// complete build over exactly these documents, so a rebuild after any
+    /// mutation scores byte-for-byte like a fresh one-shot search — never
+    /// incrementally upsert into the engine, that freezes a stale `avgdl` into
+    /// new documents' scores.
+    pub(crate) fn build<I>(docs: I) -> Self
+    where
+        I: IntoIterator<Item = (String, String)>,
+    {
+        let pairs: Vec<(String, String)> = docs.into_iter().collect();
+        let doc_count = pairs.len();
+        if doc_count == 0 {
+            return Self {
+                engine: None,
+                doc_count,
+            };
+        }
+        let engine = SearchEngineBuilder::<String>::with_documents(
+            Language::English,
+            pairs
+                .into_iter()
+                .map(|(id, contents)| Document { id, contents }),
+        )
+        .k1(BM25_K1)
+        .b(BM25_B)
+        .build();
+        Self {
+            engine: Some(engine),
+            doc_count,
+        }
     }
-    // Rank against the full corpus, then truncate — never let the engine cut to
-    // `top_k` itself. The bm25 crate sorts by score alone and collects
-    // candidates through a HashSet, so equal scores fall back to hash-seed
-    // iteration order and flip between processes; a tie straddling the `top_k`
-    // boundary would make top-K *membership* nondeterministic. We rank
-    // everything, break ties by id, then cut — so both the tool and skill
-    // buckets are stable. (Centralizes #63, which originally fixed only the tool
-    // path in ToolRegistry::search.)
-    let doc_count = pairs.len();
-    let engine = SearchEngineBuilder::<String>::with_documents(
-        Language::English,
-        pairs
+
+    /// Top-`top_k` matches as `(id, score)`, best-first with ties broken by
+    /// `id` so the result is deterministic across processes.
+    pub(crate) fn search(&self, query: &str, top_k: usize) -> Vec<(String, f32)> {
+        let Some(engine) = &self.engine else {
+            return Vec::new();
+        };
+        // Rank against the full corpus, then truncate — never let the engine
+        // cut to `top_k` itself. The bm25 crate sorts by score alone and
+        // collects candidates through a HashSet, so equal scores fall back to
+        // hash-seed iteration order and flip between processes; a tie
+        // straddling the `top_k` boundary would make top-K *membership*
+        // nondeterministic. We rank everything, break ties by id, then cut —
+        // so both the tool and skill buckets are stable. (Centralizes #63,
+        // which originally fixed only the tool path in ToolRegistry::search.)
+        let mut ranked: Vec<(String, f32)> = engine
+            .search(query, self.doc_count)
             .into_iter()
-            .map(|(id, contents)| Document { id, contents }),
-    )
-    .k1(BM25_K1)
-    .b(BM25_B)
-    .build();
-    let mut ranked: Vec<(String, f32)> = engine
-        .search(query, doc_count)
-        .into_iter()
-        .map(|r| (r.document.id, r.score))
-        .collect();
-    ranked.sort_by(|a, b| {
-        b.1.partial_cmp(&a.1)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| a.0.cmp(&b.0))
-    });
-    ranked.truncate(top_k);
-    ranked
+            .map(|r| (r.document.id, r.score))
+            .collect();
+        ranked.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.cmp(&b.0))
+        });
+        ranked.truncate(top_k);
+        ranked
+    }
+}
+
+/// Dirty-flag holder for a registry's [`Bm25Index`]: `get_or_build` returns
+/// the cached index or builds it from the caller's corpus snapshot, and every
+/// corpus mutation calls [`Self::invalidate`] so the next search rebuilds.
+/// Interior mutability (the [`DenseCache`] precedent) because searches take
+/// `&self`; the `Arc` lets a search rank outside the lock, so a concurrent
+/// invalidate never blocks on (or invalidates out from under) a live query.
+///
+/// [`DenseCache`]: crate::dense_cache::DenseCache
+pub(crate) struct Bm25Cache {
+    index: Mutex<Option<Arc<Bm25Index>>>,
+}
+
+impl Bm25Cache {
+    pub(crate) fn new() -> Self {
+        Self {
+            index: Mutex::new(None),
+        }
+    }
+
+    /// The cached index, or the one built from `docs()` and cached. `docs` is
+    /// only called on a cache miss — the first search after construction or
+    /// [`Self::invalidate`].
+    ///
+    /// The corpus snapshot runs under the lock: registries mutate through
+    /// `&mut self`, so no mutation can interleave, and concurrent first
+    /// searches build once instead of racing.
+    pub(crate) fn get_or_build<I>(&self, docs: impl FnOnce() -> I) -> Arc<Bm25Index>
+    where
+        I: IntoIterator<Item = (String, String)>,
+    {
+        let mut slot = self.index.lock().unwrap_or_else(PoisonError::into_inner);
+        match &*slot {
+            Some(index) => Arc::clone(index),
+            None => {
+                let index = Arc::new(Bm25Index::build(docs()));
+                *slot = Some(Arc::clone(&index));
+                index
+            }
+        }
+    }
+
+    /// Drop the cached index; the next [`Self::get_or_build`] rebuilds from
+    /// the then-current corpus. Called by every registry mutation.
+    pub(crate) fn invalidate(&self) {
+        *self.index.lock().unwrap_or_else(PoisonError::into_inner) = None;
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// The reference ranking: a fresh index built for exactly this query —
+    /// what the historical build-per-search path computed. Reused/cached
+    /// indexes must match it byte-for-byte.
+    fn fresh_search(docs: Vec<(String, String)>, query: &str, top_k: usize) -> Vec<(String, f32)> {
+        Bm25Index::build(docs).search(query, top_k)
+    }
+
+    fn tie_corpus() -> Vec<(String, String)> {
+        vec![
+            (
+                "zeta".to_string(),
+                "send a notification message".to_string(),
+            ),
+            (
+                "alpha".to_string(),
+                "send a notification message".to_string(),
+            ),
+            ("mid".to_string(), "send a notification message".to_string()),
+            (
+                "reader".to_string(),
+                "read a file from disk with an absolute path".to_string(),
+            ),
+        ]
+    }
+
     #[test]
-    fn empty_docs_yield_no_hits() {
-        let hits = bm25_search(Vec::<(String, String)>::new(), "anything", 5);
-        assert!(hits.is_empty());
+    fn empty_index_yields_no_hits() {
+        let index = Bm25Index::build(Vec::new());
+        assert!(index.search("anything", 5).is_empty());
     }
 
     #[test]
@@ -70,25 +173,90 @@ mod tests {
                 "write bytes to a network socket".to_string(),
             ),
         ];
-        let hits = bm25_search(docs, "read file", 5);
+        let hits = fresh_search(docs, "read file", 5);
         assert_eq!(hits.first().map(|(id, _)| id.as_str()), Some("read"));
     }
 
     #[test]
     fn respects_top_k() {
-        let docs = (0..10).map(|i| (format!("doc{i}"), "shared term content".to_string()));
-        let hits = bm25_search(docs, "shared", 3);
+        let docs: Vec<(String, String)> = (0..10)
+            .map(|i| (format!("doc{i}"), "shared term content".to_string()))
+            .collect();
+        let hits = fresh_search(docs, "shared", 3);
         assert!(hits.len() <= 3);
+    }
+
+    #[test]
+    fn a_reused_index_matches_a_fresh_build_exactly() {
+        // The whole point of caching: querying one prebuilt index must return
+        // exactly what a fresh build for each query would — ids AND f32
+        // scores, including on tied scores.
+        let index = Bm25Index::build(tie_corpus());
+        for query in ["notification message", "read file", "absolute disk path"] {
+            for top_k in [1, 2, 10] {
+                assert_eq!(
+                    index.search(query, top_k),
+                    fresh_search(tie_corpus(), query, top_k),
+                    "query={query} top_k={top_k}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn index_is_reusable_across_queries() {
+        let index = Bm25Index::build(tie_corpus());
+        let first = index.search("notification", 5);
+        let again = index.search("notification", 5);
+        assert_eq!(first, again);
+        // A different query on the same index still matches a fresh build.
+        assert_eq!(
+            index.search("file", 5),
+            fresh_search(tie_corpus(), "file", 5)
+        );
+    }
+
+    #[test]
+    fn cache_builds_once_and_reuses_the_index() {
+        let cache = Bm25Cache::new();
+        let builds = std::cell::Cell::new(0);
+        let build = || {
+            builds.set(builds.get() + 1);
+            tie_corpus()
+        };
+        let first = cache.get_or_build(build);
+        let second = cache.get_or_build(build);
+        assert_eq!(builds.get(), 1, "second get must reuse, not rebuild");
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(
+            first.search("notification", 5),
+            fresh_search(tie_corpus(), "notification", 5)
+        );
+    }
+
+    #[test]
+    fn invalidate_forces_a_rebuild_over_the_new_corpus() {
+        let cache = Bm25Cache::new();
+        let _ = cache.get_or_build(tie_corpus);
+        cache.invalidate();
+        let new_corpus = || vec![("fresh".to_string(), "compact a database table".to_string())];
+        let rebuilt = cache.get_or_build(new_corpus);
+        assert_eq!(
+            rebuilt.search("compact database", 5),
+            fresh_search(new_corpus(), "compact database", 5),
+            "post-invalidate index must reflect only the new corpus"
+        );
+        assert!(rebuilt.search("notification", 5).is_empty());
     }
 
     #[test]
     fn tied_scores_break_by_id_with_stable_top_k_membership() {
         // Identical searchable text → identical scores for any matching query.
         // The bm25 crate collects candidates through a HashSet, so the engine's
-        // own order is hash-seed dependent; bm25_search must impose a stable
-        // (score desc, id asc) order so both the returned order AND which docs
-        // survive the top_k cut are fixed across processes. Shared by the tool
-        // and skill registries — see registry.rs / skill_registry.rs.
+        // own order is hash-seed dependent; Bm25Index::search must impose a
+        // stable (score desc, id asc) order so both the returned order AND
+        // which docs survive the top_k cut are fixed across processes. Shared
+        // by the tool and skill registries.
         let docs = vec![
             (
                 "zeta".to_string(),
@@ -100,7 +268,7 @@ mod tests {
             ),
             ("mid".to_string(), "send a notification message".to_string()),
         ];
-        let hits = bm25_search(docs, "notification message", 2);
+        let hits = fresh_search(docs, "notification message", 2);
         assert_eq!(hits.len(), 2);
         assert_eq!(hits[0].0, "alpha");
         assert_eq!(hits[1].0, "mid");

--- a/src/core/src/search.rs
+++ b/src/core/src/search.rs
@@ -204,19 +204,6 @@ mod tests {
     }
 
     #[test]
-    fn index_is_reusable_across_queries() {
-        let index = Bm25Index::build(tie_corpus());
-        let first = index.search("notification", 5);
-        let again = index.search("notification", 5);
-        assert_eq!(first, again);
-        // A different query on the same index still matches a fresh build.
-        assert_eq!(
-            index.search("file", 5),
-            fresh_search(tie_corpus(), "file", 5)
-        );
-    }
-
-    #[test]
     fn cache_builds_once_and_reuses_the_index() {
         let cache = Bm25Cache::new();
         let builds = std::cell::Cell::new(0);

--- a/src/core/src/skill_registry.rs
+++ b/src/core/src/skill_registry.rs
@@ -906,32 +906,48 @@ mod tests {
         );
     }
 
+    /// A builder that must never run — proof the search path already
+    /// populated the cache (the tool-side twin explains why the public seam
+    /// can't pin this).
+    fn no_build() -> Vec<(String, String)> {
+        unreachable!("cache should already be populated by the search path")
+    }
+
+    /// Rebuild count when the builder IS expected to run — asserts the cache
+    /// was dropped by the preceding mutation.
+    fn assert_rebuilds(reg: &SkillRegistry) -> Arc<crate::search::Bm25Index> {
+        let builds = std::cell::Cell::new(0);
+        let index = reg.bm25.get_or_build(|| {
+            builds.set(builds.get() + 1);
+            reg.bm25_docs()
+        });
+        assert_eq!(builds.get(), 1, "mutation must drop the cached index");
+        index
+    }
+
     #[test]
     fn bm25_cache_is_warmed_by_search_and_dropped_by_every_mutator() {
-        // The cache's lifecycle is invisible at the public seam (results are
-        // byte-identical either way), so pin it here: search populates it,
-        // and both mutators — register and replace_all — drop it.
+        // Lifecycle pin: a public search populates the cache, and both
+        // mutators — register and replace_all — drop it. Results are
+        // byte-identical either way, so only this test fails if the
+        // search→cache wiring regresses to build-per-call.
         let mut reg = catalog();
-        let warmed = reg.bm25.get_or_build(|| reg.bm25_docs());
-        let reused = reg.bm25.get_or_build(|| reg.bm25_docs());
+        let _ = reg.search("REST API design", 5);
+        let warmed = reg.bm25.get_or_build(no_build);
+        let _ = reg.search("presentations", 5);
+        let reused = reg.bm25.get_or_build(no_build);
         assert!(
             Arc::ptr_eq(&warmed, &reused),
             "searches between mutations must reuse one index"
         );
 
         reg.register(skill("extra", "extra", "an extra skill", &[]));
-        let after_register = reg.bm25.get_or_build(|| reg.bm25_docs());
-        assert!(
-            !Arc::ptr_eq(&warmed, &after_register),
-            "register must invalidate the cached index"
-        );
+        let after_register = assert_rebuilds(&reg);
+        assert!(!Arc::ptr_eq(&warmed, &after_register));
 
         reg.replace_all(vec![skill("only", "only", "the only skill", &[])]);
-        let after_replace = reg.bm25.get_or_build(|| reg.bm25_docs());
-        assert!(
-            !Arc::ptr_eq(&after_register, &after_replace),
-            "replace_all must invalidate the cached index"
-        );
+        let after_replace = assert_rebuilds(&reg);
+        assert!(!Arc::ptr_eq(&after_register, &after_replace));
     }
 
     #[test]
@@ -956,10 +972,11 @@ mod tests {
             ]
         };
         let mut reg = catalog();
-        let warmed = reg.bm25.get_or_build(|| reg.bm25_docs());
+        let _ = reg.search("REST API design", 5);
+        let warmed = reg.bm25.get_or_build(no_build);
 
         reg.replace_all(reload());
-        let after_noop = reg.bm25.get_or_build(|| reg.bm25_docs());
+        let after_noop = reg.bm25.get_or_build(no_build);
         assert!(
             Arc::ptr_eq(&warmed, &after_noop),
             "an unchanged reload must keep the cached index"
@@ -968,7 +985,7 @@ mod tests {
         let mut body_edit = reload();
         body_edit[0].body = "rewritten body — not part of searchable_text".into();
         reg.replace_all(body_edit);
-        let after_body_edit = reg.bm25.get_or_build(|| reg.bm25_docs());
+        let after_body_edit = reg.bm25.get_or_build(no_build);
         assert!(
             Arc::ptr_eq(&warmed, &after_body_edit),
             "a body-only edit is not indexed and must keep the cached index"

--- a/src/core/src/skill_registry.rs
+++ b/src/core/src/skill_registry.rs
@@ -8,7 +8,7 @@ use crate::embedding::EmbedderError;
 use crate::embedding_config::EmbeddingModel;
 use crate::fusion::{RETRIEVE_DEPTH, RRF_K, WeightedArm, rrf_fuse_weighted};
 use crate::method::SearchMethod;
-use crate::search::bm25_search;
+use crate::search::Bm25Cache;
 use crate::skill::Skill;
 use crate::skill_indexing::searchable_text;
 use crate::tool_registry::AdaptiveRankingStatus;
@@ -89,6 +89,10 @@ pub struct SkillRegistry {
     /// place, never duplicating it (RAT-378).
     skills: IndexMap<String, Skill>,
     sink: Arc<dyn TraceSink>,
+    /// Prebuilt BM25 index over `skills` — the skill-side twin of
+    /// [`crate::ToolRegistry`]'s field: built lazily by the first search,
+    /// reused until [`Self::register`] or [`Self::replace_all`] invalidates it.
+    bm25: Bm25Cache,
     /// Dense embeddings for `skills`, keyed by id and built on demand — the
     /// skill-side twin of [`crate::ToolRegistry`]'s field (see [`DenseCache`]).
     dense: DenseCache,
@@ -111,6 +115,7 @@ impl SkillRegistry {
         Self {
             skills: IndexMap::new(),
             sink: Arc::new(NoopSink),
+            bm25: Bm25Cache::new(),
             dense: DenseCache::new(),
             graph: None,
         }
@@ -122,6 +127,7 @@ impl SkillRegistry {
         Self {
             skills: IndexMap::new(),
             sink,
+            bm25: Bm25Cache::new(),
             dense: DenseCache::new(),
             graph: None,
         }
@@ -136,6 +142,7 @@ impl SkillRegistry {
         Self {
             skills: IndexMap::new(),
             sink: Arc::new(NoopSink),
+            bm25: Bm25Cache::new(),
             dense: DenseCache::with_model(model),
             graph: None,
         }
@@ -294,6 +301,12 @@ impl SkillRegistry {
             .map(|s| (s.id.clone(), searchable_text(s)))
     }
 
+    /// The prebuilt BM25 index for the current corpus — cached across
+    /// searches, rebuilt on the first search after a mutation.
+    fn bm25_index(&self) -> Arc<crate::search::Bm25Index> {
+        self.bm25.get_or_build(|| self.bm25_docs())
+    }
+
     /// Fuse the ranked arms into the final top-`top_k`, returning the hits and
     /// the `rrf` stage — one implementation for all three engines.
     fn fuse_arms(arms: &[WeightedArm<'_>], top_k: usize) -> (Vec<SkillHit>, SearchStage) {
@@ -325,6 +338,9 @@ impl SkillRegistry {
     /// cached embedding; the corpus never holds a duplicate.
     pub fn register(&mut self, skill: Skill) {
         let skill_id = skill.id.clone();
+        // Add or replace, the corpus changed either way: the prebuilt BM25
+        // index no longer matches it.
+        self.bm25.invalidate();
         if self.skills.insert(skill_id.clone(), skill).is_some() {
             // Replaced an existing id: drop its stale embedding.
             self.dense.invalidate(&skill_id);
@@ -395,10 +411,16 @@ impl SkillRegistry {
         }
 
         let mut outcome = ReplaceOutcome::default();
+        // Whether any id's *indexed* text changed. Only then does the prebuilt
+        // BM25 index go stale — the same diff the dense cache keys on, so a
+        // reload of an unchanged catalog (or one that only edited bodies)
+        // keeps both caches and the next search rebuilds nothing.
+        let mut indexed_text_changed = false;
 
         for id in self.skills.keys() {
             if !next.contains_key(id) {
                 self.dense.invalidate(id);
+                indexed_text_changed = true;
                 self.sink.record(TraceEvent::SkillChurn {
                     kind: ChurnKind::Remove,
                     skill_id: id.clone(),
@@ -416,10 +438,14 @@ impl SkillRegistry {
                 Some(current) => {
                     if searchable_text(current) != searchable_text(skill) {
                         self.dense.invalidate(id);
+                        indexed_text_changed = true;
                     }
                     outcome.updated += 1;
                 }
-                None => outcome.added += 1,
+                None => {
+                    indexed_text_changed = true;
+                    outcome.added += 1;
+                }
             }
             self.sink.record(TraceEvent::SkillChurn {
                 kind: ChurnKind::Add,
@@ -427,6 +453,9 @@ impl SkillRegistry {
             });
         }
 
+        if indexed_text_changed {
+            self.bm25.invalidate();
+        }
         self.skills = next;
         outcome
     }
@@ -532,7 +561,7 @@ impl SkillRegistry {
             // No graph, or nothing matched: the original path with raw BM25
             // scores, unchanged.
             // Raw BM25 scores — not fused.
-            let hits = to_skill_hits(bm25_search(self.bm25_docs(), query, top_k), false);
+            let hits = to_skill_hits(self.bm25_index().search(query, top_k), false);
             let took_ms = started.elapsed().as_millis() as u64;
             let top_score = hits.first().map(|h| h.score as f64);
             self.record_search(
@@ -552,7 +581,7 @@ impl SkillRegistry {
 
         let depth = RETRIEVE_DEPTH.max(top_k);
         let t = Instant::now();
-        let bm25_ranked = bm25_search(self.bm25_docs(), query, depth);
+        let bm25_ranked = self.bm25_index().search(query, depth);
         let bm25_stage = SearchStage {
             name: "bm25".into(),
             took_ms: t.elapsed().as_millis() as u64,
@@ -664,13 +693,7 @@ impl SkillRegistry {
         let depth = RETRIEVE_DEPTH.max(top_k);
 
         let t = Instant::now();
-        let bm25_ranked = bm25_search(
-            self.skills
-                .values()
-                .map(|s| (s.id.clone(), searchable_text(s))),
-            query,
-            depth,
-        );
+        let bm25_ranked = self.bm25_index().search(query, depth);
         let bm25_stage = SearchStage {
             name: "bm25".into(),
             took_ms: t.elapsed().as_millis() as u64,
@@ -798,6 +821,7 @@ mod tests {
         SkillRegistry {
             skills: IndexMap::new(),
             sink: Arc::new(NoopSink),
+            bm25: Bm25Cache::new(),
             dense: DenseCache::with_embedder(embedder),
             graph: None,
         }
@@ -830,6 +854,125 @@ mod tests {
             &["backend", "api"],
         ));
         reg
+    }
+
+    #[test]
+    fn mutation_after_a_warmed_search_is_visible_in_the_next_search() {
+        // Same staleness guard as the tool-side integration test: searches
+        // must not pin ranking state across register or replace_all.
+        let mut reg = catalog();
+        for _ in 0..3 {
+            let _ = reg.search("REST API design", 5);
+        }
+
+        reg.register(skill(
+            "migrations",
+            "migrations",
+            "Write reversible database migrations",
+            &["backend"],
+        ));
+        assert_eq!(
+            reg.search("reversible database migrations", 5)[0].skill_id,
+            "migrations",
+            "a skill registered after searches must rank immediately"
+        );
+
+        // replace_all drops one skill and rewrites another; both must be
+        // visible in the next search.
+        let _ = reg.search("presentations", 5); // re-warm
+        reg.replace_all(vec![
+            skill(
+                "api-design",
+                "api-design",
+                "GraphQL schema federation",
+                &["backend"],
+            ),
+            skill(
+                "migrations",
+                "migrations",
+                "Write reversible database migrations",
+                &["backend"],
+            ),
+        ]);
+        assert!(
+            reg.search("animation-rich HTML presentations", 5)
+                .is_empty(),
+            "a skill removed by replace_all must stop matching immediately"
+        );
+        assert_eq!(
+            reg.search("GraphQL schema federation", 5)[0].skill_id,
+            "api-design",
+            "content rewritten by replace_all must match immediately"
+        );
+    }
+
+    #[test]
+    fn bm25_cache_is_warmed_by_search_and_dropped_by_every_mutator() {
+        // The cache's lifecycle is invisible at the public seam (results are
+        // byte-identical either way), so pin it here: search populates it,
+        // and both mutators — register and replace_all — drop it.
+        let mut reg = catalog();
+        let warmed = reg.bm25.get_or_build(|| reg.bm25_docs());
+        let reused = reg.bm25.get_or_build(|| reg.bm25_docs());
+        assert!(
+            Arc::ptr_eq(&warmed, &reused),
+            "searches between mutations must reuse one index"
+        );
+
+        reg.register(skill("extra", "extra", "an extra skill", &[]));
+        let after_register = reg.bm25.get_or_build(|| reg.bm25_docs());
+        assert!(
+            !Arc::ptr_eq(&warmed, &after_register),
+            "register must invalidate the cached index"
+        );
+
+        reg.replace_all(vec![skill("only", "only", "the only skill", &[])]);
+        let after_replace = reg.bm25.get_or_build(|| reg.bm25_docs());
+        assert!(
+            !Arc::ptr_eq(&after_register, &after_replace),
+            "replace_all must invalidate the cached index"
+        );
+    }
+
+    #[test]
+    fn an_unchanged_replace_all_keeps_the_cached_bm25_index() {
+        // The periodic-source steady state: a reload that changes nothing (or
+        // only un-indexed fields like `body`) must not throw the index away —
+        // same diff the dense cache keys on.
+        let reload = || {
+            vec![
+                skill(
+                    "frontend-slides",
+                    "frontend-slides",
+                    "Build animation-rich HTML presentations from scratch",
+                    &["frontend", "presentations"],
+                ),
+                skill(
+                    "api-design",
+                    "api-design",
+                    "REST API design patterns: resource naming, status codes, pagination",
+                    &["backend", "api"],
+                ),
+            ]
+        };
+        let mut reg = catalog();
+        let warmed = reg.bm25.get_or_build(|| reg.bm25_docs());
+
+        reg.replace_all(reload());
+        let after_noop = reg.bm25.get_or_build(|| reg.bm25_docs());
+        assert!(
+            Arc::ptr_eq(&warmed, &after_noop),
+            "an unchanged reload must keep the cached index"
+        );
+
+        let mut body_edit = reload();
+        body_edit[0].body = "rewritten body — not part of searchable_text".into();
+        reg.replace_all(body_edit);
+        let after_body_edit = reg.bm25.get_or_build(|| reg.bm25_docs());
+        assert!(
+            Arc::ptr_eq(&warmed, &after_body_edit),
+            "a body-only edit is not indexed and must keep the cached index"
+        );
     }
 
     #[test]

--- a/src/core/src/tool_registry.rs
+++ b/src/core/src/tool_registry.rs
@@ -9,7 +9,7 @@ use crate::embedding_config::EmbeddingModel;
 use crate::fusion::{RETRIEVE_DEPTH, RRF_K, WeightedArm, rrf_fuse_weighted};
 use crate::indexing::searchable_text;
 use crate::method::SearchMethod;
-use crate::search::bm25_search;
+use crate::search::Bm25Cache;
 use crate::tool::Tool;
 use crate::trace::{
     ChurnKind, NoopSink, Origin, SearchHitTrace, SearchStage, TraceEvent, TraceSink,
@@ -125,6 +125,12 @@ pub struct ToolRegistry {
     /// stays one-entry-per-id — no `avgdl` drift, no leak (RAT-378).
     tools: IndexMap<String, Tool>,
     sink: Arc<dyn TraceSink>,
+    /// Prebuilt BM25 index over `tools`, built lazily by the first search and
+    /// reused until [`Self::register`] invalidates it — a rebuild costs a full
+    /// corpus tokenization (~100x one query), so it happens once per corpus
+    /// state instead of once per search. Scores are byte-identical to a fresh
+    /// build (ADR-0011).
+    bm25: Bm25Cache,
     /// Dense embeddings for `tools`, keyed by id and built on demand. `register`
     /// invalidates a replaced id; the missing ids are embedded by
     /// [`Self::build_embeddings`] — a search never embeds the corpus (it requires
@@ -151,6 +157,7 @@ impl ToolRegistry {
         Self {
             tools: IndexMap::new(),
             sink: Arc::new(NoopSink),
+            bm25: Bm25Cache::new(),
             dense: DenseCache::new(),
             graph: None,
         }
@@ -161,6 +168,7 @@ impl ToolRegistry {
         Self {
             tools: IndexMap::new(),
             sink,
+            bm25: Bm25Cache::new(),
             dense: DenseCache::new(),
             graph: None,
         }
@@ -175,6 +183,7 @@ impl ToolRegistry {
         Self {
             tools: IndexMap::new(),
             sink: Arc::new(NoopSink),
+            bm25: Bm25Cache::new(),
             dense: DenseCache::with_model(model),
             graph: None,
         }
@@ -393,6 +402,9 @@ impl ToolRegistry {
     /// ```
     pub fn register(&mut self, tool: Tool) {
         let tool_id = tool.id.clone();
+        // Add or replace, the corpus changed either way: the prebuilt BM25
+        // index no longer matches it.
+        self.bm25.invalidate();
         if self.tools.insert(tool_id.clone(), tool).is_some() {
             // Replaced an existing id: drop its stale embedding.
             self.dense.invalidate(&tool_id);
@@ -538,6 +550,12 @@ impl ToolRegistry {
             .map(|t| (t.id.clone(), searchable_text(t)))
     }
 
+    /// The prebuilt BM25 index for the current corpus — cached across
+    /// searches, rebuilt on the first search after a [`Self::register`].
+    fn bm25_index(&self) -> Arc<crate::search::Bm25Index> {
+        self.bm25.get_or_build(|| self.bm25_docs())
+    }
+
     /// Fuse the ranked arms into the final top-`top_k`, returning the hits and
     /// the `rrf` stage. Shared by all three engines so the fusion, truncation,
     /// and `(score desc, id asc)` ordering have exactly one implementation.
@@ -576,7 +594,7 @@ impl ToolRegistry {
             // No graph, or nothing matched: the original path, unchanged, with
             // raw BM25 scores. ADR-0011's byte-for-byte promise lives here.
             // Raw BM25 scores — not fused.
-            let hits = to_search_hits(bm25_search(self.bm25_docs(), query, top_k), false);
+            let hits = to_search_hits(self.bm25_index().search(query, top_k), false);
             let took_ms = started.elapsed().as_millis() as u64;
             let top_score = hits.first().map(|h| h.score as f64);
             self.record_search(
@@ -599,7 +617,7 @@ impl ToolRegistry {
         // scores — the opt-in cost documented on `set_intent_graph`.
         let depth = RETRIEVE_DEPTH.max(top_k);
         let t = Instant::now();
-        let bm25_ranked = bm25_search(self.bm25_docs(), query, depth);
+        let bm25_ranked = self.bm25_index().search(query, depth);
         let bm25_stage = SearchStage {
             name: "bm25".into(),
             took_ms: t.elapsed().as_millis() as u64,
@@ -717,13 +735,7 @@ impl ToolRegistry {
 
         // 1. BM25 (lexical).
         let t = Instant::now();
-        let bm25_ranked = bm25_search(
-            self.tools
-                .values()
-                .map(|t| (t.id.clone(), searchable_text(t))),
-            query,
-            depth,
-        );
+        let bm25_ranked = self.bm25_index().search(query, depth);
         let bm25_stage = SearchStage {
             name: "bm25".into(),
             took_ms: t.elapsed().as_millis() as u64,
@@ -884,6 +896,7 @@ mod tests {
         ToolRegistry {
             tools: IndexMap::new(),
             sink: Arc::new(NoopSink),
+            bm25: Bm25Cache::new(),
             dense: DenseCache::with_embedder(embedder),
             graph: None,
         }
@@ -904,6 +917,29 @@ mod tests {
         reg.register(tool("read_file", "read a file"));
         reg.register(tool("delete_file", "delete a file"));
         reg
+    }
+
+    #[test]
+    fn bm25_cache_is_warmed_by_search_and_dropped_by_register() {
+        // Lifecycle pin (see the skill-side twin): search populates the cache,
+        // register — the sole corpus mutator — drops it. Results being
+        // byte-identical either way is pinned at the public seam in
+        // tests/tool_search.rs.
+        let mut reg = ToolRegistry::new();
+        reg.register(tool("read_file", "read a file"));
+        let warmed = reg.bm25.get_or_build(|| reg.bm25_docs());
+        let reused = reg.bm25.get_or_build(|| reg.bm25_docs());
+        assert!(
+            Arc::ptr_eq(&warmed, &reused),
+            "searches between mutations must reuse one index"
+        );
+
+        reg.register(tool("delete_file", "delete a file"));
+        let after_register = reg.bm25.get_or_build(|| reg.bm25_docs());
+        assert!(
+            !Arc::ptr_eq(&warmed, &after_register),
+            "register must invalidate the cached index"
+        );
     }
 
     #[test]

--- a/src/core/src/tool_registry.rs
+++ b/src/core/src/tool_registry.rs
@@ -919,27 +919,41 @@ mod tests {
         reg
     }
 
+    /// A builder that must never run — proof the search path already
+    /// populated the cache, i.e. the registry actually consults `Bm25Cache`
+    /// instead of rebuilding per call (the regression this cache exists to
+    /// prevent).
+    fn no_build() -> Vec<(String, String)> {
+        unreachable!("cache should already be populated by the search path")
+    }
+
     #[test]
     fn bm25_cache_is_warmed_by_search_and_dropped_by_register() {
-        // Lifecycle pin (see the skill-side twin): search populates the cache,
-        // register — the sole corpus mutator — drops it. Results being
-        // byte-identical either way is pinned at the public seam in
-        // tests/tool_search.rs.
+        // Lifecycle pin (see the skill-side twin): a public search populates
+        // the cache, register — the sole corpus mutator — drops it. Results
+        // are byte-identical either way (pinned in tests/tool_search.rs), so
+        // a per-call rebuild would pass every test there; this is the one
+        // that fails if the search→cache wiring regresses.
         let mut reg = ToolRegistry::new();
         reg.register(tool("read_file", "read a file"));
-        let warmed = reg.bm25.get_or_build(|| reg.bm25_docs());
-        let reused = reg.bm25.get_or_build(|| reg.bm25_docs());
+
+        let _ = reg.search("read", 5);
+        let warmed = reg.bm25.get_or_build(no_build);
+        let _ = reg.search("file", 5);
+        let reused = reg.bm25.get_or_build(no_build);
         assert!(
             Arc::ptr_eq(&warmed, &reused),
             "searches between mutations must reuse one index"
         );
 
         reg.register(tool("delete_file", "delete a file"));
-        let after_register = reg.bm25.get_or_build(|| reg.bm25_docs());
-        assert!(
-            !Arc::ptr_eq(&warmed, &after_register),
-            "register must invalidate the cached index"
-        );
+        let builds = std::cell::Cell::new(0);
+        let rebuilt = reg.bm25.get_or_build(|| {
+            builds.set(builds.get() + 1);
+            reg.bm25_docs()
+        });
+        assert_eq!(builds.get(), 1, "register must drop the cached index");
+        assert!(!Arc::ptr_eq(&warmed, &rebuilt));
     }
 
     #[test]

--- a/src/core/tests/tool_search.rs
+++ b/src/core/tests/tool_search.rs
@@ -136,6 +136,92 @@ fn re_register_keeps_corpus_size_stable() {
 }
 
 #[test]
+fn mutation_after_a_warmed_search_is_visible_in_the_next_search() {
+    // Searches before a register must not leave any stale ranking state
+    // behind: whatever the engine reuses across searches, a mutation is
+    // visible in the very next call.
+    let tool = |id: &str, desc: &str| Tool {
+        id: id.into(),
+        name: id.into(),
+        description: desc.into(),
+        input_schema: empty_schema(),
+        output_schema: empty_schema(),
+    };
+
+    let mut registry = ToolRegistry::new();
+    registry.register(tool("read", "read a file from disk"));
+    registry.register(tool("write", "write bytes to a socket"));
+    // Warm: several searches before the mutation.
+    for _ in 0..3 {
+        let _ = registry.search("read a file", 5);
+    }
+
+    registry.register(tool("archive", "compress a directory into an archive"));
+    assert_eq!(
+        registry.search("compress an archive", 5)[0].tool_id,
+        "archive",
+        "a tool registered after searches must rank immediately"
+    );
+
+    registry.register(tool("read", "stream sensor telemetry"));
+    // Query on the OLD description only ("read" would still match the name).
+    assert!(
+        registry.search("file disk", 5).is_empty(),
+        "replaced content must stop matching immediately"
+    );
+    assert_eq!(
+        registry.search("stream sensor telemetry", 5)[0].tool_id,
+        "read"
+    );
+}
+
+#[test]
+fn warmed_registry_hits_are_byte_identical_to_a_fresh_registry() {
+    // ADR-0011 pins BM25 behavior byte-for-byte: a registry that has already
+    // searched and mutated must score exactly like a fresh one holding the
+    // same final corpus — ids, order, AND f32 scores.
+    let tool = |id: &str, desc: &str| Tool {
+        id: id.into(),
+        name: id.into(),
+        description: desc.into(),
+        input_schema: empty_schema(),
+        output_schema: empty_schema(),
+    };
+    let corpus = [
+        ("read", "read a file from disk"),
+        ("write", "write bytes to a socket"),
+        ("archive", "compress a directory into an archive"),
+    ];
+
+    let mut warmed = ToolRegistry::new();
+    warmed.register(tool("read", "an obsolete description"));
+    warmed.register(tool("write", corpus[1].1));
+    let _ = warmed.search("file", 5); // warm before the corpus settles
+    warmed.register(tool(corpus[0].0, corpus[0].1)); // replace in place
+    warmed.register(tool(corpus[2].0, corpus[2].1));
+    let _ = warmed.search("socket", 5); // warm again on the final corpus
+
+    let mut fresh = ToolRegistry::new();
+    for (id, desc) in corpus {
+        fresh.register(tool(id, desc));
+    }
+
+    for query in ["read a file", "compress the directory", "write bytes"] {
+        let warmed_hits: Vec<(String, f32)> = warmed
+            .search(query, 5)
+            .into_iter()
+            .map(|h| (h.tool_id, h.score))
+            .collect();
+        let fresh_hits: Vec<(String, f32)> = fresh
+            .search(query, 5)
+            .into_iter()
+            .map(|h| (h.tool_id, h.score))
+            .collect();
+        assert_eq!(warmed_hits, fresh_hits, "query={query}");
+    }
+}
+
+#[test]
 fn search_ranks_stronger_match_above_weaker() {
     let mut registry = ToolRegistry::new();
     registry.register(Tool {


### PR DESCRIPTION
## Problem

User feedback: BM25 + embeddings indexing causes CPU spikes even with a remote embeddings endpoint. Root cause on the BM25 side: every search rebuilt the whole engine — `bm25_search` tokenized + stemmed the full corpus twice per call (bm25 crate fit pass + embed pass), and `bm25_docs()` re-derived `searchable_text` (JSON-schema walk + clones) for every item on every search. Fires 2-6x per agent turn (capabilities search = tools + skills buckets; hybrid pays the BM25 arm on top of dense).

## Fix

Index once per **catalog state**, not per search:

- `Bm25Index`: build/query split of the old one-shot path. Build = full-corpus tokenize + index; query = tokenize query + score candidates.
- `Bm25Cache`: `Mutex<Option<Arc<Bm25Index>>>` dirty-flag holder (DenseCache precedent). First search after a mutation rebuilds via the same full-corpus code path; later searches reuse. Searches rank outside the lock.
- Invalidated by the three corpus mutators: `ToolRegistry::register`, `SkillRegistry::register`, `SkillRegistry::replace_all`. `replace_all` keeps the index when no *indexed* text changed (unchanged or body-only reloads) — same diff the dense cache keys on.
- Hybrid arms reuse the cached index (previously inlined a second `searchable_text` derivation).
- Deliberately no incremental `upsert`: the crate freezes `avgdl` at fit time, upserted scores drift vs a fresh build. Full rebuild-on-dirty keeps scores byte-for-byte (ADR-0011).

## Numbers

1,000 tools, 50 searches, release build, same machine:

| | first search | each warm search | 50 searches total |
|---|---|---|---|
| main | 24.8ms | 25.4ms | 1.27s |
| this PR | 20.4ms (build) | 262µs | 13ms |

~97x on warm searches; the one-time build cost is unchanged.

## Determinism

Scores stay byte-identical: every rebuild is a full-corpus build with the same k1/b, same rank-all-then-truncate, same `(score desc, id asc)` tie-break; corpus stats (avgdl/IDF) don't depend on iteration order. Pinned by `warmed_registry_hits_are_byte_identical_to_a_fresh_registry` (ids AND f32 scores) and the existing tie-break tests. ADR-0011/0014 amended in place for the `bm25_search` → `Bm25Index::search` rename.

## Tests

TDD throughout (red → green per cycle). Mutation-verified: reverting the search paths to build-per-call fails `bm25_cache_is_warmed_by_search_and_dropped_by_register` and the skill-side twin — the tests warm via public `search()` and assert the builder never re-runs, so the wiring can't silently regress. Staleness guards: register/replace_all after warmed searches must be visible in the immediately following search; unchanged/body-only `replace_all` must keep the cached index.

`cargo test --workspace`, `clippy --all-targets -D warnings`, `fmt --check` all green.