### PR TITLE
fix(ci): restore main and install verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       protocol: ${{ steps.f.outputs.protocol }}
       release: ${{ steps.f.outputs.release }}
     steps:
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: f
         with:

--- a/.github/workflows/verify-install.yml
+++ b/.github/workflows/verify-install.yml
@@ -103,8 +103,8 @@ jobs:
           REQUESTED_UNIT: ${{ inputs.unit }}
           REQUESTED_VERSION: ${{ inputs.version }}
           REQUESTED_TAG: ${{ inputs.tag || 'latest' }}
-        # vercel-ai-sdk is GA (0.1.0 on `latest`): the cron verifies `latest`.
-        # A caller can pin a version or select the `rc` tag explicitly.
+        # The cron verifies `latest`. A caller can pin a version or select the
+        # `rc` tag explicitly.
         run: |
           set -euo pipefail
           case "$REQUESTED_TAG" in
@@ -123,16 +123,7 @@ jobs:
           else
             adapter_spec="$REQUESTED_TAG"
           fi
-          # Pull the SDK from the channel that MATCHES the adapter: a GA adapter
-          # peers on a GA SDK, which the `rc` SDK dist-tag would not satisfy →
-          # ERESOLVE. An rc adapter pairs with the rc SDK.
-          if [[ "$adapter_spec" == "rc" || "$adapter_spec" == *-rc.* ]]; then
-            sdk_spec="rc"
-          else
-            sdk_spec="latest"
-          fi
           printf 'adapter_spec=%s\n' "$adapter_spec" >> "$GITHUB_OUTPUT"
-          printf 'sdk_spec=%s\n' "$sdk_spec" >> "$GITHUB_OUTPUT"
       - name: Install + smoke-test the published adapter
         shell: bash
         run: |
@@ -140,8 +131,9 @@ jobs:
           tmp=$(mktemp -d)
           cd "$tmp"
           npm init -y >/dev/null
+          # npm installs the adapter's declared SDK peer. Do not force SDK
+          # `latest`: adapters and the SDK are independent release units.
           npm install --no-audit --no-fund \
-            "@ratel-ai/sdk@${{ steps.ver.outputs.sdk_spec }}" \
             "@ratel-ai/vercel-ai-sdk@${{ steps.ver.outputs.adapter_spec }}" \
             "ai@^7.0.0"
           node --input-type=module <<'EOF'
@@ -210,16 +202,7 @@ jobs:
           else
             adapter_spec="$REQUESTED_TAG"
           fi
-          # Pull the SDK from the channel that MATCHES the adapter: GA mastra peers
-          # on a GA SDK (^0.6.0), which the `rc` SDK dist-tag would not satisfy →
-          # ERESOLVE. An rc adapter pairs with the rc SDK.
-          if [[ "$adapter_spec" == "rc" || "$adapter_spec" == *-rc.* ]]; then
-            sdk_spec="rc"
-          else
-            sdk_spec="latest"
-          fi
           printf 'adapter_spec=%s\n' "$adapter_spec" >> "$GITHUB_OUTPUT"
-          printf 'sdk_spec=%s\n' "$sdk_spec" >> "$GITHUB_OUTPUT"
       - name: Install + smoke-test the published adapter
         shell: bash
         # Installs the adapter against @ratel-ai/sdk plus its @mastra/core peer, then
@@ -230,8 +213,9 @@ jobs:
           tmp=$(mktemp -d)
           cd "$tmp"
           npm init -y >/dev/null
+          # npm installs the adapter's declared SDK peer. Do not force SDK
+          # `latest`: adapters and the SDK are independent release units.
           npm install --no-audit --no-fund \
-            "@ratel-ai/sdk@${{ steps.ver.outputs.sdk_spec }}" \
             "@ratel-ai/mastra@${{ steps.ver.outputs.adapter_spec }}" \
             "@mastra/core@^1.11.0" \
             "zod@^4.0.0"

--- a/scripts/workflow-contracts.test.mjs
+++ b/scripts/workflow-contracts.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const ciWorkflow = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
+const verifyInstallWorkflow = readFileSync(
+  new URL("../.github/workflows/verify-install.yml", import.meta.url),
+  "utf8",
+);
+
+test("main push path filtering checks out the repository first", () => {
+  const changesJob = jobBody(ciWorkflow, "changes");
+  const checkout = changesJob.indexOf("uses: actions/checkout@");
+  const pathsFilter = changesJob.indexOf("uses: dorny/paths-filter@");
+
+  assert.notEqual(checkout, -1, "changes job must check out the repository");
+  assert.ok(checkout < pathsFilter, "checkout must run before paths-filter");
+});
+
+for (const job of ["verify-vercel-ai-sdk", "verify-mastra"]) {
+  test(`${job} lets npm resolve the adapter's declared SDK peer`, () => {
+    const body = jobBody(verifyInstallWorkflow, job);
+
+    assert.doesNotMatch(body, /"@ratel-ai\/sdk@\$\{\{/);
+  });
+}
+
+function jobBody(workflow, job) {
+  const start = workflow.indexOf(`\n  ${job}:`);
+  assert.notEqual(start, -1, `missing ${job} job`);
+
+  const rest = workflow.slice(start + 1);
+  const nextJob = rest.slice(1).search(/^  [a-z][a-z0-9-]*:\s*$/m);
+  return nextJob === -1 ? rest : rest.slice(0, nextJob + 1);
+}


### PR DESCRIPTION
Restores main push CI by checking out the repository before `paths-filter` runs.
Updates published adapter smoke tests to let npm resolve each adapter's declared SDK peer instead of forcing an incompatible SDK `latest`.
Adds workflow contract regression tests for both failure modes.
Verified with all 32 script tests, clean npm registry smoke tests for both adapters, YAML parsing, and `git diff --check`.
