### PR TITLE
feat: runtime events lane — core stream + TS/Python SDK seams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,6 +1703,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "tokenizers",
+ "ulid",
  "ureq",
 ]
 
@@ -2293,6 +2294,16 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand",
+ "web-time",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/docs/adr/0003-catalog-source-interface.md
+++ b/docs/adr/0003-catalog-source-interface.md
@@ -11,7 +11,7 @@ auth and scope), and ADR-0021 (sync and storage), all 2026-07-05. The scope mode
 originally carried is split out to [ADR-0010](0010-catalog-scope-model.md) (Proposed); the
 loader interface, auth, and sync semantics recorded here are accepted.
 
-Amended 2026-08-13 by [ADR-0019](0019-runtime-events-lane.md) to distinguish catalog-source
+Amended 2026-08-13 by [ADR-0020](0020-runtime-events-lane.md) to distinguish catalog-source
 pull from optional upward runtime facts and source-scoped catalog snapshot publication.
 
 ## Context
@@ -95,7 +95,7 @@ explicit decision; `@ratel-ai/cloud` is also the developer's tap into those.
   (`{id, name, description, tags, tools, metadata, body}`, sorted by id, timestamps excluded)
   is frozen in `protocol/v1`; changing it is a v2.
 - A running agent is a read-only consumer of the catalog-source contract. The separate upward
-  path in [ADR-0019](0019-runtime-events-lane.md) publishes append-only observations plus an
+  path in [ADR-0020](0020-runtime-events-lane.md) publishes append-only observations plus an
   atomic snapshot of the SDK's current definitions; it is not authoring/CRUD, a delta merge, or
   a write back into the source. General authoring remains deferred (PSKS-8).
 - Secrets-never-sync is enforced **structurally in both directions**: neither the source wire
@@ -131,7 +131,7 @@ explicit decision; `@ratel-ai/cloud` is also the developer's tap into those.
 - **Private cloud API, no `protocol/`:** forecloses future sources; the published contract is
   the insurance policy for the catalog rung.
 - **Bidirectional catalog sync:** still rejected because it adds offline merge and secret-leak
-  classes. [ADR-0019](0019-runtime-events-lane.md)'s upward path is deliberately not its
+  classes. [ADR-0020](0020-runtime-events-lane.md)'s upward path is deliberately not its
   inverse: facts are append-only and snapshots atomically publish observed, secret-free state
   per source; neither mutates the catalog source or merges offline edits.
 - **KDF-hashed keys / mTLS:** adds weight where a 192-bit random token needs none; a lost

--- a/docs/adr/0003-catalog-source-interface.md
+++ b/docs/adr/0003-catalog-source-interface.md
@@ -11,6 +11,9 @@ auth and scope), and ADR-0021 (sync and storage), all 2026-07-05. The scope mode
 originally carried is split out to [ADR-0010](0010-catalog-scope-model.md) (Proposed); the
 loader interface, auth, and sync semantics recorded here are accepted.
 
+Amended 2026-08-13 by [ADR-0019](0019-runtime-events-lane.md) to distinguish catalog-source
+pull from optional upward runtime facts and source-scoped catalog snapshot publication.
+
 ## Context
 
 An earlier plan scheduled a standalone `ratel-ai-server` binary as the rung between the
@@ -83,16 +86,22 @@ explicit decision; `@ratel-ai/cloud` is also the developer's tap into those.
 | Data class | Source of truth | Syncs? | Owner |
 |---|---|---|---|
 | **Catalog** (skill definitions) | the source when `RATEL_URL` is set, else local disk | yes: one-directional pull, ETag-gated | cloud / file loader / future self-hosted source |
+| **Runtime facts** | the running SDK | yes: optional append-only publication | application / Cloud adapter |
+| **Published catalog snapshot** | the running SDK registries | yes: optional source-scoped full replacement | application / Cloud adapter |
 | **Secrets** (upstream OAuth, source keys) | local machine / the source, always | **never** | ratel-local (oauth); the source (its keys, hash-only) |
 | **Config / host-wiring** | local machine, always | **never** | ratel-local, unchanged |
 
-- Sync is conditional-GET, not a delta protocol. The ETag content projection
+- Catalog-source pull is conditional-GET, not a delta protocol. The ETag content projection
   (`{id, name, description, tags, tools, metadata, body}`, sorted by id, timestamps excluded)
   is frozen in `protocol/v1`; changing it is a v2.
-- A running agent is a read-only catalog consumer. Authoring is a separate authenticated
-  write path, deferred (PSKS-8, internal tracker), so there is no offline-write/merge class.
-- Secrets-never-sync is enforced **structurally**: no wire shape has a field that can carry a
-  token, and a test fails if a secret-typed field enters a wire payload.
+- A running agent is a read-only consumer of the catalog-source contract. The separate upward
+  path in [ADR-0019](0019-runtime-events-lane.md) publishes append-only observations plus an
+  atomic snapshot of the SDK's current definitions; it is not authoring/CRUD, a delta merge, or
+  a write back into the source. General authoring remains deferred (PSKS-8).
+- Secrets-never-sync is enforced **structurally in both directions**: neither the source wire
+  nor the upward event/snapshot shapes can carry API keys, OAuth tokens, executors, tool
+  arguments/results, or other secret-typed fields. Conformance tests fail if one enters a wire
+  payload.
 - Offline: the client keeps the last-pulled catalog and runs degraded but functional;
   staleness is unbounded and should be surfaced. `RATEL_URL` unset is the permanent offline
   floor. Nothing moves off `~/.ratel/*`: config and oauth stay in ratel-local, so the pivot
@@ -121,8 +130,10 @@ explicit decision; `@ratel-ai/cloud` is also the developer's tap into those.
   the cloud already implements.
 - **Private cloud API, no `protocol/`:** forecloses future sources; the published contract is
   the insurance policy for the catalog rung.
-- **Bidirectional sync:** adds an offline-merge class and an upward path a secret could leak
-  through; authoring is a separate explicit write path instead.
+- **Bidirectional catalog sync:** still rejected because it adds offline merge and secret-leak
+  classes. [ADR-0019](0019-runtime-events-lane.md)'s upward path is deliberately not its
+  inverse: facts are append-only and snapshots atomically publish observed, secret-free state
+  per source; neither mutates the catalog source or merges offline edits.
 - **KDF-hashed keys / mTLS:** adds weight where a 192-bit random token needs none; a lost
   key is rotated, not brute-forced. (The scope-model alternatives — per-subject keys as the
   default, confidential isolation — are weighed in [ADR-0010](0010-catalog-scope-model.md).)

--- a/docs/adr/0007-telemetry-two-streams.md
+++ b/docs/adr/0007-telemetry-two-streams.md
@@ -17,7 +17,7 @@ four capture modes.
 Amended 2026-07-26 to drop the `@ratel-ai/telemetry-otlp` helper, and the TS OTLP config
 resolver with it, now that the TS host owns the OTel provider and its configuration.
 
-Amended 2026-08-13 by [ADR-0019](0019-runtime-events-lane.md): the core stream is now a
+Amended 2026-08-13 by [ADR-0020](0020-runtime-events-lane.md): the core stream is now a
 public subscription seam and may be published as a direct product-facts lane. OTel remains a
 separate, unchanged observability projection.
 
@@ -26,7 +26,7 @@ separate, unchanged observability projection.
 Two telemetry projections exist for different consumers. A core-owned runtime stream feeds the
 offline inspector, statusline / savings reporting, rerankers, suggestion analyzers, and public
 subscribers. An **OTel path** feeds Ratel Cloud and any observability backend the customer
-already runs. [ADR-0019](0019-runtime-events-lane.md) additionally permits an explicit Cloud
+already runs. [ADR-0020](0020-runtime-events-lane.md) additionally permits an explicit Cloud
 adapter to publish the runtime stream as authoritative product facts; that path is not general
 observability.
 The industry standardized the remote payload (OpenTelemetry's `gen_ai.*` semantic
@@ -49,7 +49,7 @@ make Ratel Cloud an island.
   constructing events by literal.
 - **One tagged stream, filtering at the consumer**: rerankers, suggestion analysis, and
   inspection subscribe to different cuts of the same producer; public subscriptions and their
-  delivery bounds are specified by [ADR-0019](0019-runtime-events-lane.md).
+  delivery bounds are specified by [ADR-0020](0020-runtime-events-lane.md).
 - **Query-log semantics, not oplog semantics**: trace events are observations of usage.
   Best-effort, sampleable, lossy on backpressure, loosely ordered, no synchronous durability
   on the hot path (ring buffer, periodic flush). Losing an event is acceptable; corrupting a
@@ -87,7 +87,7 @@ make Ratel Cloud an island.
 
 The runtime stream and OTel stay separate projections of the same operations. The runtime stream
 is offline-first and lossy; OTel remains a host-owned OTLP export with span lifecycle and ambient
-context. [ADR-0019](0019-runtime-events-lane.md) adds shared event ids and an optional direct
+context. [ADR-0020](0020-runtime-events-lane.md) adds shared event ids and an optional direct
 facts publisher, but explicitly does not converge or rebase the OTel producer on the stream.
 
 ## Consequences
@@ -108,4 +108,4 @@ facts publisher, but explicitly does not converge or rebase the OTel producer on
   forking `gen_ai.*`
   into a Ratel namespace (re-breaks the interop the standard buys); tracking semconv
   `latest` (unreviewed breaks); converging the runtime and OTel producers (opposite lifecycle
-  and reliability constraints; [ADR-0019](0019-runtime-events-lane.md) keeps them parallel).
+  and reliability constraints; [ADR-0020](0020-runtime-events-lane.md) keeps them parallel).

--- a/docs/adr/0007-telemetry-two-streams.md
+++ b/docs/adr/0007-telemetry-two-streams.md
@@ -17,11 +17,18 @@ four capture modes.
 Amended 2026-07-26 to drop the `@ratel-ai/telemetry-otlp` helper, and the TS OTLP config
 resolver with it, now that the TS host owns the OTel provider and its configuration.
 
+Amended 2026-08-13 by [ADR-0019](0019-runtime-events-lane.md): the core stream is now a
+public subscription seam and may be published as a direct product-facts lane. OTel remains a
+separate, unchanged observability projection.
+
 ## Context
 
-Two telemetry surfaces exist for different consumers. A **local** stream feeds the offline
-inspector, statusline / savings reporting, and future rerankers and suggestion analyzers. A
-**remote** path feeds Ratel Cloud and any observability backend the customer already runs.
+Two telemetry projections exist for different consumers. A core-owned runtime stream feeds the
+offline inspector, statusline / savings reporting, rerankers, suggestion analyzers, and public
+subscribers. An **OTel path** feeds Ratel Cloud and any observability backend the customer
+already runs. [ADR-0019](0019-runtime-events-lane.md) additionally permits an explicit Cloud
+adapter to publish the runtime stream as authoritative product facts; that path is not general
+observability.
 The industry standardized the remote payload (OpenTelemetry's `gen_ai.*` semantic
 conventions) after Ratel's first bespoke design; building our own schema and transport would
 make Ratel Cloud an island.
@@ -41,7 +48,8 @@ make Ratel Cloud an island.
   non-exhaustiveness is deliberately avoided, as it would also block downstream from
   constructing events by literal.
 - **One tagged stream, filtering at the consumer**: rerankers, suggestion analysis, and
-  inspection subscribe to different cuts of the same producer; no parallel pipes to drift.
+  inspection subscribe to different cuts of the same producer; public subscriptions and their
+  delivery bounds are specified by [ADR-0019](0019-runtime-events-lane.md).
 - **Query-log semantics, not oplog semantics**: trace events are observations of usage.
   Best-effort, sampleable, lossy on backpressure, loosely ordered, no synchronous durability
   on the hot path (ring buffer, periodic flush). Losing an event is acceptable; corrupting a
@@ -52,9 +60,9 @@ make Ratel Cloud an island.
   project directories and is owned by the consuming shell (today ratel-local), while the
   core sink accepts any path.
 
-### Remote path: OpenTelemetry, pinned, two tiers
+### OpenTelemetry path: pinned, two tiers
 
-- Remote telemetry **is** OpenTelemetry: LLM calls are `gen_ai.*` spans per a **pinned**
+- Remote observability **is** OpenTelemetry: LLM calls are `gen_ai.*` spans per a **pinned**
   semconv baseline (v1.42.0, `gen_ai` group; the group is still `Development`, so the pin is
   the contract and bumps are reviewed changes).
 - **Two tiers, layered not forked**: `gen_ai.*` adopted verbatim (never renamed or re-nested)
@@ -75,11 +83,12 @@ make Ratel Cloud an island.
   configuration, while Python keeps `init()`. Shared conformance fixtures assert every helper
   against the pin so the languages cannot drift.
 
-### Two streams by design
+### Parallel projections by design
 
-Local and remote stay separate producers: the local stream is offline-first with its own
-reliability profile; the remote path is an OTLP export. Converging them is a future decision,
-not an accident of this one.
+The runtime stream and OTel stay separate projections of the same operations. The runtime stream
+is offline-first and lossy; OTel remains a host-owned OTLP export with span lifecycle and ambient
+context. [ADR-0019](0019-runtime-events-lane.md) adds shared event ids and an optional direct
+facts publisher, but explicitly does not converge or rebase the OTel producer on the stream.
 
 ## Consequences
 
@@ -93,10 +102,10 @@ not an accident of this one.
   vocabulary we design and version, with the same care as the local event schema.
 - Cross-language reuse is built in: TS- and Python-emitted remote spans and EventRecords share
   one contract, while their local events continue to share the core-owned schema.
-- Rejected: a bespoke unified schema and per-language clients (duplicates a ratified
+- Rejected: a bespoke unified observability schema and per-language clients (duplicates a ratified
   standard; the pre-compaction 0013 built exactly this and it was deleted unpublished);
   inference-message content on span attributes (attribute limits reject unbounded text);
   forking `gen_ai.*`
   into a Ratel namespace (re-breaks the interop the standard buys); tracking semconv
-  `latest` (unreviewed breaks); converging local and remote now (opposite reliability and
-  offline constraints).
+  `latest` (unreviewed breaks); converging the runtime and OTel producers (opposite lifecycle
+  and reliability constraints; [ADR-0019](0019-runtime-events-lane.md) keeps them parallel).

--- a/docs/adr/0014-adaptive-usage-ranking.md
+++ b/docs/adr/0014-adaptive-usage-ranking.md
@@ -11,6 +11,10 @@ projection), [ADR-0011](0011-selectable-retrieval-methods.md) (the three methods
 and [ADR-0007](0007-telemetry-two-streams.md) (the local trace stream, whose sink seam this
 subscribes to). Ratifies the 2026-07-06 adaptive-ranking brief with the amendments below.
 
+Amended 2026-08-13 by [ADR-0019](0019-runtime-events-lane.md): the sink is now a fan-out
+subscription seam. The learner remains an internal consumer and cannot be replaced by attaching
+another subscriber.
+
 ## Context
 
 Every ranker in the engine scores **text similarity only** — BM25 over the flattened
@@ -201,10 +205,12 @@ to activate it, so they gate all use on their own.
 
 ### Where learning happens
 
-The learner is a `TraceSink` decorator. `Search` and `InvokeStart` arrive through separate
-API calls and the registries have no session concept, but sinks do. ADR-0007 already frames
-the sink as the subscription seam ("rerankers, suggestion analysis, and inspection
-subscribe to different cuts of the same producer"), so this needs no new plumbing.
+The learner consumes `Search` and `InvokeStart` through the core fan-out specified by
+[ADR-0019](0019-runtime-events-lane.md). It is composed as an internal subscriber/decorator,
+not installed into a replace-only sink slot: adding a JSONL, SDK, or Cloud subscriber MUST NOT
+silently disable learning. The public queue and callback machinery stays outside the learner,
+so stalled subscribers cannot block it. Adaptive ranking remains experimental; its decoration
+may be simplified if that is required to keep fan-out robust.
 
 ### What is open source
 

--- a/docs/adr/0014-adaptive-usage-ranking.md
+++ b/docs/adr/0014-adaptive-usage-ranking.md
@@ -11,7 +11,7 @@ projection), [ADR-0011](0011-selectable-retrieval-methods.md) (the three methods
 and [ADR-0007](0007-telemetry-two-streams.md) (the local trace stream, whose sink seam this
 subscribes to). Ratifies the 2026-07-06 adaptive-ranking brief with the amendments below.
 
-Amended 2026-08-13 by [ADR-0019](0019-runtime-events-lane.md): the sink is now a fan-out
+Amended 2026-08-13 by [ADR-0020](0020-runtime-events-lane.md): the sink is now a fan-out
 subscription seam. The learner remains an internal consumer and cannot be replaced by attaching
 another subscriber.
 
@@ -206,7 +206,7 @@ to activate it, so they gate all use on their own.
 ### Where learning happens
 
 The learner consumes `Search` and `InvokeStart` through the core fan-out specified by
-[ADR-0019](0019-runtime-events-lane.md). It is composed as an internal subscriber/decorator,
+[ADR-0020](0020-runtime-events-lane.md). It is composed as an internal subscriber/decorator,
 not installed into a replace-only sink slot: adding a JSONL, SDK, or Cloud subscriber MUST NOT
 silently disable learning. The public queue and callback machinery stays outside the learner,
 so stalled subscribers cannot block it. Adaptive ranking remains experimental; its decoration

--- a/docs/adr/0019-runtime-events-lane.md
+++ b/docs/adr/0019-runtime-events-lane.md
@@ -1,0 +1,161 @@
+# 19. Runtime events lane: subscribable facts and catalog snapshots
+
+Date: 2026-08-13
+
+## Status
+
+Accepted
+
+## Context
+
+Ratel's core trace stream already records the product facts that power inspection, adaptive
+ranking, suggestions, and catalog views. Ratel Cloud can infer some of those facts from the
+parallel OpenTelemetry projection, but sampling, processors, and the content-capture gate make
+OTel an observation channel rather than a census. Catalog definitions are state, not telemetry,
+and cannot be reconstructed from lossy churn events.
+
+The SDK therefore needs one public, cross-language event seam that local consumers and an
+optional Cloud adapter can subscribe to without changing the existing OTel wrappers. It also
+needs a separate snapshot seam for publishing current catalog state.
+
+## Decision
+
+### Contract and evolution
+
+The core trace producer becomes a public **runtime events** stream. Rust owns the schema; the
+TypeScript and Python SDKs expose push subscriptions to the same flattened JSON vocabulary.
+SDK-only experiment events join that vocabulary before delivery. Additive fields and event
+types are non-breaking; renames and removals are breaking. Consumers MUST ignore unknown fields
+and accept unknown event types. Shared fixtures under `src/telemetry/conformance/` pin the wire
+names and values across languages.
+
+The remotely publishable v1 event set is:
+
+| Family | Event types | Required product facts |
+|---|---|---|
+| Search | `search`, `skill_search`, `gateway_search` | `search_id`, query, target/origin, `top_k`, duration, and ordered `hits[]` of target id, rank, and score |
+| Tool invocation | `invoke_start`, `invoke_end`, `invoke_error`, `gateway_invoke`, `gateway_error` | tool id, `invocation_id`, outcome/error class, and duration where known |
+| Skill use | `skill_invoke` | skill id, outcome, and duration |
+| Catalog churn | `index_churn`, `skill_churn` | add/remove, target id, and catalog version where known |
+| Upstream MCP | `upstream_register`, `upstream_invoke`, `upstream_error` | server, transport/tool count or tool id, outcome/error class, and duration where known |
+| Auth | `auth_refresh`, `auth_needs`, `auth_flow_start`, `auth_flow_end` | upstream id and outcome; never credentials |
+| Experiments | `experiment_selection`, `experiment_results`, `experiment_comparison`, `experiment_skip`, `experiment_fallback`, `experiment_drop`, `experiment_invocation`, `experiment_outcome` | `selection_id`; served/shadow arm data; agreement metrics; result ids/scores; attribution, drop/fallback reason, and labelled outcome as applicable |
+| Delivery | `events_dropped` | dropped count, reason, and observation window |
+
+Newer SDKs may emit additive types before every receiver understands them; the receiver stores
+the unknown envelope rather than rejecting the batch. Core diagnostic variants that are not in
+the table remain local until deliberately added to the remotely publishable set.
+
+Search query text and hit ids/scores are part of the facts contract. A query is at most 4 KiB
+and `hits[]` at most 100 entries. Attaching a remote publisher is explicit consent to send those
+fields and uses a gate independent of `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`.
+Inference messages, tool arguments/results, executors, tokens, cost, and model details do not
+enter this lane; they remain absent or OTel-only as applicable.
+
+### Envelope v2 and identity
+
+Every event is flattened into this v2 envelope:
+
+| Field | Contract |
+|---|---|
+| `v` | integer `2` |
+| `event_id` | client-generated ULID, minted once for this event |
+| `ts` | producer time, Unix milliseconds |
+| `session_id` | stable for one agent session |
+| `source_id` | stable identity shared by events and snapshots |
+| `invocation_id` | present on invocation lifecycle events; one opaque id shared by start/end/error |
+| `catalog_version` | optional catalog revision known at emission |
+| `environment` | optional deployment environment |
+| `end_user_id` | optional application-provided subject id |
+| `trace_id`, `span_id` | optional active OTel correlation ids |
+| `type` and payload | flattened event tag and fields |
+
+`event_id` is the canonical deduplication and join key. The same value survives fan-out,
+batching, and retries and is stamped as `ratel.event.id` on the corresponding OTel span or Logs
+EventRecord. A receiver derives its storage id deterministically as UUIDv8 over
+`(project_id, event_id)`; replaying a batch is therefore idempotent without changing the public
+ULID. Each event in an invocation has its own `event_id`; `invocation_id` groups the lifecycle.
+
+`source_id` is an explicit attach option, defaulting to OTel `service.name`, and MUST remain
+stable. Renaming it starts a new source era and a distinct catalog snapshot.
+
+### Delivery and bounds
+
+Emission fans out to multiple independent subscribers. Each push subscriber has a bounded
+queue; enqueue is synchronous and cheap, delivery is batched and asynchronous, and subscriber
+code can never block the emitting operation. On overflow the queue drops its oldest event and
+reports loss through a later `events_dropped` meta-event plus an OTel counter. The test-only
+memory sink may remain unbounded.
+
+Delivery is deliberately best-effort: in-memory queue plus explicit `flush()`, with no disk
+spool, ordering guarantee across producers, or synchronous durability. `flush()` drains work
+already accepted by the process; it cannot recover events lost to overflow or abrupt process
+termination. The TypeScript bridge uses a napi threadsafe callback and Python marshals callback
+delivery safely off the Rust worker thread/GIL-sensitive hot path.
+
+The Cloud receiver exposes `POST /api/v1/events` with the same `rtl_` Bearer-key model as OTLP.
+Wire limits are 64 KB (65,536 bytes) per serialized event and 4 MB (4,194,304 bytes) or 5,000
+events per batch, whichever is reached first. It accepts valid events with OTLP-style partial
+success, returning rejected event ids and reasons, and rate-limits each key to 120 batch
+requests/minute with burst 240 (`429` plus `Retry-After`). Runtime facts are quota-exempt for
+now. Reject storage is metadata-only with roughly seven-day retention; raw accepted envelopes
+retain for 30 days by server receipt time and feed frontier read models at ingest.
+
+A Cloud publisher is fail-open, owns retry/backoff and lifecycle, and can be disabled with
+`RATEL_CLOUD_EVENTS=off`. Cloud transport itself is not part of this repository.
+
+### Parallel OTel projection and per-source supersede
+
+OpenTelemetry emission remains unchanged and is never rebuilt as a subscriber to this stream.
+The two projections share `event_id` and optional trace/span ids, but have different authority:
+runtime events are the census for Ratel-owned product facts; OTel remains the observability and
+trace-context path and the sole path for LLM tokens, cost, model data, and trace structure.
+
+Cloud supersedes OTel-derived product facts **per source**, not per project. The first direct
+facts event for a `source_id` starts that source's facts era; from that boundary Cloud stops
+deriving the overlapping product fact from OTel for that source. It continues to ingest OTel,
+deduplicates overlap by `ratel.event.id`, and uses trace/span correlation for enrichment and
+drill-down. Other sources in the project may continue on OTel-derived facts.
+
+### Catalog snapshot publication carve-out
+
+Catalog definitions do not ride runtime events. `catalog.snapshot()` returns the complete
+serializable definition set (ids, names, descriptions, schemas, and public metadata), never an
+executor or secret material. The Cloud adapter publishes that state separately under the same
+`source_id`, using a canonical content hash and atomic full replacement so removals work and
+unchanged snapshots are skipped. Churn events may debounce/trigger publication, but are not an
+oplog from which catalog state is rebuilt.
+
+This upward path is not catalog authoring or bidirectional source sync. It publishes the
+running SDK's observed state and append-only facts. Event and snapshot shapes structurally omit
+API keys, OAuth tokens, tool arguments/results, executors, and other secret-bearing fields;
+secrets-never-sync remains invariant.
+
+The Cloud adapter lives in `@ratel-ai/cloud-sdk/runtime`. Core runtime events and snapshots have
+TypeScript/Python parity; one-line Cloud attach is TypeScript-only while no Python Cloud adapter
+exists.
+
+## Consequences
+
+- Ratel Cloud product facts no longer depend on OTel sampling or content capture, while OTel
+  interoperability and host-owned provider configuration remain intact.
+- The runtime vocabulary is now a frozen cross-language contract with a conformance burden.
+- Slow or failed subscribers cannot stall an agent, at the accepted cost of observable loss.
+- Catalog removals converge through full snapshots even when churn events drop.
+- Stable source identity becomes operational configuration: changing it forks the facts era
+  and catalog state.
+
+## Rejected
+
+- **OTel-only product facts:** sampling and processors make counts incomplete; the content gate
+  can remove fields Cloud features require.
+- **Rebase OTel on runtime events:** point events cannot preserve wrapper span lifecycle and
+  ambient context without redesigning working instrumentation.
+- **Catalog definitions as events:** a lossy stream cannot safely reconstruct current state or
+  removals.
+- **Durable delivery in the SDK:** a spool/ack protocol is a different reliability tier; this
+  lane remains fail-open and in-memory.
+- **Bidirectional catalog sync:** creates offline merge and secret-leak classes. Source pull and
+  source-scoped snapshot publication remain distinct one-way operations.
+- **Cloud transport in core:** product-specific auth, retries, and lifecycle belong to the Cloud
+  adapter, not the language-neutral event producer.

--- a/docs/adr/0019-runtime-events-lane.md
+++ b/docs/adr/0019-runtime-events-lane.md
@@ -33,7 +33,7 @@ The remotely publishable v1 event set is:
 
 | Family | Event types | Required product facts |
 |---|---|---|
-| Search | `search`, `skill_search`, `gateway_search` | `search_id`, query, target/origin, `top_k`, duration, and ordered `hits[]` of target id, rank, and score |
+| Search | `search`, `skill_search`, `gateway_search` | query, target/origin, `top_k`, duration, and ordered `hits[]` of target id and score |
 | Tool invocation | `invoke_start`, `invoke_end`, `invoke_error`, `gateway_invoke`, `gateway_error` | tool id, `invocation_id`, outcome/error class, and duration where known |
 | Skill use | `skill_invoke` | skill id, outcome, and duration |
 | Catalog churn | `index_churn`, `skill_churn` | add/remove, target id, and catalog version where known |
@@ -41,6 +41,9 @@ The remotely publishable v1 event set is:
 | Auth | `auth_refresh`, `auth_needs`, `auth_flow_start`, `auth_flow_end` | upstream id and outcome; never credentials |
 | Experiments | `experiment_selection`, `experiment_results`, `experiment_comparison`, `experiment_skip`, `experiment_fallback`, `experiment_drop`, `experiment_invocation`, `experiment_outcome` | `selection_id`; served/shadow arm data; agreement metrics; result ids/scores; attribution, drop/fallback reason, and labelled outcome as applicable |
 | Delivery | `events_dropped` | dropped count, reason, and observation window |
+
+For search events, the envelope `event_id` identifies the search. A hit's zero-based rank is its
+position in the ordered `hits[]` array rather than a repeated field on each hit.
 
 Newer SDKs may emit additive types before every receiver understands them; the receiver stores
 the unknown envelope rather than rejecting the batch. Core diagnostic variants that are not in

--- a/docs/adr/0019-runtime-events-lane.md
+++ b/docs/adr/0019-runtime-events-lane.md
@@ -87,8 +87,9 @@ stable. Renaming it starts a new source era and a distinct catalog snapshot.
 Emission fans out to multiple independent subscribers. Each push subscriber has a bounded
 queue; enqueue is synchronous and cheap, delivery is batched and asynchronous, and subscriber
 code can never block the emitting operation. On overflow the queue drops its oldest event and
-reports loss through a later `events_dropped` meta-event plus an OTel counter. The test-only
-memory sink may remain unbounded.
+reports loss through a later `events_dropped` meta-event; monotonic SDK drop counts remain
+available for local accounting. An OTel counter projection is deferred. The test-only memory
+sink may remain unbounded.
 
 Delivery is deliberately best-effort: in-memory queue plus explicit `flush()`, with no disk
 spool, ordering guarantee across producers, or synchronous durability. `flush()` drains work

--- a/docs/adr/0020-runtime-events-lane.md
+++ b/docs/adr/0020-runtime-events-lane.md
@@ -79,8 +79,12 @@ EventRecord. A receiver derives its storage id deterministically as UUIDv8 over
 `(project_id, event_id)`; replaying a batch is therefore idempotent without changing the public
 ULID. Each event in an invocation has its own `event_id`; `invocation_id` groups the lifecycle.
 
-`source_id` is an explicit attach option, defaulting to OTel `service.name`, and MUST remain
-stable. Renaming it starts a new source era and a distinct catalog snapshot.
+`source_id` is an explicit attach option, defaulting to the env-var-configured OTel
+`service.name` (`OTEL_SERVICE_NAME`, then `service.name` in `OTEL_RESOURCE_ATTRIBUTES`),
+falling back to `ratel`. A programmatically configured OTel resource — including a
+service name passed to the SDK's own `configure_telemetry` — is not read; pass `source_id`
+explicitly in that case. It MUST remain stable: renaming it starts a new source era and a
+distinct catalog snapshot.
 
 ### Delivery and bounds
 

--- a/docs/adr/0020-runtime-events-lane.md
+++ b/docs/adr/0020-runtime-events-lane.md
@@ -102,8 +102,9 @@ termination. The TypeScript bridge uses a napi threadsafe callback and Python ma
 delivery safely off the Rust worker thread/GIL-sensitive hot path.
 
 The Cloud receiver exposes `POST /api/v1/events` with the same `rtl_` Bearer-key model as OTLP.
-Wire limits are 64 KB (65,536 bytes) per serialized event and 4 MB (4,194,304 bytes) or 5,000
-events per batch, whichever is reached first. It accepts valid events with OTLP-style partial
+Wire limits are 64 KB (65,536 bytes) per serialized event and 4,000,000 bytes or 5,000
+events per batch, whichever is reached first; the first-party Cloud SDK batches below
+3,900,000 bytes to stay clear of the receiver cap. It accepts valid events with OTLP-style partial
 success, returning rejected event ids and reasons, and rate-limits each key to 120 batch
 requests/minute with burst 240 (`429` plus `Retry-After`). Runtime facts are quota-exempt for
 now. Reject storage is metadata-only with roughly seven-day retention; raw accepted envelopes

--- a/docs/adr/0020-runtime-events-lane.md
+++ b/docs/adr/0020-runtime-events-lane.md
@@ -1,4 +1,4 @@
-# 19. Runtime events lane: subscribable facts and catalog snapshots
+# 20. Runtime events lane: subscribable facts and catalog snapshots
 
 Date: 2026-08-13
 

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -19,6 +19,7 @@ bm25 = "2.3"
 indexmap = "2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
+ulid = "1"
 
 # Dense (semantic) retrieval — pure-Rust Candle inference, no C++/ONNX native
 # dep, so the SDK wheels/addons stay clean cross-platform. `hf-hub` fetches the

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -115,9 +115,9 @@ pub use skill_registry::{ReplaceOutcome, SkillHit, SkillRegistry};
 pub use tool::Tool;
 pub use tool_registry::{AdaptiveRankingStatus, SearchHit, ToolRegistry};
 pub use trace::{
-    ChurnKind, EmbedderLoadStatus, FactHitTrace, FactInjectReason, JsonlSink, MemorySink, NoopSink,
-    Origin, SearchHitTrace, SearchStage, SkillHitTrace, TraceEnvelope, TraceEvent,
-    TraceEventContext, TraceSink,
+    ChurnKind, EmbedderLoadStatus, FactHitTrace, FactInjectReason, FanoutSink, FanoutSubscription,
+    JsonlSink, MemorySink, NoopSink, Origin, SearchHitTrace, SearchStage, SkillHitTrace,
+    TraceEnvelope, TraceEvent, TraceEventContext, TraceSink,
 };
 pub use usage::{Intent, IntentGraph, IntentGraphError};
 pub use usage_learner::UsageLearner;

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -116,7 +116,8 @@ pub use tool::Tool;
 pub use tool_registry::{AdaptiveRankingStatus, SearchHit, ToolRegistry};
 pub use trace::{
     ChurnKind, EmbedderLoadStatus, FactHitTrace, FactInjectReason, JsonlSink, MemorySink, NoopSink,
-    Origin, SearchHitTrace, SearchStage, SkillHitTrace, TraceEnvelope, TraceEvent, TraceSink,
+    Origin, SearchHitTrace, SearchStage, SkillHitTrace, TraceEnvelope, TraceEvent,
+    TraceEventContext, TraceSink,
 };
 pub use usage::{Intent, IntentGraph, IntentGraphError};
 pub use usage_learner::UsageLearner;

--- a/src/core/src/skill_registry.rs
+++ b/src/core/src/skill_registry.rs
@@ -15,7 +15,8 @@ use crate::skill::Skill;
 use crate::skill_indexing::searchable_text;
 use crate::tool_registry::AdaptiveRankingStatus;
 use crate::trace::{
-    ChurnKind, NoopSink, Origin, SearchStage, SkillHitTrace, TraceEvent, TraceSink,
+    ChurnKind, NoopSink, Origin, SearchStage, SkillHitTrace, TraceEvent, TraceEventContext,
+    TraceSink,
 };
 use crate::usage::{Capability, IntentGraph, UsageArm};
 
@@ -161,6 +162,11 @@ impl SkillRegistry {
     /// their `skill_invoke` (content-load) events through this.
     pub fn record_event(&self, event: TraceEvent) {
         self.sink.record(event);
+    }
+
+    /// Record an arbitrary event with per-emission envelope correlation.
+    pub fn record_event_with_context(&self, event: TraceEvent, context: TraceEventContext) {
+        self.sink.record_with_context(event, context);
     }
 
     /// Attach (or with `None`, detach) the usage-ranking read model — the

--- a/src/core/src/skill_registry.rs
+++ b/src/core/src/skill_registry.rs
@@ -527,10 +527,30 @@ impl SkillRegistry {
         origin: Origin,
         method: SearchMethod,
     ) -> Result<Vec<SkillHit>, EmbedderError> {
+        self.search_with_method_and_context(
+            query,
+            top_k,
+            origin,
+            method,
+            TraceEventContext::default(),
+        )
+    }
+
+    /// Search with caller-supplied event identity and OTel correlation.
+    pub fn search_with_method_and_context(
+        &self,
+        query: &str,
+        top_k: usize,
+        origin: Origin,
+        method: SearchMethod,
+        context: TraceEventContext,
+    ) -> Result<Vec<SkillHit>, EmbedderError> {
         match method {
-            SearchMethod::Bm25 => Ok(self.bm25_search_traced(query, top_k, origin)),
-            SearchMethod::Semantic => self.semantic_search_traced(query, top_k, origin),
-            SearchMethod::Hybrid => self.hybrid_search_traced(query, top_k, origin),
+            SearchMethod::Bm25 => {
+                Ok(self.bm25_search_traced_with_context(query, top_k, origin, context))
+            }
+            SearchMethod::Semantic => self.semantic_search_traced(query, top_k, origin, context),
+            SearchMethod::Hybrid => self.hybrid_search_traced(query, top_k, origin, context),
         }
     }
 
@@ -626,6 +646,16 @@ impl SkillRegistry {
     // ---- engines -----------------------------------------------------------
 
     fn bm25_search_traced(&self, query: &str, top_k: usize, origin: Origin) -> Vec<SkillHit> {
+        self.bm25_search_traced_with_context(query, top_k, origin, TraceEventContext::default())
+    }
+
+    fn bm25_search_traced_with_context(
+        &self,
+        query: &str,
+        top_k: usize,
+        origin: Origin,
+        context: TraceEventContext,
+    ) -> Vec<SkillHit> {
         let started = Instant::now();
         let t = Instant::now();
         let arm = self.usage_arm(query, None);
@@ -649,6 +679,7 @@ impl SkillRegistry {
                     top_score,
                 }],
                 took_ms,
+                context,
             );
             return hits;
         };
@@ -673,6 +704,7 @@ impl SkillRegistry {
             &hits,
             vec![bm25_stage, Self::usage_stage(&arm, usage_ms), rrf_stage],
             took_ms,
+            context,
         );
         hits
     }
@@ -682,10 +714,11 @@ impl SkillRegistry {
         query: &str,
         top_k: usize,
         origin: Origin,
+        context: TraceEventContext,
     ) -> Result<Vec<SkillHit>, EmbedderError> {
         let started = Instant::now();
         if self.skills.is_empty() || top_k == 0 {
-            self.record_search(query, origin, top_k, &[], Vec::new(), 0);
+            self.record_search(query, origin, top_k, &[], Vec::new(), 0, context);
             return Ok(Vec::new());
         }
         // Retrieve deeper only when a graph is attached; without one the depth,
@@ -729,6 +762,7 @@ impl SkillRegistry {
                     top_score,
                 }],
                 took_ms,
+                context,
             );
             return Ok(hits);
         };
@@ -749,6 +783,7 @@ impl SkillRegistry {
             &hits,
             vec![dense_stage, Self::usage_stage(&arm, usage_ms), rrf_stage],
             took_ms,
+            context,
         );
         Ok(hits)
     }
@@ -758,10 +793,11 @@ impl SkillRegistry {
         query: &str,
         top_k: usize,
         origin: Origin,
+        context: TraceEventContext,
     ) -> Result<Vec<SkillHit>, EmbedderError> {
         let started = Instant::now();
         if self.skills.is_empty() || top_k == 0 {
-            self.record_search(query, origin, top_k, &[], Vec::new(), 0);
+            self.record_search(query, origin, top_k, &[], Vec::new(), 0, context);
             return Ok(Vec::new());
         }
         let depth = RETRIEVE_DEPTH.max(top_k);
@@ -807,7 +843,7 @@ impl SkillRegistry {
         stages.push(rrf_stage);
 
         let took_ms = started.elapsed().as_millis() as u64;
-        self.record_search(query, origin, top_k, &hits, stages, took_ms);
+        self.record_search(query, origin, top_k, &hits, stages, took_ms, context);
         Ok(hits)
     }
 
@@ -820,21 +856,25 @@ impl SkillRegistry {
         hits: &[SkillHit],
         stages: Vec<SearchStage>,
         took_ms: u64,
+        context: TraceEventContext,
     ) {
-        self.sink.record(TraceEvent::SkillSearch {
-            query: query.to_string(),
-            origin,
-            top_k: top_k as u32,
-            hits: hits
-                .iter()
-                .map(|h| SkillHitTrace {
-                    skill_id: h.skill_id.clone(),
-                    score: h.score as f64,
-                })
-                .collect(),
-            stages,
-            took_ms,
-        });
+        self.sink.record_with_context(
+            TraceEvent::SkillSearch {
+                query: query.to_string(),
+                origin,
+                top_k: top_k as u32,
+                hits: hits
+                    .iter()
+                    .map(|h| SkillHitTrace {
+                        skill_id: h.skill_id.clone(),
+                        score: h.score as f64,
+                    })
+                    .collect(),
+                stages,
+                took_ms,
+            },
+            context,
+        );
     }
 }
 

--- a/src/core/src/tool_registry.rs
+++ b/src/core/src/tool_registry.rs
@@ -14,7 +14,8 @@ use crate::method::SearchMethod;
 use crate::search::Bm25Cache;
 use crate::tool::Tool;
 use crate::trace::{
-    ChurnKind, NoopSink, Origin, SearchHitTrace, SearchStage, TraceEvent, TraceSink,
+    ChurnKind, NoopSink, Origin, SearchHitTrace, SearchStage, TraceEvent, TraceEventContext,
+    TraceSink,
 };
 use crate::usage::{Capability, IntentGraph, UsageArm};
 
@@ -203,6 +204,11 @@ impl ToolRegistry {
     /// registry's own search and churn events (ADR-0007).
     pub fn record_event(&self, event: TraceEvent) {
         self.sink.record(event);
+    }
+
+    /// Record an arbitrary event with per-emission envelope correlation.
+    pub fn record_event_with_context(&self, event: TraceEvent, context: TraceEventContext) {
+        self.sink.record_with_context(event, context);
     }
 
     /// Attach (or with `None`, detach) the usage-ranking read model — adaptive

--- a/src/core/src/tool_registry.rs
+++ b/src/core/src/tool_registry.rs
@@ -514,10 +514,30 @@ impl ToolRegistry {
         origin: Origin,
         method: SearchMethod,
     ) -> Result<Vec<SearchHit>, EmbedderError> {
+        self.search_with_method_and_context(
+            query,
+            top_k,
+            origin,
+            method,
+            TraceEventContext::default(),
+        )
+    }
+
+    /// Search with caller-supplied event identity and OTel correlation.
+    pub fn search_with_method_and_context(
+        &self,
+        query: &str,
+        top_k: usize,
+        origin: Origin,
+        method: SearchMethod,
+        context: TraceEventContext,
+    ) -> Result<Vec<SearchHit>, EmbedderError> {
         match method {
-            SearchMethod::Bm25 => Ok(self.bm25_search_traced(query, top_k, origin)),
-            SearchMethod::Semantic => self.semantic_search_traced(query, top_k, origin),
-            SearchMethod::Hybrid => self.hybrid_search_traced(query, top_k, origin),
+            SearchMethod::Bm25 => {
+                Ok(self.bm25_search_traced_with_context(query, top_k, origin, context))
+            }
+            SearchMethod::Semantic => self.semantic_search_traced(query, top_k, origin, context),
+            SearchMethod::Hybrid => self.hybrid_search_traced(query, top_k, origin, context),
         }
     }
 
@@ -659,6 +679,16 @@ impl ToolRegistry {
     }
 
     fn bm25_search_traced(&self, query: &str, top_k: usize, origin: Origin) -> Vec<SearchHit> {
+        self.bm25_search_traced_with_context(query, top_k, origin, TraceEventContext::default())
+    }
+
+    fn bm25_search_traced_with_context(
+        &self,
+        query: &str,
+        top_k: usize,
+        origin: Origin,
+        context: TraceEventContext,
+    ) -> Vec<SearchHit> {
         let started = Instant::now();
         let t = Instant::now();
         let arm = self.usage_arm(query, None);
@@ -682,6 +712,7 @@ impl ToolRegistry {
                     top_score,
                 }],
                 took_ms,
+                context,
             );
             return hits;
         };
@@ -709,6 +740,7 @@ impl ToolRegistry {
             &hits,
             vec![bm25_stage, Self::usage_stage(&arm, usage_ms), rrf_stage],
             took_ms,
+            context,
         );
         hits
     }
@@ -718,10 +750,11 @@ impl ToolRegistry {
         query: &str,
         top_k: usize,
         origin: Origin,
+        context: TraceEventContext,
     ) -> Result<Vec<SearchHit>, EmbedderError> {
         let started = Instant::now();
         if self.tools.is_empty() || top_k == 0 {
-            self.record_search(query, origin, top_k, &[], Vec::new(), 0);
+            self.record_search(query, origin, top_k, &[], Vec::new(), 0, context);
             return Ok(Vec::new());
         }
         // Retrieve deeper than `top_k` only when a graph is attached; without
@@ -765,6 +798,7 @@ impl ToolRegistry {
                     top_score,
                 }],
                 took_ms,
+                context,
             );
             return Ok(hits);
         };
@@ -785,6 +819,7 @@ impl ToolRegistry {
             &hits,
             vec![dense_stage, Self::usage_stage(&arm, usage_ms), rrf_stage],
             took_ms,
+            context,
         );
         Ok(hits)
     }
@@ -797,10 +832,11 @@ impl ToolRegistry {
         query: &str,
         top_k: usize,
         origin: Origin,
+        context: TraceEventContext,
     ) -> Result<Vec<SearchHit>, EmbedderError> {
         let started = Instant::now();
         if self.tools.is_empty() || top_k == 0 {
-            self.record_search(query, origin, top_k, &[], Vec::new(), 0);
+            self.record_search(query, origin, top_k, &[], Vec::new(), 0, context);
             return Ok(Vec::new());
         }
         // Retrieve deeper than `top_k` so a tool ranked low by one arm but high
@@ -852,7 +888,7 @@ impl ToolRegistry {
         stages.push(rrf_stage);
 
         let took_ms = started.elapsed().as_millis() as u64;
-        self.record_search(query, origin, top_k, &hits, stages, took_ms);
+        self.record_search(query, origin, top_k, &hits, stages, took_ms, context);
         Ok(hits)
     }
 
@@ -865,21 +901,25 @@ impl ToolRegistry {
         hits: &[SearchHit],
         stages: Vec<SearchStage>,
         took_ms: u64,
+        context: TraceEventContext,
     ) {
-        self.sink.record(TraceEvent::Search {
-            query: query.to_string(),
-            origin,
-            top_k: top_k as u32,
-            hits: hits
-                .iter()
-                .map(|h| SearchHitTrace {
-                    tool_id: h.tool_id.clone(),
-                    score: h.score as f64,
-                })
-                .collect(),
-            stages,
-            took_ms,
-        });
+        self.sink.record_with_context(
+            TraceEvent::Search {
+                query: query.to_string(),
+                origin,
+                top_k: top_k as u32,
+                hits: hits
+                    .iter()
+                    .map(|h| SearchHitTrace {
+                        tool_id: h.tool_id.clone(),
+                        score: h.score as f64,
+                    })
+                    .collect(),
+                stages,
+                took_ms,
+            },
+            context,
+        );
     }
 }
 

--- a/src/core/src/trace/event.rs
+++ b/src/core/src/trace/event.rs
@@ -369,6 +369,17 @@ pub enum TraceEvent {
         /// Whether the flow produced valid credentials.
         ok: bool,
     },
+    /// One fan-out subscriber lost events because its bounded queue overflowed.
+    EventsDropped {
+        /// Number of events dropped during this observation window.
+        dropped_count: u64,
+        /// Stable machine-readable loss reason; currently `queue_overflow`.
+        reason: String,
+        /// Timestamp of the first drop in this report, in Unix milliseconds.
+        window_start_ts: u64,
+        /// Timestamp of the last drop in this report, in Unix milliseconds.
+        window_end_ts: u64,
+    },
     /// Emitted once, on the first (cold) load of the embedding model. `status`
     /// flags a slow load (possibly underpowered machine) or a failed one;
     /// `reason` carries the hint / error. See `embedding.rs` and ADR-0011.
@@ -486,6 +497,7 @@ pub struct TraceEnvelope {
     /// Envelope schema version; currently `2`.
     pub v: u32,
     /// Client-generated ULID identifying exactly this event.
+    #[serde(default)]
     pub event_id: String,
     /// Event time, in milliseconds since the Unix epoch.
     pub ts: u64,
@@ -493,6 +505,7 @@ pub struct TraceEnvelope {
     /// all events from one agent session.
     pub session_id: String,
     /// Stable source identity shared by events and catalog snapshots.
+    #[serde(default)]
     pub source_id: String,
     /// Id shared by every event in one invocation lifecycle.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/core/src/trace/event.rs
+++ b/src/core/src/trace/event.rs
@@ -488,6 +488,18 @@ pub struct TraceEventContext {
     pub span_id: Option<String>,
 }
 
+impl TraceEventContext {
+    /// Create context for one invocation lifecycle with a fresh opaque id.
+    /// Clone and pass it with the start and terminal event so concurrent calls
+    /// to the same tool remain paired even when they finish out of order.
+    pub fn new_invocation() -> Self {
+        Self {
+            invocation_id: Some(ulid::Ulid::new().to_string()),
+            ..Self::default()
+        }
+    }
+}
+
 /// The versioned wrapper a sink writes around each [`TraceEvent`]: schema
 /// version, stable identity, timestamp, and correlation fields. On the wire the event is flattened
 /// (`#[serde(flatten)]`), so its `type` tag and fields sit beside `v` / `ts` /

--- a/src/core/src/trace/event.rs
+++ b/src/core/src/trace/event.rs
@@ -456,19 +456,62 @@ pub enum TraceEvent {
     },
 }
 
+/// Per-event correlation fields supplied by the emitting integration.
+///
+/// Sinks fill stable envelope fields such as `event_id`, `session_id`, and
+/// `source_id`; callers use this context only for facts known at the emission
+/// site. Missing fields are omitted from the flattened JSON envelope.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TraceEventContext {
+    /// Id shared by every event in one invocation lifecycle.
+    pub invocation_id: Option<String>,
+    /// Catalog revision known when the event was emitted.
+    pub catalog_version: Option<String>,
+    /// Deployment environment supplied by the application.
+    pub environment: Option<String>,
+    /// Application-provided subject id.
+    pub end_user_id: Option<String>,
+    /// Active OpenTelemetry trace id, when available.
+    pub trace_id: Option<String>,
+    /// Active OpenTelemetry span id, when available.
+    pub span_id: Option<String>,
+}
+
 /// The versioned wrapper a sink writes around each [`TraceEvent`]: schema
-/// version, timestamp, and session id. On the wire the event is flattened
+/// version, stable identity, timestamp, and correlation fields. On the wire the event is flattened
 /// (`#[serde(flatten)]`), so its `type` tag and fields sit beside `v` / `ts` /
 /// `session_id` in one JSON object.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TraceEnvelope {
-    /// Envelope schema version; currently `1`.
+    /// Envelope schema version; currently `2`.
     pub v: u32,
+    /// Client-generated ULID identifying exactly this event.
+    pub event_id: String,
     /// Event time, in milliseconds since the Unix epoch.
     pub ts: u64,
     /// The session the event belongs to, as given to the sink — correlates
     /// all events from one agent session.
     pub session_id: String,
+    /// Stable source identity shared by events and catalog snapshots.
+    pub source_id: String,
+    /// Id shared by every event in one invocation lifecycle.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub invocation_id: Option<String>,
+    /// Catalog revision known when the event was emitted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub catalog_version: Option<String>,
+    /// Deployment environment supplied by the application.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environment: Option<String>,
+    /// Application-provided subject id.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_user_id: Option<String>,
+    /// Active OpenTelemetry trace id, when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    /// Active OpenTelemetry span id, when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span_id: Option<String>,
     /// The event itself, flattened into the envelope on the wire.
     #[serde(flatten)]
     pub event: TraceEvent,

--- a/src/core/src/trace/event.rs
+++ b/src/core/src/trace/event.rs
@@ -474,6 +474,8 @@ pub enum TraceEvent {
 /// site. Missing fields are omitted from the flattened JSON envelope.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TraceEventContext {
+    /// Client-generated id for this event. Sinks mint one when absent.
+    pub event_id: Option<String>,
     /// Id shared by every event in one invocation lifecycle.
     pub invocation_id: Option<String>,
     /// Catalog revision known when the event was emitted.

--- a/src/core/src/trace/mod.rs
+++ b/src/core/src/trace/mod.rs
@@ -10,4 +10,4 @@ pub use event::{
     ChurnKind, EmbedderLoadStatus, FactHitTrace, FactInjectReason, Origin, SearchHitTrace,
     SearchStage, SkillHitTrace, TraceEnvelope, TraceEvent, TraceEventContext,
 };
-pub use sink::{JsonlSink, MemorySink, NoopSink, TraceSink};
+pub use sink::{FanoutSink, FanoutSubscription, JsonlSink, MemorySink, NoopSink, TraceSink};

--- a/src/core/src/trace/mod.rs
+++ b/src/core/src/trace/mod.rs
@@ -8,6 +8,6 @@ mod sink;
 
 pub use event::{
     ChurnKind, EmbedderLoadStatus, FactHitTrace, FactInjectReason, Origin, SearchHitTrace,
-    SearchStage, SkillHitTrace, TraceEnvelope, TraceEvent,
+    SearchStage, SkillHitTrace, TraceEnvelope, TraceEvent, TraceEventContext,
 };
 pub use sink::{JsonlSink, MemorySink, NoopSink, TraceSink};

--- a/src/core/src/trace/sink.rs
+++ b/src/core/src/trace/sink.rs
@@ -14,6 +14,7 @@ const ENVELOPE_VERSION: u32 = 2;
 const QUEUE_OVERFLOW: &str = "queue_overflow";
 
 /// A handle to one [`FanoutSink`] subscriber.
+#[must_use = "dropping the handle unsubscribes the sink"]
 pub struct FanoutSubscription {
     id: u64,
     inner: Arc<Subscriber>,
@@ -90,6 +91,10 @@ impl EnvelopeFactory {
     }
 
     fn correlate_invocation(&self, event: &TraceEvent, context: &mut TraceEventContext) {
+        // Explicit context is the concurrency-safe path. The pending queues keep
+        // legacy sequential record(event) callers conformant until higher layers
+        // can carry context; same-tool calls that may finish out of order must use
+        // TraceEventContext::new_invocation().
         match event {
             TraceEvent::InvokeStart { tool_id, .. } => {
                 let invocation_id = context.invocation_id.get_or_insert_with(new_ulid).clone();

--- a/src/core/src/trace/sink.rs
+++ b/src/core/src/trace/sink.rs
@@ -76,7 +76,7 @@ impl EnvelopeFactory {
         self.correlate_invocation(&event, &mut context);
         TraceEnvelope {
             v: ENVELOPE_VERSION,
-            event_id: ulid::Ulid::new().to_string(),
+            event_id: context.event_id.take().unwrap_or_else(new_ulid),
             ts: now_ms(),
             session_id: self.session_id.clone(),
             source_id: self.source_id.clone(),

--- a/src/core/src/trace/sink.rs
+++ b/src/core/src/trace/sink.rs
@@ -2,13 +2,59 @@ use std::collections::{HashMap, VecDeque};
 use std::fs::{File, OpenOptions};
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex, Weak};
+use std::thread;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::trace::event::{TraceEnvelope, TraceEvent, TraceEventContext};
 
 const DEFAULT_SOURCE_ID: &str = "ratel";
 const ENVELOPE_VERSION: u32 = 2;
+const QUEUE_OVERFLOW: &str = "queue_overflow";
+
+/// A handle to one [`FanoutSink`] subscriber.
+pub struct FanoutSubscription {
+    id: u64,
+    inner: Arc<Subscriber>,
+    owner: Weak<FanoutInner>,
+}
+
+/// A sink that wraps each event once, then asynchronously dispatches the same
+/// envelope to any number of bounded subscribers.
+#[derive(Clone)]
+pub struct FanoutSink {
+    inner: Arc<FanoutInner>,
+}
+
+struct FanoutInner {
+    factory: Arc<EnvelopeFactory>,
+    subscribers: Mutex<HashMap<u64, Arc<Subscriber>>>,
+    dropped: AtomicU64,
+    next_id: AtomicU64,
+}
+
+struct Subscriber {
+    capacity: usize,
+    dropped: AtomicU64,
+    sink: Arc<dyn TraceSink>,
+    state: Mutex<SubscriberState>,
+    changed: Condvar,
+}
+
+#[derive(Default)]
+struct SubscriberState {
+    queue: VecDeque<TraceEnvelope>,
+    pending_loss: Option<DropWindow>,
+    delivering: bool,
+    closed: bool,
+}
+
+struct DropWindow {
+    count: u64,
+    start_ts: u64,
+    end_ts: u64,
+}
 
 struct EnvelopeFactory {
     session_id: String,
@@ -104,9 +150,10 @@ impl EnvelopeFactory {
 /// hot path — see ADR-0007 for the query-log reliability profile (lossy on
 /// backpressure is fine, blocking the agent loop is not).
 ///
-/// Three implementations ship with the crate: [`NoopSink`] (discard — the
-/// registries' default), [`MemorySink`] (in-memory buffer for tests and
-/// introspection), and [`JsonlSink`] (append-to-file local persistence).
+/// Four implementations ship with the crate: [`NoopSink`] (discard — the
+/// registries' default), [`FanoutSink`] (bounded asynchronous subscribers),
+/// [`MemorySink`] (unbounded in-memory buffer for tests and introspection), and
+/// [`JsonlSink`] (append-to-file local persistence).
 pub trait TraceSink: Send + Sync {
     /// Record one event. Called synchronously on the hot path, so it must be
     /// cheap and non-blocking; on failure, drop the event rather than
@@ -143,6 +190,226 @@ impl TraceSink for NoopSink {
     fn record(&self, _event: TraceEvent) {}
 }
 
+impl FanoutSink {
+    /// Create an empty fan-out whose source defaults to `OTEL_SERVICE_NAME`,
+    /// falling back to `ratel`.
+    pub fn new(session_id: impl Into<String>) -> Self {
+        Self::with_source(session_id, default_source_id())
+    }
+
+    /// Create an empty fan-out for one session and explicit stable source.
+    pub fn with_source(session_id: impl Into<String>, source_id: impl Into<String>) -> Self {
+        Self {
+            inner: Arc::new(FanoutInner {
+                factory: Arc::new(EnvelopeFactory::new(session_id, source_id)),
+                subscribers: Mutex::new(HashMap::new()),
+                dropped: AtomicU64::new(0),
+                next_id: AtomicU64::new(1),
+            }),
+        }
+    }
+
+    /// Add an asynchronously dispatched subscriber with a bounded queue.
+    /// Zero capacity is treated as one so emission always has a usable slot.
+    pub fn subscribe(&self, sink: Arc<dyn TraceSink>, queue_capacity: usize) -> FanoutSubscription {
+        let id = self.inner.next_id.fetch_add(1, Ordering::Relaxed);
+        let subscriber = Arc::new(Subscriber {
+            capacity: queue_capacity.max(1),
+            dropped: AtomicU64::new(0),
+            sink,
+            state: Mutex::new(SubscriberState::default()),
+            changed: Condvar::new(),
+        });
+        self.inner
+            .subscribers
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(id, subscriber.clone());
+        spawn_dispatcher(subscriber.clone(), self.inner.factory.clone());
+        FanoutSubscription {
+            id,
+            inner: subscriber,
+            owner: Arc::downgrade(&self.inner),
+        }
+    }
+
+    /// Wait until every current subscriber finishes all accepted work.
+    pub fn flush(&self) {
+        let subscribers: Vec<_> = self
+            .inner
+            .subscribers
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .values()
+            .cloned()
+            .collect();
+        for subscriber in subscribers {
+            subscriber.flush();
+        }
+    }
+
+    /// Total events dropped across every subscriber since this fan-out was created.
+    /// This monotonic counter is the core seam for an OpenTelemetry counter projection.
+    pub fn dropped_count(&self) -> u64 {
+        self.inner.dropped.load(Ordering::Relaxed)
+    }
+}
+
+impl TraceSink for FanoutSink {
+    fn record(&self, event: TraceEvent) {
+        self.record_with_context(event, TraceEventContext::default());
+    }
+
+    fn record_with_context(&self, event: TraceEvent, context: TraceEventContext) {
+        let envelope = self.inner.factory.wrap(event, context);
+        self.record_envelope(envelope);
+    }
+
+    fn record_envelope(&self, envelope: TraceEnvelope) {
+        let subscribers: Vec<_> = self
+            .inner
+            .subscribers
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .values()
+            .cloned()
+            .collect();
+        for subscriber in subscribers {
+            if subscriber.enqueue(envelope.clone()) {
+                self.inner.dropped.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+}
+
+impl FanoutSubscription {
+    /// Total events dropped from this subscriber's queue since subscription.
+    pub fn dropped_count(&self) -> u64 {
+        self.inner.dropped.load(Ordering::Relaxed)
+    }
+
+    /// Wait until this subscriber finishes accepted work and loss reports.
+    pub fn flush(&self) {
+        self.inner.flush();
+    }
+}
+
+impl Drop for FanoutSubscription {
+    fn drop(&mut self) {
+        if let Some(owner) = self.owner.upgrade()
+            && let Ok(mut subscribers) = owner.subscribers.lock()
+        {
+            subscribers.remove(&self.id);
+        }
+        self.inner.close();
+    }
+}
+
+impl Drop for FanoutInner {
+    fn drop(&mut self) {
+        let subscribers = self
+            .subscribers
+            .get_mut()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for subscriber in subscribers.values() {
+            subscriber.close();
+        }
+    }
+}
+
+impl Subscriber {
+    fn enqueue(&self, envelope: TraceEnvelope) -> bool {
+        let Ok(mut state) = self.state.lock() else {
+            return false;
+        };
+        if state.closed {
+            return false;
+        }
+        let dropped = state.queue.len() == self.capacity;
+        if dropped {
+            state.queue.pop_front();
+            let dropped_at = now_ms();
+            let loss = state.pending_loss.get_or_insert(DropWindow {
+                count: 0,
+                start_ts: dropped_at,
+                end_ts: dropped_at,
+            });
+            loss.count += 1;
+            loss.end_ts = dropped_at;
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+        }
+        state.queue.push_back(envelope);
+        self.changed.notify_one();
+        dropped
+    }
+
+    fn flush(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while !state.queue.is_empty() || state.pending_loss.is_some() || state.delivering {
+            state = self
+                .changed
+                .wait(state)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+    }
+
+    fn close(&self) {
+        if let Ok(mut state) = self.state.lock() {
+            state.closed = true;
+            self.changed.notify_all();
+        }
+    }
+}
+
+fn spawn_dispatcher(subscriber: Arc<Subscriber>, factory: Arc<EnvelopeFactory>) {
+    thread::spawn(move || dispatch(subscriber, factory));
+}
+
+fn dispatch(subscriber: Arc<Subscriber>, factory: Arc<EnvelopeFactory>) {
+    loop {
+        let envelope = {
+            let mut state = subscriber
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            while state.queue.is_empty() && state.pending_loss.is_none() && !state.closed {
+                state = subscriber
+                    .changed
+                    .wait(state)
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+            }
+            let envelope = if let Some(loss) = state.pending_loss.take() {
+                factory.wrap(
+                    TraceEvent::EventsDropped {
+                        dropped_count: loss.count,
+                        reason: QUEUE_OVERFLOW.into(),
+                        window_start_ts: loss.start_ts,
+                        window_end_ts: loss.end_ts,
+                    },
+                    TraceEventContext::default(),
+                )
+            } else if let Some(envelope) = state.queue.pop_front() {
+                envelope
+            } else {
+                return;
+            };
+            state.delivering = true;
+            envelope
+        };
+
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            subscriber.sink.record_envelope(envelope);
+        }));
+        if let Ok(mut state) = subscriber.state.lock() {
+            state.delivering = false;
+            subscriber.changed.notify_all();
+        }
+    }
+}
+
 /// A sink that buffers enveloped events in memory, for tests and in-process
 /// introspection: record, then assert on [`Self::snapshot`] or
 /// [`Self::drain`]. The buffer is unbounded, so drain it periodically if the
@@ -153,9 +420,10 @@ pub struct MemorySink {
 }
 
 impl MemorySink {
-    /// An empty sink whose envelopes are stamped with `session_id`.
+    /// An empty sink stamped with `session_id` and a source defaulting to
+    /// `OTEL_SERVICE_NAME`, falling back to `ratel`.
     pub fn new(session_id: impl Into<String>) -> Self {
-        Self::with_source(session_id, DEFAULT_SOURCE_ID)
+        Self::with_source(session_id, default_source_id())
     }
 
     /// An empty sink with explicit stable `source_id` identity.
@@ -214,7 +482,8 @@ pub struct JsonlSink {
 
 impl JsonlSink {
     /// Open (or create) the JSONL file at `path` in append mode, creating
-    /// missing parent directories. On Unix the file's permissions are
+    /// missing parent directories. The source defaults to `OTEL_SERVICE_NAME`,
+    /// falling back to `ratel`. On Unix the file's permissions are
     /// tightened to `0600` (best-effort) since traces can carry query text.
     ///
     /// # Errors
@@ -222,7 +491,7 @@ impl JsonlSink {
     /// Any [`std::io::Error`] from creating the parent directories or opening
     /// the file.
     pub fn new(session_id: impl Into<String>, path: impl AsRef<Path>) -> std::io::Result<Self> {
-        Self::with_source(session_id, DEFAULT_SOURCE_ID, path)
+        Self::with_source(session_id, default_source_id(), path)
     }
 
     /// Open a JSONL sink with explicit stable `source_id` identity.
@@ -281,4 +550,11 @@ fn now_ms() -> u64 {
 
 fn new_ulid() -> String {
     ulid::Ulid::new().to_string()
+}
+
+fn default_source_id() -> String {
+    std::env::var("OTEL_SERVICE_NAME")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| DEFAULT_SOURCE_ID.into())
 }

--- a/src/core/src/trace/sink.rs
+++ b/src/core/src/trace/sink.rs
@@ -11,6 +11,7 @@ use crate::trace::event::{TraceEnvelope, TraceEvent, TraceEventContext};
 
 const DEFAULT_SOURCE_ID: &str = "ratel";
 const ENVELOPE_VERSION: u32 = 2;
+const MAX_PENDING_INVOCATIONS_PER_TOOL: usize = 1_024;
 const QUEUE_OVERFLOW: &str = "queue_overflow";
 
 /// A handle to one [`FanoutSink`] subscriber.
@@ -97,12 +98,17 @@ impl EnvelopeFactory {
         // TraceEventContext::new_invocation().
         match event {
             TraceEvent::InvokeStart { tool_id, .. } => {
+                let has_explicit_invocation = context.invocation_id.is_some();
                 let invocation_id = context.invocation_id.get_or_insert_with(new_ulid).clone();
+                if has_explicit_invocation {
+                    return;
+                }
                 if let Ok(mut pending) = self.pending_invocations.lock() {
-                    pending
-                        .entry(tool_id.clone())
-                        .or_default()
-                        .push_back(invocation_id);
+                    let ids = pending.entry(tool_id.clone()).or_default();
+                    if ids.len() == MAX_PENDING_INVOCATIONS_PER_TOOL {
+                        ids.pop_front();
+                    }
+                    ids.push_back(invocation_id);
                 }
             }
             TraceEvent::InvokeEnd { tool_id, .. } | TraceEvent::InvokeError { tool_id, .. } => {

--- a/src/core/src/trace/sink.rs
+++ b/src/core/src/trace/sink.rs
@@ -1,12 +1,104 @@
+use std::collections::{HashMap, VecDeque};
 use std::fs::{File, OpenOptions};
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::trace::event::{TraceEnvelope, TraceEvent};
+use crate::trace::event::{TraceEnvelope, TraceEvent, TraceEventContext};
 
-const ENVELOPE_VERSION: u32 = 1;
+const DEFAULT_SOURCE_ID: &str = "ratel";
+const ENVELOPE_VERSION: u32 = 2;
+
+struct EnvelopeFactory {
+    session_id: String,
+    source_id: String,
+    pending_invocations: Mutex<HashMap<String, VecDeque<String>>>,
+}
+
+impl EnvelopeFactory {
+    fn new(session_id: impl Into<String>, source_id: impl Into<String>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            source_id: source_id.into(),
+            pending_invocations: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn wrap(&self, event: TraceEvent, mut context: TraceEventContext) -> TraceEnvelope {
+        self.correlate_invocation(&event, &mut context);
+        TraceEnvelope {
+            v: ENVELOPE_VERSION,
+            event_id: ulid::Ulid::new().to_string(),
+            ts: now_ms(),
+            session_id: self.session_id.clone(),
+            source_id: self.source_id.clone(),
+            invocation_id: context.invocation_id,
+            catalog_version: context.catalog_version,
+            environment: context.environment,
+            end_user_id: context.end_user_id,
+            trace_id: context.trace_id,
+            span_id: context.span_id,
+            event,
+        }
+    }
+
+    fn correlate_invocation(&self, event: &TraceEvent, context: &mut TraceEventContext) {
+        match event {
+            TraceEvent::InvokeStart { tool_id, .. } => {
+                let invocation_id = context.invocation_id.get_or_insert_with(new_ulid).clone();
+                if let Ok(mut pending) = self.pending_invocations.lock() {
+                    pending
+                        .entry(tool_id.clone())
+                        .or_default()
+                        .push_back(invocation_id);
+                }
+            }
+            TraceEvent::InvokeEnd { tool_id, .. } | TraceEvent::InvokeError { tool_id, .. } => {
+                if context.invocation_id.is_none() {
+                    context.invocation_id =
+                        self.take_invocation(tool_id).or_else(|| Some(new_ulid()));
+                } else {
+                    self.remove_invocation(tool_id, context.invocation_id.as_deref());
+                }
+            }
+            TraceEvent::SkillInvoke { .. }
+            | TraceEvent::GatewayInvoke { .. }
+            | TraceEvent::GatewayError { .. }
+            | TraceEvent::UpstreamInvoke { .. }
+            | TraceEvent::UpstreamError { .. } => {
+                context.invocation_id.get_or_insert_with(new_ulid);
+            }
+            _ => {}
+        }
+    }
+
+    fn take_invocation(&self, tool_id: &str) -> Option<String> {
+        let mut pending = self.pending_invocations.lock().ok()?;
+        let ids = pending.get_mut(tool_id)?;
+        let invocation_id = ids.pop_front();
+        if ids.is_empty() {
+            pending.remove(tool_id);
+        }
+        invocation_id
+    }
+
+    fn remove_invocation(&self, tool_id: &str, invocation_id: Option<&str>) {
+        let Some(invocation_id) = invocation_id else {
+            return;
+        };
+        let Ok(mut pending) = self.pending_invocations.lock() else {
+            return;
+        };
+        let Some(ids) = pending.get_mut(tool_id) else {
+            return;
+        };
+        ids.retain(|id| id != invocation_id);
+        if ids.is_empty() {
+            pending.remove(tool_id);
+        }
+    }
+}
 
 /// A best-effort sink for trace events. Implementations must be cheap on the
 /// hot path — see ADR-0007 for the query-log reliability profile (lossy on
@@ -20,6 +112,19 @@ pub trait TraceSink: Send + Sync {
     /// cheap and non-blocking; on failure, drop the event rather than
     /// propagate (trace events are observations, never load-bearing).
     fn record(&self, event: TraceEvent);
+
+    /// Record an event with correlation fields known at the emission site.
+    /// Legacy sinks may ignore the context; envelope-aware sinks preserve it.
+    fn record_with_context(&self, event: TraceEvent, _context: TraceEventContext) {
+        self.record(event);
+    }
+
+    /// Accept an event already wrapped by an upstream fan-out sink. Envelope-aware
+    /// sinks override this so identity survives fan-out; legacy sinks still see
+    /// the underlying event.
+    fn record_envelope(&self, envelope: TraceEnvelope) {
+        self.record(envelope.event);
+    }
 
     /// Per-sink rate limit hint. Currently a documentation knob — nothing
     /// rate-limits yet — but the contract is in place so consumers can adopt
@@ -43,15 +148,20 @@ impl TraceSink for NoopSink {
 /// [`Self::drain`]. The buffer is unbounded, so drain it periodically if the
 /// producer is long-lived.
 pub struct MemorySink {
-    session_id: String,
+    factory: EnvelopeFactory,
     events: Mutex<Vec<TraceEnvelope>>,
 }
 
 impl MemorySink {
     /// An empty sink whose envelopes are stamped with `session_id`.
     pub fn new(session_id: impl Into<String>) -> Self {
+        Self::with_source(session_id, DEFAULT_SOURCE_ID)
+    }
+
+    /// An empty sink with explicit stable `source_id` identity.
+    pub fn with_source(session_id: impl Into<String>, source_id: impl Into<String>) -> Self {
         Self {
-            session_id: session_id.into(),
+            factory: EnvelopeFactory::new(session_id, source_id),
             events: Mutex::new(Vec::new()),
         }
     }
@@ -71,13 +181,21 @@ impl MemorySink {
 
     /// The session id stamped on every envelope this sink records.
     pub fn session_id(&self) -> &str {
-        &self.session_id
+        &self.factory.session_id
     }
 }
 
 impl TraceSink for MemorySink {
     fn record(&self, event: TraceEvent) {
-        let envelope = wrap(self.session_id.clone(), event);
+        self.record_with_context(event, TraceEventContext::default());
+    }
+
+    fn record_with_context(&self, event: TraceEvent, context: TraceEventContext) {
+        let envelope = self.factory.wrap(event, context);
+        self.record_envelope(envelope);
+    }
+
+    fn record_envelope(&self, envelope: TraceEnvelope) {
         if let Ok(mut guard) = self.events.lock() {
             guard.push(envelope);
         }
@@ -90,7 +208,7 @@ impl TraceSink for MemorySink {
 /// but the sink accepts any path). Writes are best-effort: a serialization or
 /// I/O failure drops the event rather than disturb the agent loop.
 pub struct JsonlSink {
-    session_id: String,
+    factory: EnvelopeFactory,
     file: Mutex<BufWriter<File>>,
 }
 
@@ -104,6 +222,15 @@ impl JsonlSink {
     /// Any [`std::io::Error`] from creating the parent directories or opening
     /// the file.
     pub fn new(session_id: impl Into<String>, path: impl AsRef<Path>) -> std::io::Result<Self> {
+        Self::with_source(session_id, DEFAULT_SOURCE_ID, path)
+    }
+
+    /// Open a JSONL sink with explicit stable `source_id` identity.
+    pub fn with_source(
+        session_id: impl Into<String>,
+        source_id: impl Into<String>,
+        path: impl AsRef<Path>,
+    ) -> std::io::Result<Self> {
         let path: PathBuf = path.as_ref().to_path_buf();
         if let Some(parent) = path.parent()
             && !parent.as_os_str().is_empty()
@@ -117,7 +244,7 @@ impl JsonlSink {
             let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
         }
         Ok(Self {
-            session_id: session_id.into(),
+            factory: EnvelopeFactory::new(session_id, source_id),
             file: Mutex::new(BufWriter::new(file)),
         })
     }
@@ -125,7 +252,15 @@ impl JsonlSink {
 
 impl TraceSink for JsonlSink {
     fn record(&self, event: TraceEvent) {
-        let envelope = wrap(self.session_id.clone(), event);
+        self.record_with_context(event, TraceEventContext::default());
+    }
+
+    fn record_with_context(&self, event: TraceEvent, context: TraceEventContext) {
+        let envelope = self.factory.wrap(event, context);
+        self.record_envelope(envelope);
+    }
+
+    fn record_envelope(&self, envelope: TraceEnvelope) {
         let Ok(line) = serde_json::to_string(&envelope) else {
             return;
         };
@@ -137,18 +272,13 @@ impl TraceSink for JsonlSink {
     }
 }
 
-fn wrap(session_id: String, event: TraceEvent) -> TraceEnvelope {
-    TraceEnvelope {
-        v: ENVELOPE_VERSION,
-        ts: now_ms(),
-        session_id,
-        event,
-    }
-}
-
 fn now_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
+}
+
+fn new_ulid() -> String {
+    ulid::Ulid::new().to_string()
 }

--- a/src/core/src/usage_learner.rs
+++ b/src/core/src/usage_learner.rs
@@ -45,7 +45,7 @@
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::trace::{TraceEnvelope, TraceEvent, TraceSink};
+use crate::trace::{TraceEnvelope, TraceEvent, TraceEventContext, TraceSink};
 use crate::usage::{Capability, IntentGraph};
 
 /// The learner's most recent search — the query an invoke attributes to. Kept
@@ -196,6 +196,16 @@ impl TraceSink for UsageLearner {
     fn record(&self, event: TraceEvent) {
         self.learn_from(&event, now_ms());
         self.inner.record(event);
+    }
+
+    fn record_with_context(&self, event: TraceEvent, context: TraceEventContext) {
+        self.learn_from(&event, now_ms());
+        self.inner.record_with_context(event, context);
+    }
+
+    fn record_envelope(&self, envelope: TraceEnvelope) {
+        self.learn_from(&envelope.event, envelope.ts);
+        self.inner.record_envelope(envelope);
     }
 
     fn sample_rate(&self) -> f64 {

--- a/src/core/tests/trace.rs
+++ b/src/core/tests/trace.rs
@@ -149,6 +149,49 @@ fn invocation_lifecycle_events_share_one_invocation_id() {
 }
 
 #[test]
+fn explicit_invocation_context_pairs_concurrent_same_tool_calls() {
+    let sink = MemorySink::new("session");
+    let first = TraceEventContext::new_invocation();
+    let second = TraceEventContext::new_invocation();
+
+    sink.record_with_context(
+        TraceEvent::InvokeStart {
+            tool_id: "alpha".into(),
+            args_size_bytes: 1,
+        },
+        first.clone(),
+    );
+    sink.record_with_context(
+        TraceEvent::InvokeStart {
+            tool_id: "alpha".into(),
+            args_size_bytes: 2,
+        },
+        second.clone(),
+    );
+    sink.record_with_context(
+        TraceEvent::InvokeEnd {
+            tool_id: "alpha".into(),
+            took_ms: 3,
+        },
+        second.clone(),
+    );
+    sink.record_with_context(
+        TraceEvent::InvokeError {
+            tool_id: "alpha".into(),
+            took_ms: 4,
+            error: "boom".into(),
+        },
+        first.clone(),
+    );
+
+    let events = sink.snapshot();
+    assert_eq!(events[0].invocation_id, first.invocation_id);
+    assert_eq!(events[1].invocation_id, second.invocation_id);
+    assert_eq!(events[2].invocation_id, second.invocation_id);
+    assert_eq!(events[3].invocation_id, first.invocation_id);
+}
+
+#[test]
 fn registry_forwards_event_context_to_its_sink() {
     let sink = Arc::new(MemorySink::new("session"));
     let registry = ToolRegistry::with_trace_sink(sink.clone());

--- a/src/core/tests/trace.rs
+++ b/src/core/tests/trace.rs
@@ -192,6 +192,53 @@ fn explicit_invocation_context_pairs_concurrent_same_tool_calls() {
 }
 
 #[test]
+fn explicit_invocation_start_does_not_shift_legacy_pairing() {
+    let sink = MemorySink::new("session");
+    let explicit = TraceEventContext::new_invocation();
+
+    sink.record_with_context(
+        TraceEvent::InvokeStart {
+            tool_id: "alpha".into(),
+            args_size_bytes: 1,
+        },
+        explicit.clone(),
+    );
+    sink.record(TraceEvent::InvokeStart {
+        tool_id: "alpha".into(),
+        args_size_bytes: 2,
+    });
+    sink.record(TraceEvent::InvokeEnd {
+        tool_id: "alpha".into(),
+        took_ms: 3,
+    });
+
+    let events = sink.snapshot();
+    assert_eq!(events[0].invocation_id, explicit.invocation_id);
+    assert_eq!(events[1].invocation_id, events[2].invocation_id);
+    assert_ne!(events[0].invocation_id, events[2].invocation_id);
+}
+
+#[test]
+fn legacy_invocation_pairing_drops_oldest_after_the_per_tool_limit() {
+    let sink = MemorySink::new("session");
+
+    for _ in 0..=1_024 {
+        sink.record(TraceEvent::InvokeStart {
+            tool_id: "alpha".into(),
+            args_size_bytes: 0,
+        });
+    }
+    sink.record(TraceEvent::InvokeEnd {
+        tool_id: "alpha".into(),
+        took_ms: 1,
+    });
+
+    let events = sink.snapshot();
+    assert_eq!(events[1].invocation_id, events[1_025].invocation_id);
+    assert_ne!(events[0].invocation_id, events[1_025].invocation_id);
+}
+
+#[test]
 fn registry_forwards_event_context_to_its_sink() {
     let sink = Arc::new(MemorySink::new("session"));
     let registry = ToolRegistry::with_trace_sink(sink.clone());

--- a/src/core/tests/trace.rs
+++ b/src/core/tests/trace.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use ratel_ai_core::{
     ChurnKind, JsonlSink, MemorySink, NoopSink, Origin, Tool, ToolRegistry, TraceEnvelope,
-    TraceEvent, TraceSink,
+    TraceEvent, TraceEventContext, TraceSink,
 };
 use serde_json::{Value, json};
 use tempfile::tempdir;
@@ -38,7 +38,9 @@ fn register_emits_index_churn_add() {
     assert_eq!(events.len(), 1);
     let env: &TraceEnvelope = &events[0];
     assert_eq!(env.session_id, "session-1");
-    assert_eq!(env.v, 1);
+    assert_eq!(env.source_id, "ratel");
+    assert_eq!(env.v, 2);
+    assert_eq!(env.event_id.len(), 26);
     assert!(env.ts > 0);
     match &env.event {
         TraceEvent::IndexChurn { kind, tool_id } => {
@@ -47,6 +49,84 @@ fn register_emits_index_churn_add() {
         }
         other => panic!("expected IndexChurn, got {other:?}"),
     }
+}
+
+#[test]
+fn envelope_v2_carries_explicit_source_and_span_context() {
+    let sink = MemorySink::with_source("session", "worker-a");
+
+    sink.record_with_context(
+        TraceEvent::AuthNeeds {
+            upstream: "github".into(),
+        },
+        TraceEventContext {
+            trace_id: Some("trace-1".into()),
+            span_id: Some("span-1".into()),
+            ..TraceEventContext::default()
+        },
+    );
+
+    let events = sink.snapshot();
+    let envelope = &events[0];
+    assert_eq!(envelope.source_id, "worker-a");
+    assert_eq!(envelope.trace_id.as_deref(), Some("trace-1"));
+    assert_eq!(envelope.span_id.as_deref(), Some("span-1"));
+    assert!(envelope.invocation_id.is_none());
+}
+
+#[test]
+fn invocation_lifecycle_events_share_one_invocation_id() {
+    let sink = MemorySink::new("session");
+
+    sink.record(TraceEvent::InvokeStart {
+        tool_id: "alpha".into(),
+        args_size_bytes: 1,
+    });
+    sink.record(TraceEvent::InvokeEnd {
+        tool_id: "alpha".into(),
+        took_ms: 2,
+    });
+    sink.record(TraceEvent::InvokeStart {
+        tool_id: "alpha".into(),
+        args_size_bytes: 3,
+    });
+    sink.record(TraceEvent::InvokeError {
+        tool_id: "alpha".into(),
+        took_ms: 4,
+        error: "boom".into(),
+    });
+
+    let events = sink.snapshot();
+    assert_eq!(events[0].invocation_id, events[1].invocation_id);
+    assert_eq!(events[2].invocation_id, events[3].invocation_id);
+    assert_ne!(events[0].invocation_id, events[2].invocation_id);
+    assert!(events.iter().all(|event| event.invocation_id.is_some()));
+    assert!(
+        events
+            .windows(2)
+            .all(|pair| pair[0].event_id != pair[1].event_id)
+    );
+}
+
+#[test]
+fn registry_forwards_event_context_to_its_sink() {
+    let sink = Arc::new(MemorySink::new("session"));
+    let registry = ToolRegistry::with_trace_sink(sink.clone());
+
+    registry.record_event_with_context(
+        TraceEvent::AuthNeeds {
+            upstream: "github".into(),
+        },
+        TraceEventContext {
+            environment: Some("production".into()),
+            end_user_id: Some("user-1".into()),
+            ..TraceEventContext::default()
+        },
+    );
+
+    let events = sink.snapshot();
+    assert_eq!(events[0].environment.as_deref(), Some("production"));
+    assert_eq!(events[0].end_user_id.as_deref(), Some("user-1"));
 }
 
 #[test]
@@ -192,8 +272,10 @@ fn jsonl_sink_writes_one_line_per_event() {
     assert_eq!(lines.len(), 2);
 
     let first: Value = serde_json::from_str(lines[0]).unwrap();
-    assert_eq!(first["v"], 1);
+    assert_eq!(first["v"], 2);
+    assert_eq!(first["event_id"].as_str().unwrap().len(), 26);
     assert_eq!(first["session_id"], "session-7");
+    assert_eq!(first["source_id"], "ratel");
     assert_eq!(first["type"], "auth_needs");
     assert_eq!(first["upstream"], "github");
     assert!(first["ts"].as_u64().unwrap() > 0);

--- a/src/core/tests/trace.rs
+++ b/src/core/tests/trace.rs
@@ -1,11 +1,51 @@
-use std::sync::Arc;
+use std::sync::{Arc, Condvar, Mutex, RwLock, mpsc};
 
 use ratel_ai_core::{
-    ChurnKind, JsonlSink, MemorySink, NoopSink, Origin, Tool, ToolRegistry, TraceEnvelope,
-    TraceEvent, TraceEventContext, TraceSink,
+    ChurnKind, FanoutSink, IntentGraph, JsonlSink, MemorySink, NoopSink, Origin, Tool,
+    ToolRegistry, TraceEnvelope, TraceEvent, TraceEventContext, TraceSink, UsageLearner,
 };
 use serde_json::{Value, json};
 use tempfile::tempdir;
+
+struct BlockingSink {
+    released: (Mutex<bool>, Condvar),
+    started: Mutex<Option<mpsc::SyncSender<()>>>,
+    events: Mutex<Vec<TraceEnvelope>>,
+}
+
+impl BlockingSink {
+    fn new(started: mpsc::SyncSender<()>) -> Self {
+        Self {
+            released: (Mutex::new(false), Condvar::new()),
+            started: Mutex::new(Some(started)),
+            events: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn release(&self) {
+        *self.released.0.lock().unwrap() = true;
+        self.released.1.notify_all();
+    }
+
+    fn snapshot(&self) -> Vec<TraceEnvelope> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+impl TraceSink for BlockingSink {
+    fn record(&self, _event: TraceEvent) {}
+
+    fn record_envelope(&self, envelope: TraceEnvelope) {
+        if let Some(started) = self.started.lock().unwrap().take() {
+            started.send(()).unwrap();
+            let mut released = self.released.0.lock().unwrap();
+            while !*released {
+                released = self.released.1.wait(released).unwrap();
+            }
+        }
+        self.events.lock().unwrap().push(envelope);
+    }
+}
 
 fn empty_schema() -> Value {
     json!({})
@@ -30,7 +70,7 @@ fn default_registry_uses_noop_sink_and_does_not_panic() {
 
 #[test]
 fn register_emits_index_churn_add() {
-    let sink = Arc::new(MemorySink::new("session-1"));
+    let sink = Arc::new(MemorySink::with_source("session-1", "ratel"));
     let mut registry = ToolRegistry::with_trace_sink(sink.clone());
     registry.register(lookup_tool("alpha"));
 
@@ -127,6 +167,84 @@ fn registry_forwards_event_context_to_its_sink() {
     let events = sink.snapshot();
     assert_eq!(events[0].environment.as_deref(), Some("production"));
     assert_eq!(events[0].end_user_id.as_deref(), Some("user-1"));
+}
+
+#[test]
+fn fanout_is_non_blocking_and_reports_drop_oldest_loss() {
+    let fanout = FanoutSink::with_source("session", "source");
+    let fast = Arc::new(MemorySink::new("ignored"));
+    let (started_tx, started_rx) = mpsc::sync_channel(1);
+    let slow = Arc::new(BlockingSink::new(started_tx));
+    let fast_subscription = fanout.subscribe(fast.clone(), 8);
+    let slow_subscription = fanout.subscribe(slow.clone(), 2);
+
+    fanout.record(TraceEvent::AuthNeeds {
+        upstream: "one".into(),
+    });
+    started_rx.recv().unwrap();
+    for upstream in ["two", "three", "four"] {
+        fanout.record(TraceEvent::AuthNeeds {
+            upstream: upstream.into(),
+        });
+    }
+
+    assert_eq!(slow_subscription.dropped_count(), 1);
+    assert_eq!(fanout.dropped_count(), 1);
+    slow.release();
+    fanout.flush();
+
+    let fast_events = fast.snapshot();
+    let slow_events = slow.snapshot();
+    assert_eq!(fast_events.len(), 4);
+    assert_eq!(slow_events.len(), 4);
+    assert_eq!(slow_events[0].event_id, fast_events[0].event_id);
+    assert_eq!(slow_events[2].event_id, fast_events[2].event_id);
+    assert_eq!(slow_events[3].event_id, fast_events[3].event_id);
+    assert!(fast_events.iter().all(|event| event.source_id == "source"));
+    assert_eq!(fast_subscription.dropped_count(), 0);
+
+    match &slow_events[1].event {
+        TraceEvent::EventsDropped {
+            dropped_count,
+            reason,
+            window_start_ts,
+            window_end_ts,
+        } => {
+            assert_eq!(*dropped_count, 1);
+            assert_eq!(reason, "queue_overflow");
+            assert!(*window_start_ts > 0);
+            assert!(*window_end_ts >= *window_start_ts);
+        }
+        event => panic!("expected events_dropped, got {event:?}"),
+    }
+}
+
+#[test]
+fn usage_learner_subscriber_learns_and_preserves_fanout_identity() {
+    let fanout = FanoutSink::with_source("session", "source");
+    let graph = Arc::new(RwLock::new(IntentGraph::empty()));
+    let recorded = Arc::new(MemorySink::new("ignored"));
+    let learner = Arc::new(UsageLearner::new(graph.clone(), recorded.clone()));
+    let subscription = fanout.subscribe(learner, 8);
+
+    fanout.record(TraceEvent::Search {
+        query: "find logs".into(),
+        origin: Origin::Agent,
+        top_k: 5,
+        hits: vec![],
+        stages: vec![],
+        took_ms: 1,
+    });
+    fanout.record(TraceEvent::InvokeStart {
+        tool_id: "logs".into(),
+        args_size_bytes: 0,
+    });
+    subscription.flush();
+
+    assert_eq!(graph.read().unwrap().len(), 1);
+    let events = recorded.snapshot();
+    assert_eq!(events.len(), 2);
+    assert!(events.iter().all(|event| event.source_id == "source"));
 }
 
 #[test]
@@ -257,7 +375,7 @@ fn noop_sink_drops_everything() {
 fn jsonl_sink_writes_one_line_per_event() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("trace.jsonl");
-    let sink = Arc::new(JsonlSink::new("session-7", &path).expect("open sink"));
+    let sink = Arc::new(JsonlSink::with_source("session-7", "ratel", &path).expect("open sink"));
     sink.record(TraceEvent::AuthNeeds {
         upstream: "github".into(),
     });
@@ -371,6 +489,12 @@ fn trace_event_round_trips_through_json() {
         TraceEvent::AuthFlowEnd {
             upstream: "u".into(),
             ok: true,
+        },
+        TraceEvent::EventsDropped {
+            dropped_count: 2,
+            reason: "queue_overflow".into(),
+            window_start_ts: 10,
+            window_end_ts: 11,
         },
         TraceEvent::IndexChurn {
             kind: ChurnKind::Add,

--- a/src/sdk/python/README.md
+++ b/src/sdk/python/README.md
@@ -120,9 +120,9 @@ subscription.unsubscribe()
 
 Async handlers are marshaled onto the subscribing event loop; synchronous handlers run on the
 native callback thread. Both are observational and fail open. `flush()` waits for work already
-accepted by the bounded native queues. Snapshots contain sorted public definitions only — never
-tool executors or skill bodies. Python exposes no Cloud transport; applications may publish these
-events and snapshots through their own adapter.
+accepted by the bounded native queues and for async handlers to settle. Snapshots contain sorted
+public definitions only — never tool executors or skill bodies. Python exposes no Cloud transport;
+applications may publish these events and snapshots through their own adapter.
 
 ## Facts (experimental)
 

--- a/src/sdk/python/README.md
+++ b/src/sdk/python/README.md
@@ -90,6 +90,40 @@ asyncio.run(main())
 
 Continue with the [Python guide](https://docs.ratel.sh/docs/sdks/python), [capability tools](https://docs.ratel.sh/docs/capability-tools), [API reference](https://docs.ratel.sh/docs/api/sdk-python), or the [Pydantic AI example](https://github.com/ratel-ai/ratel/tree/main/examples/pydantic-ai).
 
+## Runtime events and catalog snapshots
+
+`RuntimeEvents` merges tool and skill facts into one bounded push stream. Give the paired
+`RuntimeCatalog` the stream's `source_id` so envelopes and full snapshots identify the same
+deployment source:
+
+```python
+from ratel_ai import RuntimeCatalog, RuntimeEvents, SkillCatalog, ToolCatalog
+
+tools = ToolCatalog()
+skills = SkillCatalog()
+events = RuntimeEvents(
+    [tools, skills],
+    session_id="agent-session",
+    source_id="checkout-agent",
+)
+catalog = RuntimeCatalog(tools, skills, source_id=events.source_id)
+
+async def publish(batch):
+    await send_runtime_facts(batch)
+
+subscription = events.subscribe(publish)  # call from the target asyncio event loop
+# Register, search, and invoke through tools / skills as usual.
+await subscription.flush()
+snapshot = catalog.snapshot()
+subscription.unsubscribe()
+```
+
+Async handlers are marshaled onto the subscribing event loop; synchronous handlers run on the
+native callback thread. Both are observational and fail open. `flush()` waits for work already
+accepted by the bounded native queues. Snapshots contain sorted public definitions only — never
+tool executors or skill bodies. Python exposes no Cloud transport; applications may publish these
+events and snapshots through their own adapter.
+
 ## Facts (experimental)
 
 Tools and skills are **pulled** — a query ranks them and only the winners reach the model. Facts are the opposite: constant content the agent should always work from (a shop's address, hours, a brand's voice), **pushed** into the context and deduplicated so it is injected once rather than every turn.

--- a/src/sdk/python/native/src/lib.rs
+++ b/src/sdk/python/native/src/lib.rs
@@ -47,6 +47,32 @@ const DEFAULT_EVENT_QUEUE_CAPACITY: usize = 1_024;
 const DEFAULT_EVENT_BATCH_SIZE: usize = 64;
 const EVENT_BATCH_DELAY: Duration = Duration::from_millis(1);
 
+fn trace_event_context(context: Option<&Bound<'_, PyAny>>) -> PyResult<core::TraceEventContext> {
+    let Some(context) = context else {
+        return Ok(core::TraceEventContext::default());
+    };
+    let value: Value = pythonize::depythonize(context)
+        .map_err(|e| PyValueError::new_err(format!("invalid trace event context: {e}")))?;
+    let object = value
+        .as_object()
+        .ok_or_else(|| PyValueError::new_err("trace event context must be a dict"))?;
+    let string = |key: &str| {
+        object
+            .get(key)
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+    };
+    Ok(core::TraceEventContext {
+        event_id: string("event_id"),
+        invocation_id: string("invocation_id"),
+        catalog_version: string("catalog_version"),
+        environment: string("environment"),
+        end_user_id: string("end_user_id"),
+        trace_id: string("trace_id"),
+        span_id: string("span_id"),
+    })
+}
+
 /// Handle for one private native runtime-event callback subscription.
 #[pyclass]
 struct NativeEventSubscription {
@@ -776,13 +802,29 @@ impl ToolRegistry {
     /// BM25 search tagged with who initiated it: `"agent"` (a model calling a
     /// capability tool) or anything else → `"direct"` (host code). The origin
     /// only labels the emitted trace event — ranking is identical to `search`.
-    fn search_with_origin(&self, query: String, top_k: u32, origin: String) -> Vec<SearchHit> {
+    #[pyo3(signature = (query, top_k, origin, context=None))]
+    fn search_with_origin(
+        &self,
+        query: String,
+        top_k: u32,
+        origin: String,
+        context: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<Vec<SearchHit>> {
         let parsed = match origin.as_str() {
             "agent" => Origin::Agent,
             _ => Origin::Direct,
         };
-        self.inner
-            .search_with_origin(&query, top_k as usize, parsed)
+        let hits = self
+            .inner
+            .search_with_method_and_context(
+                &query,
+                top_k as usize,
+                parsed,
+                core::SearchMethod::Bm25,
+                trace_event_context(context)?,
+            )
+            .map_err(map_embedder_err)?;
+        Ok(hits
             .into_iter()
             .map(|hit| SearchHit {
                 tool_id: hit.tool_id,
@@ -790,7 +832,7 @@ impl ToolRegistry {
                 rank: hit.rank,
                 fused: hit.fused,
             })
-            .collect()
+            .collect())
     }
 
     /// Search with an explicit method (`"bm25"` | `"semantic"` | `"hybrid"`).
@@ -798,6 +840,7 @@ impl ToolRegistry {
     /// cache and raise `RuntimeError` (`EmbeddingsNotBuilt`) if it isn't built — the
     /// model loads at `_build_embeddings`, never inside a search. Private worker
     /// primitive; releases the GIL. An unknown method raises `ValueError`.
+    #[pyo3(signature = (query, top_k, origin, method, context=None))]
     fn _search_with_method(
         &self,
         py: Python<'_>,
@@ -805,6 +848,7 @@ impl ToolRegistry {
         top_k: u32,
         origin: String,
         method: String,
+        context: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Vec<SearchHit>> {
         let parsed_origin = match origin.as_str() {
             "agent" => Origin::Agent,
@@ -813,10 +857,16 @@ impl ToolRegistry {
         let parsed_method = method
             .parse::<core::SearchMethod>()
             .map_err(|e| PyValueError::new_err(e.to_string()))?;
+        let context = trace_event_context(context)?;
         let hits = py
             .allow_threads(|| {
-                self.inner
-                    .search_with_method(&query, top_k as usize, parsed_origin, parsed_method)
+                self.inner.search_with_method_and_context(
+                    &query,
+                    top_k as usize,
+                    parsed_origin,
+                    parsed_method,
+                    context,
+                )
             })
             .map_err(map_embedder_err)?;
         Ok(hits
@@ -889,6 +939,21 @@ impl ToolRegistry {
         let event: TraceEvent = serde_json::from_value(value)
             .map_err(|e| PyValueError::new_err(format!("invalid trace event: {e}")))?;
         self.inner.record_event(event);
+        Ok(())
+    }
+
+    /// Record an event with caller-supplied identity and OTel correlation.
+    fn record_event_with_context(
+        &self,
+        event: &Bound<'_, PyAny>,
+        context: &Bound<'_, PyAny>,
+    ) -> PyResult<()> {
+        let value: Value = pythonize::depythonize(event)
+            .map_err(|e| PyValueError::new_err(format!("invalid trace event: {e}")))?;
+        let event: TraceEvent = serde_json::from_value(value)
+            .map_err(|e| PyValueError::new_err(format!("invalid trace event: {e}")))?;
+        self.inner
+            .record_event_with_context(event, trace_event_context(Some(context))?);
         Ok(())
     }
 
@@ -1179,13 +1244,29 @@ impl SkillRegistry {
 
     /// BM25 search tagged with who initiated it — see
     /// [`ToolRegistry::search_with_origin`].
-    fn search_with_origin(&self, query: String, top_k: u32, origin: String) -> Vec<SkillHit> {
+    #[pyo3(signature = (query, top_k, origin, context=None))]
+    fn search_with_origin(
+        &self,
+        query: String,
+        top_k: u32,
+        origin: String,
+        context: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<Vec<SkillHit>> {
         let parsed = match origin.as_str() {
             "agent" => Origin::Agent,
             _ => Origin::Direct,
         };
-        self.inner
-            .search_with_origin(&query, top_k as usize, parsed)
+        let hits = self
+            .inner
+            .search_with_method_and_context(
+                &query,
+                top_k as usize,
+                parsed,
+                core::SearchMethod::Bm25,
+                trace_event_context(context)?,
+            )
+            .map_err(map_embedder_err)?;
+        Ok(hits
             .into_iter()
             .map(|hit| SkillHit {
                 skill_id: hit.skill_id,
@@ -1193,10 +1274,11 @@ impl SkillRegistry {
                 rank: hit.rank,
                 fused: hit.fused,
             })
-            .collect()
+            .collect())
     }
 
     /// Private GIL-releasing method search — see [`ToolRegistry::_search_with_method`].
+    #[pyo3(signature = (query, top_k, origin, method, context=None))]
     fn _search_with_method(
         &self,
         py: Python<'_>,
@@ -1204,6 +1286,7 @@ impl SkillRegistry {
         top_k: u32,
         origin: String,
         method: String,
+        context: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Vec<SkillHit>> {
         let parsed_origin = match origin.as_str() {
             "agent" => Origin::Agent,
@@ -1212,10 +1295,16 @@ impl SkillRegistry {
         let parsed_method = method
             .parse::<core::SearchMethod>()
             .map_err(|e| PyValueError::new_err(e.to_string()))?;
+        let context = trace_event_context(context)?;
         let hits = py
             .allow_threads(|| {
-                self.inner
-                    .search_with_method(&query, top_k as usize, parsed_origin, parsed_method)
+                self.inner.search_with_method_and_context(
+                    &query,
+                    top_k as usize,
+                    parsed_origin,
+                    parsed_method,
+                    context,
+                )
             })
             .map_err(map_embedder_err)?;
         Ok(hits
@@ -1283,6 +1372,21 @@ impl SkillRegistry {
         let event: TraceEvent = serde_json::from_value(value)
             .map_err(|e| PyValueError::new_err(format!("invalid trace event: {e}")))?;
         self.inner.record_event(event);
+        Ok(())
+    }
+
+    /// Record an event with caller-supplied identity and OTel correlation.
+    fn record_event_with_context(
+        &self,
+        event: &Bound<'_, PyAny>,
+        context: &Bound<'_, PyAny>,
+    ) -> PyResult<()> {
+        let value: Value = pythonize::depythonize(event)
+            .map_err(|e| PyValueError::new_err(format!("invalid trace event: {e}")))?;
+        let event: TraceEvent = serde_json::from_value(value)
+            .map_err(|e| PyValueError::new_err(format!("invalid trace event: {e}")))?;
+        self.inner
+            .record_event_with_context(event, trace_event_context(Some(context))?);
         Ok(())
     }
 

--- a/src/sdk/python/native/src/lib.rs
+++ b/src/sdk/python/native/src/lib.rs
@@ -86,9 +86,17 @@ struct NativeEventSubscription {
 
 struct EventStream {
     fanout: Arc<core::FanoutSink>,
-    base_subscription: core::FanoutSubscription,
     session_id: String,
     source_id: Option<String>,
+}
+
+/// Records to the pre-existing base sink synchronously on the producer thread,
+/// then fans out to bounded push subscribers. Keeping the base sink out of the
+/// bounded fan-out queues preserves the lossless local memory/jsonl projection;
+/// only push subscribers may drop on overflow. Mirrors the TS binding.
+struct RuntimeEventSink {
+    base: Arc<dyn core::TraceSink>,
+    fanout: Arc<core::FanoutSink>,
 }
 
 struct EventCallbackSink {
@@ -151,19 +159,13 @@ impl NativeEventSubscription {
 }
 
 impl EventStream {
-    fn new(
-        session_id: String,
-        source_id: Option<String>,
-        base_sink: Arc<dyn core::TraceSink>,
-    ) -> Self {
+    fn new(session_id: String, source_id: Option<String>) -> Self {
         let fanout = Arc::new(match source_id.as_ref() {
             Some(source_id) => core::FanoutSink::with_source(&session_id, source_id),
             None => core::FanoutSink::new(&session_id),
         });
-        let base_subscription = fanout.subscribe(base_sink, DEFAULT_EVENT_QUEUE_CAPACITY);
         Self {
             fanout,
-            base_subscription,
             session_id,
             source_id,
         }
@@ -177,9 +179,23 @@ impl EventStream {
         }
         Ok(())
     }
+}
 
-    fn replace_base_sink(&mut self, sink: Arc<dyn core::TraceSink>) {
-        self.base_subscription = self.fanout.subscribe(sink, DEFAULT_EVENT_QUEUE_CAPACITY);
+impl core::TraceSink for RuntimeEventSink {
+    fn record(&self, event: TraceEvent) {
+        self.base.record(event.clone());
+        self.fanout.record(event);
+    }
+
+    fn record_with_context(&self, event: TraceEvent, context: core::TraceEventContext) {
+        self.base
+            .record_with_context(event.clone(), context.clone());
+        self.fanout.record_with_context(event, context);
+    }
+
+    fn record_envelope(&self, envelope: TraceEnvelope) {
+        self.base.record_envelope(envelope.clone());
+        self.fanout.record_envelope(envelope);
     }
 }
 
@@ -236,7 +252,6 @@ impl core::TraceSink for EventCallbackSink {
 
 fn subscribe_event_callback(
     stream: &mut Option<EventStream>,
-    base_sink: Arc<dyn core::TraceSink>,
     callback: Py<PyAny>,
     session_id: String,
     source_id: Option<String>,
@@ -249,7 +264,7 @@ fn subscribe_event_callback(
             stream.validate_identity(&session_id, source_id.as_deref())?;
             stream
         }
-        slot @ None => slot.insert(EventStream::new(session_id, source_id, base_sink)),
+        slot @ None => slot.insert(EventStream::new(session_id, source_id)),
     };
     let subscription = stream
         .fanout
@@ -592,7 +607,10 @@ fn active_trace_sink(
     event_stream: &Option<EventStream>,
 ) -> Arc<dyn core::TraceSink> {
     let sink: Arc<dyn core::TraceSink> = match event_stream {
-        Some(stream) => stream.fanout.clone(),
+        Some(stream) => Arc::new(RuntimeEventSink {
+            base: base_sink.clone(),
+            fanout: stream.fanout.clone(),
+        }),
         None => base_sink.clone(),
     };
     wrap_learner(sink, graph)
@@ -982,19 +1000,14 @@ impl ToolRegistry {
     ) -> PyResult<NativeEventSubscription> {
         let subscription = subscribe_event_callback(
             &mut self.event_stream,
-            self.base_sink.clone(),
             callback,
             session_id,
             source_id,
             queue_capacity,
             batch_size,
         )?;
-        let stream = self
-            .event_stream
-            .as_ref()
-            .expect("event stream initialized by subscribe_event_callback");
-        self.inner
-            .set_trace_sink(wrap_learner(stream.fanout.clone(), self.graph.as_ref()));
+        let sink = active_trace_sink(&self.base_sink, self.graph.as_ref(), &self.event_stream);
+        self.inner.set_trace_sink(sink);
         Ok(subscription)
     }
 
@@ -1014,9 +1027,6 @@ impl ToolRegistry {
             "noop" => {
                 self.memory_sink = None;
                 self.base_sink = Arc::new(NoopSink);
-                if let Some(stream) = self.event_stream.as_mut() {
-                    stream.replace_base_sink(self.base_sink.clone());
-                }
                 let sink =
                     active_trace_sink(&self.base_sink, self.graph.as_ref(), &self.event_stream);
                 self.inner.set_trace_sink(sink);
@@ -1027,9 +1037,6 @@ impl ToolRegistry {
                 let sink = Arc::new(MemorySink::new(session_id));
                 self.memory_sink = Some(sink.clone());
                 self.base_sink = sink;
-                if let Some(stream) = self.event_stream.as_mut() {
-                    stream.replace_base_sink(self.base_sink.clone());
-                }
                 let sink =
                     active_trace_sink(&self.base_sink, self.graph.as_ref(), &self.event_stream);
                 self.inner.set_trace_sink(sink);
@@ -1042,9 +1049,6 @@ impl ToolRegistry {
                     .map_err(|e| PyValueError::new_err(format!("open jsonl sink: {e}")))?;
                 self.memory_sink = None;
                 self.base_sink = Arc::new(sink);
-                if let Some(stream) = self.event_stream.as_mut() {
-                    stream.replace_base_sink(self.base_sink.clone());
-                }
                 let sink =
                     active_trace_sink(&self.base_sink, self.graph.as_ref(), &self.event_stream);
                 self.inner.set_trace_sink(sink);
@@ -1092,9 +1096,6 @@ impl ToolRegistry {
         let Some(sink) = self.memory_sink.as_ref() else {
             return Ok(out);
         };
-        if let Some(stream) = self.event_stream.as_ref() {
-            stream.base_subscription.flush();
-        }
         for env in sink.drain() {
             let obj = pythonize::pythonize(py, &env)
                 .map_err(|e| PyValueError::new_err(format!("serialize trace envelope: {e}")))?;
@@ -1414,19 +1415,14 @@ impl SkillRegistry {
     ) -> PyResult<NativeEventSubscription> {
         let subscription = subscribe_event_callback(
             &mut self.event_stream,
-            self.base_sink.clone(),
             callback,
             session_id,
             source_id,
             queue_capacity,
             batch_size,
         )?;
-        let stream = self
-            .event_stream
-            .as_ref()
-            .expect("event stream initialized by subscribe_event_callback");
-        self.inner
-            .set_trace_sink(wrap_learner(stream.fanout.clone(), self.graph.as_ref()));
+        let sink = active_trace_sink(&self.base_sink, self.graph.as_ref(), &self.event_stream);
+        self.inner.set_trace_sink(sink);
         Ok(subscription)
     }
 
@@ -1443,9 +1439,6 @@ impl SkillRegistry {
             "noop" => {
                 self.memory_sink = None;
                 self.base_sink = Arc::new(NoopSink);
-                if let Some(stream) = self.event_stream.as_mut() {
-                    stream.replace_base_sink(self.base_sink.clone());
-                }
                 let sink =
                     active_trace_sink(&self.base_sink, self.graph.as_ref(), &self.event_stream);
                 self.inner.set_trace_sink(sink);
@@ -1456,9 +1449,6 @@ impl SkillRegistry {
                 let sink = Arc::new(MemorySink::new(session_id));
                 self.memory_sink = Some(sink.clone());
                 self.base_sink = sink;
-                if let Some(stream) = self.event_stream.as_mut() {
-                    stream.replace_base_sink(self.base_sink.clone());
-                }
                 let sink =
                     active_trace_sink(&self.base_sink, self.graph.as_ref(), &self.event_stream);
                 self.inner.set_trace_sink(sink);
@@ -1471,9 +1461,6 @@ impl SkillRegistry {
                     .map_err(|e| PyValueError::new_err(format!("open jsonl sink: {e}")))?;
                 self.memory_sink = None;
                 self.base_sink = Arc::new(sink);
-                if let Some(stream) = self.event_stream.as_mut() {
-                    stream.replace_base_sink(self.base_sink.clone());
-                }
                 let sink =
                     active_trace_sink(&self.base_sink, self.graph.as_ref(), &self.event_stream);
                 self.inner.set_trace_sink(sink);
@@ -1521,9 +1508,6 @@ impl SkillRegistry {
         let Some(sink) = self.memory_sink.as_ref() else {
             return Ok(out);
         };
-        if let Some(stream) = self.event_stream.as_ref() {
-            stream.base_subscription.flush();
-        }
         for env in sink.drain() {
             let obj = pythonize::pythonize(py, &env)
                 .map_err(|e| PyValueError::new_err(format!("serialize trace envelope: {e}")))?;

--- a/src/sdk/python/native/src/lib.rs
+++ b/src/sdk/python/native/src/lib.rs
@@ -4,7 +4,10 @@
 //! ADR-0007 for the core-owned trace schema this emits into.
 
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
+use std::sync::{Arc, Condvar, Mutex, RwLock};
+use std::thread;
+use std::time::Duration;
 
 use pyo3::create_exception;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
@@ -13,7 +16,7 @@ use pyo3::types::{PyBytes, PyList};
 use ratel_ai_core as core;
 use ratel_ai_core::{
     ArtifactError as CoreArtifactError, ArtifactWarmError as CoreArtifactWarmError, JsonlSink,
-    MemorySink, NoopSink, OnArtifactMiss, Origin, TraceEvent, UsageLearner,
+    MemorySink, NoopSink, OnArtifactMiss, Origin, TraceEnvelope, TraceEvent, UsageLearner,
 };
 use serde_json::Value;
 
@@ -39,6 +42,229 @@ type FactBatchItem = (
     String,
     String,
 );
+
+const DEFAULT_EVENT_QUEUE_CAPACITY: usize = 1_024;
+const DEFAULT_EVENT_BATCH_SIZE: usize = 64;
+const EVENT_BATCH_DELAY: Duration = Duration::from_millis(1);
+
+/// Handle for one private native runtime-event callback subscription.
+#[pyclass]
+struct NativeEventSubscription {
+    subscription: Arc<Mutex<Option<core::FanoutSubscription>>>,
+    callback: Arc<EventCallbackSink>,
+}
+
+struct EventStream {
+    fanout: Arc<core::FanoutSink>,
+    base_subscription: core::FanoutSubscription,
+    session_id: String,
+    source_id: Option<String>,
+}
+
+struct EventCallbackSink {
+    sender: SyncSender<TraceEnvelope>,
+    progress: Arc<EventCallbackProgress>,
+}
+
+struct EventCallbackProgress {
+    state: Mutex<EventCallbackState>,
+    changed: Condvar,
+}
+
+#[derive(Default)]
+struct EventCallbackState {
+    accepted: u64,
+    delivered: u64,
+}
+
+#[pymethods]
+impl NativeEventSubscription {
+    /// Wait without the GIL until accepted callback work has completed.
+    fn flush(&self, py: Python<'_>) {
+        py.allow_threads(|| {
+            if let Ok(subscription) = self.subscription.lock()
+                && let Some(subscription) = subscription.as_ref()
+            {
+                subscription.flush();
+            }
+            self.callback.flush();
+        });
+    }
+
+    /// Stop future delivery. Already-running callback work is best-effort.
+    fn unsubscribe(&self) {
+        if let Ok(mut subscription) = self.subscription.lock() {
+            subscription.take();
+        }
+    }
+
+    /// Number of envelopes displaced by this subscriber's bounded queue.
+    #[getter]
+    fn dropped_count(&self) -> u64 {
+        self.subscription
+            .lock()
+            .ok()
+            .and_then(|subscription| {
+                subscription
+                    .as_ref()
+                    .map(core::FanoutSubscription::dropped_count)
+            })
+            .unwrap_or(0)
+    }
+}
+
+impl EventStream {
+    fn new(
+        session_id: String,
+        source_id: Option<String>,
+        base_sink: Arc<dyn core::TraceSink>,
+    ) -> Self {
+        let fanout = Arc::new(match source_id.as_ref() {
+            Some(source_id) => core::FanoutSink::with_source(&session_id, source_id),
+            None => core::FanoutSink::new(&session_id),
+        });
+        let base_subscription = fanout.subscribe(base_sink, DEFAULT_EVENT_QUEUE_CAPACITY);
+        Self {
+            fanout,
+            base_subscription,
+            session_id,
+            source_id,
+        }
+    }
+
+    fn validate_identity(&self, session_id: &str, source_id: Option<&str>) -> PyResult<()> {
+        if self.session_id != session_id || self.source_id.as_deref() != source_id {
+            return Err(PyValueError::new_err(
+                "runtime event stream already configured with a different session_id/source_id",
+            ));
+        }
+        Ok(())
+    }
+
+    fn replace_base_sink(&mut self, sink: Arc<dyn core::TraceSink>) {
+        self.base_subscription = self.fanout.subscribe(sink, DEFAULT_EVENT_QUEUE_CAPACITY);
+    }
+}
+
+impl EventCallbackSink {
+    fn new(callback: Py<PyAny>, batch_size: usize) -> Arc<Self> {
+        let (sender, receiver) = sync_channel(batch_size);
+        let progress = Arc::new(EventCallbackProgress {
+            state: Mutex::new(EventCallbackState::default()),
+            changed: Condvar::new(),
+        });
+        let sink = Arc::new(Self {
+            sender,
+            progress: progress.clone(),
+        });
+        spawn_event_callback_dispatcher(receiver, callback, batch_size, progress);
+        sink
+    }
+
+    fn flush(&self) {
+        self.progress.flush();
+    }
+}
+
+impl EventCallbackProgress {
+    fn flush(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while state.delivered < state.accepted {
+            state = self
+                .changed
+                .wait(state)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+    }
+
+    fn mark_delivered(&self, count: usize) {
+        if let Ok(mut state) = self.state.lock() {
+            state.delivered += count as u64;
+            self.changed.notify_all();
+        }
+    }
+}
+
+impl core::TraceSink for EventCallbackSink {
+    fn record(&self, _event: TraceEvent) {}
+
+    fn record_envelope(&self, envelope: TraceEnvelope) {
+        if let Ok(mut state) = self.progress.state.lock() {
+            state.accepted += 1;
+        }
+        if self.sender.send(envelope).is_err() {
+            self.progress.mark_delivered(1);
+        }
+    }
+}
+
+fn subscribe_event_callback(
+    stream: &mut Option<EventStream>,
+    base_sink: Arc<dyn core::TraceSink>,
+    callback: Py<PyAny>,
+    session_id: String,
+    source_id: Option<String>,
+    queue_capacity: usize,
+    batch_size: usize,
+) -> PyResult<NativeEventSubscription> {
+    let callback_sink = EventCallbackSink::new(callback, batch_size.max(1));
+    let stream = match stream {
+        Some(stream) => {
+            stream.validate_identity(&session_id, source_id.as_deref())?;
+            stream
+        }
+        slot @ None => slot.insert(EventStream::new(session_id, source_id, base_sink)),
+    };
+    let subscription = stream
+        .fanout
+        .subscribe(callback_sink.clone(), queue_capacity.max(1));
+    Ok(NativeEventSubscription {
+        subscription: Arc::new(Mutex::new(Some(subscription))),
+        callback: callback_sink,
+    })
+}
+
+fn spawn_event_callback_dispatcher(
+    receiver: Receiver<TraceEnvelope>,
+    callback: Py<PyAny>,
+    batch_size: usize,
+    progress: Arc<EventCallbackProgress>,
+) {
+    thread::spawn(move || dispatch_event_callbacks(receiver, callback, batch_size, progress));
+}
+
+/// Marshal batches from the fan-out subscriber thread onto a dedicated
+/// callback thread. This thread alone acquires the GIL and invokes the Python
+/// callable; core emission and dense-search workers never run subscriber code.
+fn dispatch_event_callbacks(
+    receiver: Receiver<TraceEnvelope>,
+    callback: Py<PyAny>,
+    batch_size: usize,
+    progress: Arc<EventCallbackProgress>,
+) {
+    while let Ok(first) = receiver.recv() {
+        let mut envelopes = vec![first];
+        while envelopes.len() < batch_size {
+            match receiver.recv_timeout(EVENT_BATCH_DELAY) {
+                Ok(envelope) => envelopes.push(envelope),
+                Err(_) => break,
+            }
+        }
+        let delivered = envelopes.len();
+        let _ = Python::with_gil(|py| -> PyResult<()> {
+            let batch = PyList::empty(py);
+            for envelope in envelopes {
+                batch.append(pythonize::pythonize(py, &envelope)?)?;
+            }
+            callback.call1(py, (batch,))?;
+            Ok(())
+        });
+        progress.mark_delivered(delivered);
+    }
+}
 
 create_exception!(
     _native,
@@ -323,6 +549,18 @@ fn wrap_learner(
     }
 }
 
+fn active_trace_sink(
+    base_sink: &Arc<dyn core::TraceSink>,
+    graph: Option<&Arc<RwLock<core::IntentGraph>>>,
+    event_stream: &Option<EventStream>,
+) -> Arc<dyn core::TraceSink> {
+    let sink: Arc<dyn core::TraceSink> = match event_stream {
+        Some(stream) => stream.fanout.clone(),
+        None => base_sink.clone(),
+    };
+    wrap_learner(sink, graph)
+}
+
 /// A shared usage-ranking intent graph (ADR-0014): clusters of past queries,
 /// each remembering the capabilities invoked after them.
 ///
@@ -419,6 +657,7 @@ pub struct ToolRegistry {
     /// Retained so `set_trace_sink` can re-wrap the new sink in a learner —
     /// otherwise changing sinks would silently switch learning off.
     graph: Option<Arc<RwLock<core::IntentGraph>>>,
+    event_stream: Option<EventStream>,
 }
 
 #[pymethods]
@@ -465,6 +704,7 @@ impl ToolRegistry {
             memory_sink: None,
             base_sink: Arc::new(NoopSink),
             graph: None,
+            event_stream: None,
         })
     }
 
@@ -652,6 +892,36 @@ impl ToolRegistry {
         Ok(())
     }
 
+    /// Attach the private batched callback seam consumed by the public SDK in
+    /// Phase 5. A dedicated Rust thread acquires the GIL for each callback;
+    /// producer and dense-search worker threads only enqueue.
+    #[pyo3(signature = (callback, session_id, source_id=None, queue_capacity=DEFAULT_EVENT_QUEUE_CAPACITY, batch_size=DEFAULT_EVENT_BATCH_SIZE))]
+    fn subscribe_trace_events(
+        &mut self,
+        callback: Py<PyAny>,
+        session_id: String,
+        source_id: Option<String>,
+        queue_capacity: usize,
+        batch_size: usize,
+    ) -> PyResult<NativeEventSubscription> {
+        let subscription = subscribe_event_callback(
+            &mut self.event_stream,
+            self.base_sink.clone(),
+            callback,
+            session_id,
+            source_id,
+            queue_capacity,
+            batch_size,
+        )?;
+        let stream = self
+            .event_stream
+            .as_ref()
+            .expect("event stream initialized by subscribe_event_callback");
+        self.inner
+            .set_trace_sink(wrap_learner(stream.fanout.clone(), self.graph.as_ref()));
+        Ok(subscription)
+    }
+
     /// Route trace events to a sink. `kind` is `"noop"` (drop everything, the
     /// initial state), `"memory"` (buffer for `drain_trace_events`; requires
     /// `session_id`) or `"jsonl"` (append to a file; requires `session_id` and
@@ -668,7 +938,11 @@ impl ToolRegistry {
             "noop" => {
                 self.memory_sink = None;
                 self.base_sink = Arc::new(NoopSink);
-                let sink = wrap_learner(self.base_sink.clone(), self.graph.as_ref());
+                if let Some(stream) = self.event_stream.as_mut() {
+                    stream.replace_base_sink(self.base_sink.clone());
+                }
+                let sink =
+                    active_trace_sink(&self.base_sink, self.graph.as_ref(), &self.event_stream);
                 self.inner.set_trace_sink(sink);
             }
             "memory" => {
@@ -677,7 +951,11 @@ impl ToolRegistry {
                 let sink = Arc::new(MemorySink::new(session_id));
                 self.memory_sink = Some(sink.clone());
                 self.base_sink = sink;
-                let sink = wrap_learner(self.base_sink.clone(), self.graph.as_ref());
+                if let Some(stream) = self.event_stream.as_mut() {
+                    stream.replace_base_sink(self.base_sink.clone());
+                }
+                let sink =
+                    active_trace_sink(&self.base_sink, self.graph.as_ref(), &self.event_stream);
                 self.inner.set_trace_sink(sink);
             }
             "jsonl" => {
@@ -688,7 +966,11 @@ impl ToolRegistry {
                     .map_err(|e| PyValueError::new_err(format!("open jsonl sink: {e}")))?;
                 self.memory_sink = None;
                 self.base_sink = Arc::new(sink);
-                let sink = wrap_learner(self.base_sink.clone(), self.graph.as_ref());
+                if let Some(stream) = self.event_stream.as_mut() {
+                    stream.replace_base_sink(self.base_sink.clone());
+                }
+                let sink =
+                    active_trace_sink(&self.base_sink, self.graph.as_ref(), &self.event_stream);
                 self.inner.set_trace_sink(sink);
             }
             other => {
@@ -712,9 +994,8 @@ impl ToolRegistry {
     /// compare ordering rather than magnitudes.
     fn enable_adaptive_ranking(&mut self, graph: &IntentGraph) {
         let handle = graph.inner.clone();
-        let inner_sink = self.base_sink.clone();
-        self.inner
-            .set_trace_sink(Arc::new(UsageLearner::new(handle.clone(), inner_sink)));
+        let sink = active_trace_sink(&self.base_sink, Some(&handle), &self.event_stream);
+        self.inner.set_trace_sink(sink);
         self.inner.set_intent_graph(Some(handle.clone()));
         self.graph = Some(handle);
     }
@@ -722,8 +1003,8 @@ impl ToolRegistry {
     /// Turn adaptive usage ranking off: ranking returns to the base engine and
     /// the graph stops growing. The graph keeps what it learned.
     fn disable_adaptive_ranking(&mut self) {
-        let inner_sink = self.base_sink.clone();
-        self.inner.set_trace_sink(inner_sink);
+        let sink = active_trace_sink(&self.base_sink, None, &self.event_stream);
+        self.inner.set_trace_sink(sink);
         self.inner.set_intent_graph(None);
         self.graph = None;
     }
@@ -735,6 +1016,9 @@ impl ToolRegistry {
         let Some(sink) = self.memory_sink.as_ref() else {
             return Ok(out);
         };
+        if let Some(stream) = self.event_stream.as_ref() {
+            stream.base_subscription.flush();
+        }
         for env in sink.drain() {
             let obj = pythonize::pythonize(py, &env)
                 .map_err(|e| PyValueError::new_err(format!("serialize trace envelope: {e}")))?;
@@ -757,6 +1041,7 @@ pub struct SkillRegistry {
     /// Retained so `set_trace_sink` can re-wrap the new sink in a learner —
     /// otherwise changing sinks would silently switch learning off.
     graph: Option<Arc<RwLock<core::IntentGraph>>>,
+    event_stream: Option<EventStream>,
 }
 
 #[pymethods]
@@ -800,6 +1085,7 @@ impl SkillRegistry {
             memory_sink: None,
             base_sink: Arc::new(NoopSink),
             graph: None,
+            event_stream: None,
         })
     }
 
@@ -1000,6 +1286,35 @@ impl SkillRegistry {
         Ok(())
     }
 
+    /// Attach the private batched callback seam — see
+    /// [`ToolRegistry::subscribe_trace_events`].
+    #[pyo3(signature = (callback, session_id, source_id=None, queue_capacity=DEFAULT_EVENT_QUEUE_CAPACITY, batch_size=DEFAULT_EVENT_BATCH_SIZE))]
+    fn subscribe_trace_events(
+        &mut self,
+        callback: Py<PyAny>,
+        session_id: String,
+        source_id: Option<String>,
+        queue_capacity: usize,
+        batch_size: usize,
+    ) -> PyResult<NativeEventSubscription> {
+        let subscription = subscribe_event_callback(
+            &mut self.event_stream,
+            self.base_sink.clone(),
+            callback,
+            session_id,
+            source_id,
+            queue_capacity,
+            batch_size,
+        )?;
+        let stream = self
+            .event_stream
+            .as_ref()
+            .expect("event stream initialized by subscribe_event_callback");
+        self.inner
+            .set_trace_sink(wrap_learner(stream.fanout.clone(), self.graph.as_ref()));
+        Ok(subscription)
+    }
+
     /// Route trace events to a sink — see [`ToolRegistry::set_trace_sink`] for
     /// the kind / session_id / path rules and `ValueError` conditions.
     #[pyo3(signature = (kind, session_id=None, path=None))]
@@ -1013,7 +1328,11 @@ impl SkillRegistry {
             "noop" => {
                 self.memory_sink = None;
                 self.base_sink = Arc::new(NoopSink);
-                let sink = wrap_learner(self.base_sink.clone(), self.graph.as_ref());
+                if let Some(stream) = self.event_stream.as_mut() {
+                    stream.replace_base_sink(self.base_sink.clone());
+                }
+                let sink =
+                    active_trace_sink(&self.base_sink, self.graph.as_ref(), &self.event_stream);
                 self.inner.set_trace_sink(sink);
             }
             "memory" => {
@@ -1022,7 +1341,11 @@ impl SkillRegistry {
                 let sink = Arc::new(MemorySink::new(session_id));
                 self.memory_sink = Some(sink.clone());
                 self.base_sink = sink;
-                let sink = wrap_learner(self.base_sink.clone(), self.graph.as_ref());
+                if let Some(stream) = self.event_stream.as_mut() {
+                    stream.replace_base_sink(self.base_sink.clone());
+                }
+                let sink =
+                    active_trace_sink(&self.base_sink, self.graph.as_ref(), &self.event_stream);
                 self.inner.set_trace_sink(sink);
             }
             "jsonl" => {
@@ -1033,7 +1356,11 @@ impl SkillRegistry {
                     .map_err(|e| PyValueError::new_err(format!("open jsonl sink: {e}")))?;
                 self.memory_sink = None;
                 self.base_sink = Arc::new(sink);
-                let sink = wrap_learner(self.base_sink.clone(), self.graph.as_ref());
+                if let Some(stream) = self.event_stream.as_mut() {
+                    stream.replace_base_sink(self.base_sink.clone());
+                }
+                let sink =
+                    active_trace_sink(&self.base_sink, self.graph.as_ref(), &self.event_stream);
                 self.inner.set_trace_sink(sink);
             }
             other => {
@@ -1057,9 +1384,8 @@ impl SkillRegistry {
     /// compare ordering rather than magnitudes.
     fn enable_adaptive_ranking(&mut self, graph: &IntentGraph) {
         let handle = graph.inner.clone();
-        let inner_sink = self.base_sink.clone();
-        self.inner
-            .set_trace_sink(Arc::new(UsageLearner::new(handle.clone(), inner_sink)));
+        let sink = active_trace_sink(&self.base_sink, Some(&handle), &self.event_stream);
+        self.inner.set_trace_sink(sink);
         self.inner.set_intent_graph(Some(handle.clone()));
         self.graph = Some(handle);
     }
@@ -1067,8 +1393,8 @@ impl SkillRegistry {
     /// Turn adaptive usage ranking off: ranking returns to the base engine and
     /// the graph stops growing. The graph keeps what it learned.
     fn disable_adaptive_ranking(&mut self) {
-        let inner_sink = self.base_sink.clone();
-        self.inner.set_trace_sink(inner_sink);
+        let sink = active_trace_sink(&self.base_sink, None, &self.event_stream);
+        self.inner.set_trace_sink(sink);
         self.inner.set_intent_graph(None);
         self.graph = None;
     }
@@ -1080,6 +1406,9 @@ impl SkillRegistry {
         let Some(sink) = self.memory_sink.as_ref() else {
             return Ok(out);
         };
+        if let Some(stream) = self.event_stream.as_ref() {
+            stream.base_subscription.flush();
+        }
         for env in sink.drain() {
             let obj = pythonize::pythonize(py, &env)
                 .map_err(|e| PyValueError::new_err(format!("serialize trace envelope: {e}")))?;
@@ -1340,6 +1669,7 @@ impl FactRegistry {
 
 #[pymodule]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<NativeEventSubscription>()?;
     m.add_class::<ToolRegistry>()?;
     m.add_class::<IntentGraph>()?;
     m.add_class::<SearchHit>()?;

--- a/src/sdk/python/native/src/lib.rs
+++ b/src/sdk/python/native/src/lib.rs
@@ -4,6 +4,7 @@
 //! ADR-0007 for the core-owned trace schema this emits into.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
 use std::sync::{Arc, Condvar, Mutex, RwLock};
 use std::thread;
@@ -77,7 +78,10 @@ fn trace_event_context(context: Option<&Bound<'_, PyAny>>) -> PyResult<core::Tra
 #[pyclass]
 struct NativeEventSubscription {
     subscription: Arc<Mutex<Option<Arc<core::FanoutSubscription>>>>,
-    callback: Arc<EventCallbackSink>,
+    // Retain progress, not the sink: unsubscribe must release its sender so
+    // the callback dispatcher observes a disconnected receiver and exits.
+    progress: Arc<EventCallbackProgress>,
+    final_dropped_count: AtomicU64,
 }
 
 struct EventStream {
@@ -116,15 +120,18 @@ impl NativeEventSubscription {
             if let Some(subscription) = subscription {
                 subscription.flush();
             }
-            self.callback.flush();
+            self.progress.flush();
         });
     }
 
     /// Stop accepting new events. Envelopes already queued still drain.
     fn unsubscribe(&self, py: Python<'_>) {
         py.allow_threads(|| {
-            if let Ok(mut subscription) = self.subscription.lock() {
-                subscription.take();
+            if let Ok(mut subscription) = self.subscription.lock()
+                && let Some(subscription) = subscription.take()
+            {
+                self.final_dropped_count
+                    .store(subscription.dropped_count(), Ordering::Relaxed);
             }
         });
     }
@@ -133,15 +140,12 @@ impl NativeEventSubscription {
     #[getter]
     fn dropped_count(&self, py: Python<'_>) -> u64 {
         py.allow_threads(|| {
-            self.subscription
-                .lock()
-                .ok()
-                .and_then(|subscription| {
-                    subscription
-                        .as_ref()
-                        .map(|subscription| subscription.dropped_count())
-                })
-                .unwrap_or(0)
+            let current = self.subscription.lock().ok().and_then(|subscription| {
+                subscription
+                    .as_ref()
+                    .map(|subscription| subscription.dropped_count())
+            });
+            current.unwrap_or_else(|| self.final_dropped_count.load(Ordering::Relaxed))
         })
     }
 }
@@ -192,10 +196,6 @@ impl EventCallbackSink {
         });
         spawn_event_callback_dispatcher(receiver, callback, batch_size, progress);
         sink
-    }
-
-    fn flush(&self) {
-        self.progress.flush();
     }
 }
 
@@ -256,7 +256,8 @@ fn subscribe_event_callback(
         .subscribe(callback_sink.clone(), queue_capacity.max(1));
     Ok(NativeEventSubscription {
         subscription: Arc::new(Mutex::new(Some(Arc::new(subscription)))),
-        callback: callback_sink,
+        progress: callback_sink.progress.clone(),
+        final_dropped_count: AtomicU64::new(0),
     })
 }
 

--- a/src/sdk/python/native/src/lib.rs
+++ b/src/sdk/python/native/src/lib.rs
@@ -117,7 +117,7 @@ impl NativeEventSubscription {
         });
     }
 
-    /// Stop future delivery. Already-running callback work is best-effort.
+    /// Stop accepting new events. Envelopes already queued still drain.
     fn unsubscribe(&self) {
         if let Ok(mut subscription) = self.subscription.lock() {
             subscription.take();
@@ -283,7 +283,10 @@ fn dispatch_event_callbacks(
         let _ = Python::with_gil(|py| -> PyResult<()> {
             let batch = PyList::empty(py);
             for envelope in envelopes {
-                batch.append(pythonize::pythonize(py, &envelope)?)?;
+                let Ok(value) = pythonize::pythonize(py, &envelope) else {
+                    continue;
+                };
+                batch.append(value)?;
             }
             callback.call1(py, (batch,))?;
             Ok(())

--- a/src/sdk/python/native/src/lib.rs
+++ b/src/sdk/python/native/src/lib.rs
@@ -76,7 +76,7 @@ fn trace_event_context(context: Option<&Bound<'_, PyAny>>) -> PyResult<core::Tra
 /// Handle for one private native runtime-event callback subscription.
 #[pyclass]
 struct NativeEventSubscription {
-    subscription: Arc<Mutex<Option<core::FanoutSubscription>>>,
+    subscription: Arc<Mutex<Option<Arc<core::FanoutSubscription>>>>,
     callback: Arc<EventCallbackSink>,
 }
 
@@ -108,9 +108,12 @@ impl NativeEventSubscription {
     /// Wait without the GIL until accepted callback work has completed.
     fn flush(&self, py: Python<'_>) {
         py.allow_threads(|| {
-            if let Ok(subscription) = self.subscription.lock()
-                && let Some(subscription) = subscription.as_ref()
-            {
+            let subscription = self
+                .subscription
+                .lock()
+                .ok()
+                .and_then(|subscription| subscription.clone());
+            if let Some(subscription) = subscription {
                 subscription.flush();
             }
             self.callback.flush();
@@ -118,24 +121,28 @@ impl NativeEventSubscription {
     }
 
     /// Stop accepting new events. Envelopes already queued still drain.
-    fn unsubscribe(&self) {
-        if let Ok(mut subscription) = self.subscription.lock() {
-            subscription.take();
-        }
+    fn unsubscribe(&self, py: Python<'_>) {
+        py.allow_threads(|| {
+            if let Ok(mut subscription) = self.subscription.lock() {
+                subscription.take();
+            }
+        });
     }
 
     /// Number of envelopes displaced by this subscriber's bounded queue.
     #[getter]
-    fn dropped_count(&self) -> u64 {
-        self.subscription
-            .lock()
-            .ok()
-            .and_then(|subscription| {
-                subscription
-                    .as_ref()
-                    .map(core::FanoutSubscription::dropped_count)
-            })
-            .unwrap_or(0)
+    fn dropped_count(&self, py: Python<'_>) -> u64 {
+        py.allow_threads(|| {
+            self.subscription
+                .lock()
+                .ok()
+                .and_then(|subscription| {
+                    subscription
+                        .as_ref()
+                        .map(|subscription| subscription.dropped_count())
+                })
+                .unwrap_or(0)
+        })
     }
 }
 
@@ -248,7 +255,7 @@ fn subscribe_event_callback(
         .fanout
         .subscribe(callback_sink.clone(), queue_capacity.max(1));
     Ok(NativeEventSubscription {
-        subscription: Arc::new(Mutex::new(Some(subscription))),
+        subscription: Arc::new(Mutex::new(Some(Arc::new(subscription)))),
         callback: callback_sink,
     })
 }

--- a/src/sdk/python/pyproject.toml
+++ b/src/sdk/python/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = ["ratel-ai-telemetry>=0.1.3"]
 [project.optional-dependencies]
 # register_mcp_server() ingests upstream MCP servers via the official client.
 # Lazily imported, so the base SDK installs without it. Requires Python >=3.10.
-mcp = ["mcp>=1.0"]
+mcp = ["mcp>=1.0; python_version >= '3.10'"]
 # OpenTelemetry export of the ratel.*/gen_ai.* funnel (ADR-0007). The base install
 # already carries the OTel-free vocabulary above; this extra adds the OTLP exporter +
 # OpenTelemetry SDK so configure_telemetry() can ship traces and Logs to Ratel Cloud.

--- a/src/sdk/python/ratel_ai/__init__.py
+++ b/src/sdk/python/ratel_ai/__init__.py
@@ -61,6 +61,7 @@ from .exceptions import (
     IncompatibleMergeError,
 )
 from .mcp import McpServerHandle, McpToolsListError, register_mcp_server
+from .runtime_events import RuntimeCatalog
 from .skill_catalog import PendingReplace, ReplaceOutcome, Skill, SkillCatalog, SkillRegistry
 from .skill_tools import GET_SKILL_CONTENT_ID, get_skill_content_tool
 
@@ -96,6 +97,7 @@ __all__ = [
     "OllamaEmbeddingConfig",
     "PendingReplace",
     "ReplaceOutcome",
+    "RuntimeCatalog",
     "SearchHit",
     "SearchMethod",
     "SearchOrigin",

--- a/src/sdk/python/ratel_ai/__init__.py
+++ b/src/sdk/python/ratel_ai/__init__.py
@@ -9,6 +9,8 @@ Mirrors the public surface of the TypeScript SDK (`@ratel-ai/sdk`):
 - `search_capabilities_tool` / `invoke_tool_tool` / `get_skill_content_tool` —
   framework-neutral capability tools.
 - `register_mcp_server` — ingest an upstream MCP server's tools (extra: mcp).
+- `RuntimeEvents` / `RuntimeCatalog` — subscribe to runtime facts and snapshot
+  executor-free tool/skill state (ADR-0019; no Python Cloud transport).
 
 The facts/grounding surface (`FactCatalog` / `Fact`, the push-path grounding
 analogue: constant content injected into the context, gated by the pure
@@ -67,7 +69,10 @@ from .runtime_events import (
     RUNTIME_EVENT_MAX_QUERY_BYTES,
     RUNTIME_EVENT_TYPES,
     RuntimeCatalog,
+    RuntimeEvent,
+    RuntimeEventHandler,
     RuntimeEvents,
+    RuntimeEventSubscription,
 )
 from .skill_catalog import PendingReplace, ReplaceOutcome, Skill, SkillCatalog, SkillRegistry
 from .skill_tools import GET_SKILL_CONTENT_ID, get_skill_content_tool
@@ -105,6 +110,9 @@ __all__ = [
     "PendingReplace",
     "ReplaceOutcome",
     "RuntimeCatalog",
+    "RuntimeEvent",
+    "RuntimeEventHandler",
+    "RuntimeEventSubscription",
     "RuntimeEvents",
     "RUNTIME_EVENT_MAX_HITS",
     "RUNTIME_EVENT_MAX_PAYLOAD_BYTES",

--- a/src/sdk/python/ratel_ai/__init__.py
+++ b/src/sdk/python/ratel_ai/__init__.py
@@ -10,7 +10,7 @@ Mirrors the public surface of the TypeScript SDK (`@ratel-ai/sdk`):
   framework-neutral capability tools.
 - `register_mcp_server` — ingest an upstream MCP server's tools (extra: mcp).
 - `RuntimeEvents` / `RuntimeCatalog` — subscribe to runtime facts and snapshot
-  executor-free tool/skill state (ADR-0019; no Python Cloud transport).
+  executor-free tool/skill state (ADR-0020; no Python Cloud transport).
 
 The facts/grounding surface (`FactCatalog` / `Fact`, the push-path grounding
 analogue: constant content injected into the context, gated by the pure

--- a/src/sdk/python/ratel_ai/__init__.py
+++ b/src/sdk/python/ratel_ai/__init__.py
@@ -61,7 +61,14 @@ from .exceptions import (
     IncompatibleMergeError,
 )
 from .mcp import McpServerHandle, McpToolsListError, register_mcp_server
-from .runtime_events import RuntimeCatalog
+from .runtime_events import (
+    RUNTIME_EVENT_MAX_HITS,
+    RUNTIME_EVENT_MAX_PAYLOAD_BYTES,
+    RUNTIME_EVENT_MAX_QUERY_BYTES,
+    RUNTIME_EVENT_TYPES,
+    RuntimeCatalog,
+    RuntimeEvents,
+)
 from .skill_catalog import PendingReplace, ReplaceOutcome, Skill, SkillCatalog, SkillRegistry
 from .skill_tools import GET_SKILL_CONTENT_ID, get_skill_content_tool
 
@@ -98,6 +105,11 @@ __all__ = [
     "PendingReplace",
     "ReplaceOutcome",
     "RuntimeCatalog",
+    "RuntimeEvents",
+    "RUNTIME_EVENT_MAX_HITS",
+    "RUNTIME_EVENT_MAX_PAYLOAD_BYTES",
+    "RUNTIME_EVENT_MAX_QUERY_BYTES",
+    "RUNTIME_EVENT_TYPES",
     "SearchHit",
     "SearchMethod",
     "SearchOrigin",

--- a/src/sdk/python/ratel_ai/_native.pyi
+++ b/src/sdk/python/ratel_ai/_native.pyi
@@ -160,7 +160,13 @@ class ToolRegistry:
         Model-free and infallible; the trace event records origin "direct".
         """
 
-    def search_with_origin(self, query: str, top_k: int, origin: str) -> list[SearchHit]:
+    def search_with_origin(
+        self,
+        query: str,
+        top_k: int,
+        origin: str,
+        context: object | None = ...,
+    ) -> list[SearchHit]:
         """BM25 search tagged with who initiated it.
 
         `origin` is "agent" (a model calling a capability tool) or anything
@@ -169,7 +175,12 @@ class ToolRegistry:
         """
 
     def _search_with_method(
-        self, query: str, top_k: int, origin: str, method: str
+        self,
+        query: str,
+        top_k: int,
+        origin: str,
+        method: str,
+        context: object | None = ...,
     ) -> list[SearchHit]:
         """Search with an explicit method ("bm25" | "semantic" | "hybrid").
 
@@ -202,6 +213,11 @@ class ToolRegistry:
         shapes (ADR-0007, e.g. `{"type": "gateway_search", ...}`); anything
         else raises `ValueError`.
         """
+
+    def record_event_with_context(
+        self, event: dict[str, Any], context: object
+    ) -> None:
+        """Record an event with caller-supplied identity and OTel correlation."""
 
     def subscribe_trace_events(
         self,
@@ -389,11 +405,22 @@ class SkillRegistry:
     def search(self, query: str, top_k: int) -> list[SkillHit]:
         """Lexical BM25 search over the skill corpus — see `ToolRegistry.search`."""
 
-    def search_with_origin(self, query: str, top_k: int, origin: str) -> list[SkillHit]:
+    def search_with_origin(
+        self,
+        query: str,
+        top_k: int,
+        origin: str,
+        context: object | None = ...,
+    ) -> list[SkillHit]:
         """BM25 search tagged with who initiated it — see `ToolRegistry.search_with_origin`."""
 
     def _search_with_method(
-        self, query: str, top_k: int, origin: str, method: str
+        self,
+        query: str,
+        top_k: int,
+        origin: str,
+        method: str,
+        context: object | None = ...,
     ) -> list[SkillHit]:
         """Private worker-thread search primitive."""
 
@@ -411,6 +438,11 @@ class SkillRegistry:
 
     def record_event(self, event: dict[str, Any]) -> None:
         """Record an SDK-layer trace event — see `ToolRegistry.record_event`."""
+
+    def record_event_with_context(
+        self, event: dict[str, Any], context: object
+    ) -> None:
+        """Record an event with caller-supplied identity and OTel correlation."""
 
     def subscribe_trace_events(
         self,

--- a/src/sdk/python/ratel_ai/_native.pyi
+++ b/src/sdk/python/ratel_ai/_native.pyi
@@ -6,6 +6,7 @@ native layer is a pure pass-through over `ratel-ai-core`; the ergonomic SDK
 surface lives in the pure Python modules of this package.
 """
 
+from collections.abc import Callable
 from typing import Any
 
 class SearchHit:
@@ -96,6 +97,19 @@ class IntentGraph:
         and a stored graph whose ``rev`` is higher than the one you loaded was
         written by another process (stale-base detection).
         """
+
+class NativeEventSubscription:
+    """Private handle for one native runtime-event callback subscription."""
+
+    def flush(self) -> None:
+        """Wait without the GIL until accepted callback work has completed."""
+
+    def unsubscribe(self) -> None:
+        """Stop future delivery; already-running callback work is best-effort."""
+
+    @property
+    def dropped_count(self) -> int:
+        """Envelopes displaced by this subscriber's bounded queue."""
 
 class ToolRegistry:
     """Private native metadata registry over `ratel-ai-core`.
@@ -188,6 +202,16 @@ class ToolRegistry:
         shapes (ADR-0007, e.g. `{"type": "gateway_search", ...}`); anything
         else raises `ValueError`.
         """
+
+    def subscribe_trace_events(
+        self,
+        callback: Callable[[list[dict[str, Any]]], object],
+        session_id: str,
+        source_id: str | None = ...,
+        queue_capacity: int = ...,
+        batch_size: int = ...,
+    ) -> NativeEventSubscription:
+        """Attach the private GIL-safe, batched runtime-event callback seam."""
 
     def set_trace_sink(
         self,
@@ -387,6 +411,16 @@ class SkillRegistry:
 
     def record_event(self, event: dict[str, Any]) -> None:
         """Record an SDK-layer trace event — see `ToolRegistry.record_event`."""
+
+    def subscribe_trace_events(
+        self,
+        callback: Callable[[list[dict[str, Any]]], object],
+        session_id: str,
+        source_id: str | None = ...,
+        queue_capacity: int = ...,
+        batch_size: int = ...,
+    ) -> NativeEventSubscription:
+        """Attach the private GIL-safe, batched runtime-event callback seam."""
 
     def set_trace_sink(
         self,

--- a/src/sdk/python/ratel_ai/_native.pyi
+++ b/src/sdk/python/ratel_ai/_native.pyi
@@ -105,7 +105,7 @@ class NativeEventSubscription:
         """Wait without the GIL until accepted callback work has completed."""
 
     def unsubscribe(self) -> None:
-        """Stop future delivery; already-running callback work is best-effort."""
+        """Stop accepting new events; already-queued envelopes still drain."""
 
     @property
     def dropped_count(self) -> int:

--- a/src/sdk/python/ratel_ai/capabilities.py
+++ b/src/sdk/python/ratel_ai/capabilities.py
@@ -407,9 +407,10 @@ def invoke_tool_tool(
                     maybe = on_unauthorized(upstream)
                     if inspect.isawaitable(maybe):
                         await maybe
-                record_auth_needed(upstream)
+                projection = record_auth_needed(upstream)
                 catalog.record_event(
-                    {"type": "gateway_error", "tool_id": tool_id, "error": "needs_auth"}
+                    {"type": "gateway_error", "tool_id": tool_id, "error": "needs_auth"},
+                    projection,
                 )
                 payload: dict[str, Any] = {
                     "error": "needs_auth",

--- a/src/sdk/python/ratel_ai/catalog.py
+++ b/src/sdk/python/ratel_ai/catalog.py
@@ -14,12 +14,12 @@ import json
 import threading
 import time
 import warnings
-from collections.abc import Awaitable, Iterable
+from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
-from typing import Any, Callable, Literal, TypedDict, TypeVar, Union, overload
+from typing import Any, Literal, TypedDict, TypeVar, Union, overload
 
 from ._native import IntentGraph as IntentGraph  # re-exported for `ratel_ai.IntentGraph`
-from ._native import SearchHit
+from ._native import NativeEventSubscription, SearchHit
 from ._native import ToolRegistry as _NativeToolRegistry
 from .embedding_artifact import (
     ExperimentalEmbeddingArtifact,
@@ -553,6 +553,26 @@ class ToolRegistry:
         """Record an SDK-layer trace event."""
         self._native.record_event(event)
 
+    def subscribe_events(
+        self,
+        handler: Callable[[list[dict[str, Any]]], object],
+        *,
+        session_id: str,
+        source_id: str,
+        queue_capacity: int = 1_024,
+        batch_size: int = 64,
+    ) -> NativeEventSubscription:
+        """Attach one public batched runtime-event subscriber."""
+        with self._dense_state:
+            self._raise_if_busy()
+            return self._native.subscribe_trace_events(
+                handler,
+                session_id,
+                source_id,
+                queue_capacity,
+                batch_size,
+            )
+
     def set_trace_sink(
         self, kind: str, session_id: str | None = None, path: str | None = None
     ) -> None:
@@ -935,6 +955,24 @@ class ToolCatalog:
             ValueError: if the dict doesn't match any known event shape.
         """
         self._registry.record_event(event)
+
+    def subscribe_events(
+        self,
+        handler: Callable[[list[dict[str, Any]]], object],
+        *,
+        session_id: str,
+        source_id: str,
+        queue_capacity: int = 1_024,
+        batch_size: int = 64,
+    ) -> NativeEventSubscription:
+        """Attach one public runtime-event subscriber."""
+        return self._registry.subscribe_events(
+            handler,
+            session_id=session_id,
+            source_id=source_id,
+            queue_capacity=queue_capacity,
+            batch_size=batch_size,
+        )
 
     def experimental_enable_adaptive_ranking(
         self,

--- a/src/sdk/python/ratel_ai/catalog.py
+++ b/src/sdk/python/ratel_ai/catalog.py
@@ -1071,6 +1071,7 @@ class ToolCatalog:
 
         Raises:
             ValueError: if `tool_id` is not registered.
+            asyncio.CancelledError: after recording a cancelled `invoke_error`.
             Exception: whatever the handler raises, re-raised after an
                 `invoke_error` trace event is recorded.
         """
@@ -1105,6 +1106,19 @@ class ToolCatalog:
                     terminal_projection,
                 )
                 return result
+            except asyncio.CancelledError as err:
+                terminal_projection = projection.copy()
+                terminal_projection["event_id"] = new_runtime_event_id()
+                self._registry.record_event(
+                    {
+                        "type": "invoke_error",
+                        "tool_id": tool_id,
+                        "took_ms": _elapsed_ms(started),
+                        "error": _error_message(err),
+                    },
+                    terminal_projection,
+                )
+                raise
             except Exception as err:
                 terminal_projection = projection.copy()
                 terminal_projection["event_id"] = new_runtime_event_id()

--- a/src/sdk/python/ratel_ai/catalog.py
+++ b/src/sdk/python/ratel_ai/catalog.py
@@ -26,7 +26,14 @@ from .embedding_artifact import (
     OnArtifactMiss,
     resolve_embedding_artifact,
 )
-from .telemetry import SEARCH_TARGET_TOOL, trace_execute_tool, trace_search, trace_search_async
+from .runtime_events import new_runtime_event_id
+from .telemetry import (
+    SEARCH_TARGET_TOOL,
+    RuntimeEventProjection,
+    trace_execute_tool,
+    trace_search,
+    trace_search_async,
+)
 
 Executor = Callable[[dict[str, Any]], Union[Awaitable[Any], Any]]
 """A tool handler: takes the tool's arguments dict, returns the result.
@@ -434,9 +441,15 @@ class ToolRegistry:
         """Run synchronous, model-free BM25 retrieval."""
         return self._native.search(query, top_k)
 
-    def search_with_origin(self, query: str, top_k: int, origin: SearchOrigin) -> list[SearchHit]:
+    def search_with_origin(
+        self,
+        query: str,
+        top_k: int,
+        origin: SearchOrigin,
+        projection: RuntimeEventProjection | None = None,
+    ) -> list[SearchHit]:
         """Run BM25 retrieval with an explicit trace origin."""
-        return self._native.search_with_origin(query, top_k, origin)
+        return self._native.search_with_origin(query, top_k, origin, projection)
 
     def search_with_method(
         self, query: str, top_k: int, origin: SearchOrigin, method: SearchMethod
@@ -536,22 +549,30 @@ class ToolRegistry:
         top_k: int,
         origin: SearchOrigin = "direct",
         method: SearchMethod = "bm25",
+        projection: RuntimeEventProjection | None = None,
     ) -> list[SearchHit]:
         """Search immediately with BM25 or run dense retrieval on a worker thread."""
         if method not in ("bm25", "semantic", "hybrid"):
             raise ValueError(f"unknown search method: {method}")
         if method == "bm25":
-            return self.search_with_origin(query, top_k, origin)
+            return self.search_with_origin(query, top_k, origin, projection)
         if self._undriven_builds > 0:
             raise RuntimeError(_UNAWAITED_REGISTER)
         await self._maybe_rebuild_on_model_change()
         return await self._run_dense(
-            lambda: self._native._search_with_method(query, top_k, origin, method)
+            lambda: self._native._search_with_method(query, top_k, origin, method, projection)
         )
 
-    def record_event(self, event: dict[str, Any]) -> None:
+    def record_event(
+        self,
+        event: dict[str, Any],
+        projection: RuntimeEventProjection | None = None,
+    ) -> None:
         """Record an SDK-layer trace event."""
-        self._native.record_event(event)
+        if projection is None:
+            self._native.record_event(event)
+        else:
+            self._native.record_event_with_context(event, projection)
 
     def subscribe_events(
         self,
@@ -884,7 +905,9 @@ class ToolCatalog:
             query,
             top_k,
             origin,
-            lambda: self._registry.search_with_origin(query, top_k, origin),
+            lambda projection: self._registry.search_with_origin(
+                query, top_k, origin, projection
+            ),
         )
 
     async def search_async(
@@ -905,7 +928,9 @@ class ToolCatalog:
             query,
             top_k,
             origin,
-            lambda: self._registry.search_async(query, top_k, origin, resolved_method),
+            lambda projection: self._registry.search_async(
+                query, top_k, origin, resolved_method, projection
+            ),
         )
 
     def has(self, tool_id: str) -> bool:
@@ -944,17 +969,22 @@ class ToolCatalog:
             execute=execute,
         )
 
-    def record_event(self, event: dict[str, Any]) -> None:
+    def record_event(
+        self,
+        event: dict[str, Any],
+        projection: RuntimeEventProjection | None = None,
+    ) -> None:
         """Record a trace event into the catalog's sink.
 
         Args:
             event: a dict matching one of the core-owned `TraceEvent` shapes
                 (ADR-0007), e.g. `{"type": "gateway_search", ...}`.
+            projection: optional event identity and OTel correlation shared with the envelope.
 
         Raises:
             ValueError: if the dict doesn't match any known event shape.
         """
-        self._registry.record_event(event)
+        self._registry.record_event(event, projection)
 
     def subscribe_events(
         self,
@@ -1048,13 +1078,14 @@ class ToolCatalog:
         if fn is None:
             raise ValueError(f"unknown toolId: {tool_id}")
 
-        async def _run() -> Any:
+        async def _run(projection: RuntimeEventProjection) -> Any:
             self._registry.record_event(
                 {
                     "type": "invoke_start",
                     "tool_id": tool_id,
                     "args_size_bytes": _args_size_bytes(args),
-                }
+                },
+                projection,
             )
             started = time.monotonic()
             try:
@@ -1063,22 +1094,28 @@ class ToolCatalog:
                 result = fn(args)
                 if inspect.isawaitable(result):
                     result = await result
+                terminal_projection = projection.copy()
+                terminal_projection["event_id"] = new_runtime_event_id()
                 self._registry.record_event(
                     {
                         "type": "invoke_end",
                         "tool_id": tool_id,
                         "took_ms": _elapsed_ms(started),
-                    }
+                    },
+                    terminal_projection,
                 )
                 return result
             except Exception as err:
+                terminal_projection = projection.copy()
+                terminal_projection["event_id"] = new_runtime_event_id()
                 self._registry.record_event(
                     {
                         "type": "invoke_error",
                         "tool_id": tool_id,
                         "took_ms": _elapsed_ms(started),
                         "error": _error_message(err),
-                    }
+                    },
+                    terminal_projection,
                 )
                 raise
 

--- a/src/sdk/python/ratel_ai/catalog.py
+++ b/src/sdk/python/ratel_ai/catalog.py
@@ -8,6 +8,7 @@ layers executable handlers on top and emits the same trace events the TS SDK doe
 from __future__ import annotations
 
 import asyncio
+import copy
 import inspect
 import json
 import threading
@@ -894,6 +895,19 @@ class ToolCatalog:
     def get(self, tool_id: str) -> Tool | None:
         """Return the metadata-only `Tool` for an id, or `None` if unknown."""
         return self._tools.get(tool_id)
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        """Return the complete deterministic executor-free tool definitions."""
+        return [
+            {
+                "id": tool.id,
+                "name": tool.name,
+                "description": tool.description,
+                "input_schema": copy.deepcopy(tool.input_schema),
+                "output_schema": copy.deepcopy(tool.output_schema),
+            }
+            for tool in sorted(self._tools.values(), key=lambda item: item.id)
+        ]
 
     def get_executable(self, tool_id: str) -> ExecutableTool | None:
         """Return the `ExecutableTool` (metadata plus handler) for an id, or `None`."""

--- a/src/sdk/python/ratel_ai/fact_catalog.py
+++ b/src/sdk/python/ratel_ai/fact_catalog.py
@@ -559,7 +559,7 @@ class FactCatalog:
             query,
             top_k,
             origin,
-            lambda: self._registry.search_with_origin(query, top_k, origin),
+            lambda _projection: self._registry.search_with_origin(query, top_k, origin),
         )
 
     async def search_async(
@@ -579,7 +579,7 @@ class FactCatalog:
             query,
             top_k,
             origin,
-            lambda: self._registry.search_async(query, top_k, origin, resolved_method),
+            lambda _projection: self._registry.search_async(query, top_k, origin, resolved_method),
         )
 
     async def ground(

--- a/src/sdk/python/ratel_ai/mcp.py
+++ b/src/sdk/python/ratel_ai/mcp.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Literal
 
 from .catalog import ExecutableTool, ToolCatalog
-from .telemetry import trace_upstream_register
+from .telemetry import RuntimeEventProjection, trace_upstream_register
 
 _MCP_LIST_MAX_PAGES = 64
 
@@ -190,7 +190,10 @@ async def register_mcp_server(
 
     # The whole registration (list + ingest) is one `ratel.upstream.register` span;
     # per-tool invocations later get their own `execute_tool` spans (ADR-0007).
-    async def _run(report_tool_count: Callable[[int], None]) -> McpServerHandle:
+    async def _run(
+        report_tool_count: Callable[[int], None],
+        projection: RuntimeEventProjection,
+    ) -> McpServerHandle:
         tools = await _list_all_mcp_tools(session)
         report_tool_count(len(tools))
         catalog.record_event(
@@ -199,7 +202,8 @@ async def register_mcp_server(
                 "server": name,
                 "transport": transport_label,
                 "tool_count": len(tools),
-            }
+            },
+            projection,
         )
 
         tool_ids, registered = _build_registered_mcp_tools(catalog, session, name, tools)

--- a/src/sdk/python/ratel_ai/runtime_events.py
+++ b/src/sdk/python/ratel_ai/runtime_events.py
@@ -158,7 +158,9 @@ class RuntimeEvents:
                         return
                     task: asyncio.Task[None] = loop.create_task(async_handler(normalized))
                     pending.add(task)
-                    task.add_done_callback(pending.discard)
+                    task.add_done_callback(
+                        lambda finished: _finish_async_handler(finished, pending)
+                    )
 
                 loop.call_soon_threadsafe(schedule)
 
@@ -194,6 +196,16 @@ def _default_source_id() -> str:
         if separator and key == "service.name" and value:
             return value
     return "ratel"
+
+
+def _finish_async_handler(
+    task: asyncio.Task[None],
+    pending: set[asyncio.Task[None]],
+) -> None:
+    pending.discard(task)
+    if task.cancelled():
+        return
+    task.exception()
 
 
 def _normalize_runtime_event(event: RuntimeEvent) -> RuntimeEvent:

--- a/src/sdk/python/ratel_ai/runtime_events.py
+++ b/src/sdk/python/ratel_ai/runtime_events.py
@@ -182,8 +182,6 @@ class RuntimeEvents:
                 normalized = [_normalize_runtime_event(event) for event in batch]
 
                 def schedule() -> None:
-                    if not active[0]:
-                        return
                     schedule_awaitable(async_handler(normalized))
 
                 loop.call_soon_threadsafe(schedule)
@@ -191,8 +189,6 @@ class RuntimeEvents:
         else:
 
             def deliver(batch: list[RuntimeEvent]) -> None:
-                if not active[0]:
-                    return
                 try:
                     result = handler([_normalize_runtime_event(event) for event in batch])
                     if inspect.isawaitable(result):

--- a/src/sdk/python/ratel_ai/runtime_events.py
+++ b/src/sdk/python/ratel_ai/runtime_events.py
@@ -7,8 +7,10 @@ import inspect
 import json
 import os
 import secrets
+import threading
 import time
 import uuid
+import warnings
 from collections.abc import Awaitable, Callable, Coroutine, Sequence
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
@@ -84,6 +86,38 @@ class _EventSource(Protocol):
     ) -> NativeEventSubscription: ...
 
 
+class _SubscriptionState:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._active = True
+        self._dropped_count = 0
+        self._warned_closed_loop = False
+
+    def unsubscribe(self) -> bool:
+        with self._lock:
+            if not self._active:
+                return False
+            self._active = False
+            return True
+
+    def record_closed_loop_drop(self, count: int) -> None:
+        with self._lock:
+            self._dropped_count += count
+            warn = not self._warned_closed_loop
+            self._warned_closed_loop = True
+        if warn:
+            warnings.warn(
+                "runtime events dropped because the async handler's event loop is closed",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+    @property
+    def dropped_count(self) -> int:
+        with self._lock:
+            return self._dropped_count
+
+
 class RuntimeEventSubscription:
     """Handle over one merged bounded runtime-event subscription."""
 
@@ -91,12 +125,12 @@ class RuntimeEventSubscription:
         self,
         subscriptions: list[NativeEventSubscription],
         pending: set[asyncio.Future[None]],
-        active: list[bool],
+        state: _SubscriptionState,
     ) -> None:
         """Create a subscription over native handles and pending handler work."""
         self._subscriptions = subscriptions
         self._pending = pending
-        self._active = active
+        self._state = state
 
     async def flush(self) -> None:
         """Wait until accepted native and async-handler work completes."""
@@ -110,16 +144,18 @@ class RuntimeEventSubscription:
 
     def unsubscribe(self) -> None:
         """Stop accepting new events; already-queued native envelopes still drain."""
-        if not self._active[0]:
+        if not self._state.unsubscribe():
             return
-        self._active[0] = False
         for subscription in self._subscriptions:
             subscription.unsubscribe()
 
     @property
     def dropped_count(self) -> int:
-        """Envelopes displaced by this subscriber's native queues."""
-        return sum(subscription.dropped_count for subscription in self._subscriptions)
+        """Envelopes lost to native overflow or a closed async-handler loop."""
+        native_dropped = sum(
+            subscription.dropped_count for subscription in self._subscriptions
+        )
+        return native_dropped + self._state.dropped_count
 
 
 class RuntimeEvents:
@@ -143,7 +179,7 @@ class RuntimeEvents:
 
     def subscribe(self, handler: RuntimeEventHandler) -> RuntimeEventSubscription:
         """Subscribe to bounded asynchronous runtime-event batches."""
-        active = [True]
+        state = _SubscriptionState()
         pending: set[asyncio.Future[None]] = set()
         try:
             loop: asyncio.AbstractEventLoop | None = asyncio.get_running_loop()
@@ -171,7 +207,10 @@ class RuntimeEvents:
             if on_target_loop:
                 schedule()
             else:
-                loop.call_soon_threadsafe(schedule)
+                if not _schedule_on_loop(loop, schedule, state, 1):
+                    close = getattr(awaitable, "close", None)
+                    if callable(close):
+                        close()
 
         if inspect.iscoroutinefunction(handler):
             if loop is None:
@@ -184,7 +223,7 @@ class RuntimeEvents:
                 def schedule() -> None:
                     schedule_awaitable(async_handler(normalized))
 
-                loop.call_soon_threadsafe(schedule)
+                _schedule_on_loop(loop, schedule, state, len(normalized))
 
         else:
 
@@ -206,7 +245,26 @@ class RuntimeEvents:
             )
             for source in self._sources
         ]
-        return RuntimeEventSubscription(subscriptions, pending, active)
+        return RuntimeEventSubscription(subscriptions, pending, state)
+
+
+def _schedule_on_loop(
+    loop: asyncio.AbstractEventLoop,
+    callback: Callable[[], None],
+    state: _SubscriptionState,
+    dropped_count: int,
+) -> bool:
+    if loop.is_closed():
+        state.record_closed_loop_drop(dropped_count)
+        return False
+    try:
+        loop.call_soon_threadsafe(callback)
+    except RuntimeError:
+        if not loop.is_closed():
+            raise
+        state.record_closed_loop_drop(dropped_count)
+        return False
+    return True
 
 
 def _default_source_id() -> str:

--- a/src/sdk/python/ratel_ai/runtime_events.py
+++ b/src/sdk/python/ratel_ai/runtime_events.py
@@ -173,7 +173,15 @@ class RuntimeEvents:
         queue_capacity: int = 1_024,
         batch_size: int = 64,
     ) -> None:
-        """Create a stream sharing one identity across all event sources."""
+        """Create a stream sharing one identity across all event sources.
+
+        ``source_id`` defaults to the env-var-configured OTel ``service.name``
+        (``OTEL_SERVICE_NAME``, then ``service.name`` in
+        ``OTEL_RESOURCE_ATTRIBUTES``), falling back to ``"ratel"``. A
+        programmatically configured OTel resource — including
+        ``configure_telemetry(service_name=...)`` — is not read; pass
+        ``source_id`` explicitly in that case.
+        """
         self.session_id = session_id or str(uuid.uuid4())
         self.source_id = source_id or _default_source_id()
         self._sources = tuple(sources)

--- a/src/sdk/python/ratel_ai/runtime_events.py
+++ b/src/sdk/python/ratel_ai/runtime_events.py
@@ -109,7 +109,7 @@ class RuntimeEventSubscription:
             await asyncio.sleep(0)
 
     def unsubscribe(self) -> None:
-        """Stop accepting future events; already-running work is best-effort."""
+        """Stop accepting new events; already-queued native envelopes still drain."""
         if not self._active[0]:
             return
         self._active[0] = False

--- a/src/sdk/python/ratel_ai/runtime_events.py
+++ b/src/sdk/python/ratel_ai/runtime_events.py
@@ -238,16 +238,25 @@ class RuntimeEvents:
                 except Exception:
                     pass
 
-        subscriptions = [
-            source.subscribe_events(
-                deliver,
-                session_id=self.session_id,
-                source_id=self.source_id,
-                queue_capacity=self._queue_capacity,
-                batch_size=self._batch_size,
-            )
-            for source in self._sources
-        ]
+        # Subscribe incrementally so a later source's failure explicitly unwinds the
+        # native handles already granted (newest first), mirroring the TS SDK rather
+        # than leaving the rollback to garbage collection.
+        subscriptions: list[NativeEventSubscription] = []
+        try:
+            for source in self._sources:
+                subscriptions.append(
+                    source.subscribe_events(
+                        deliver,
+                        session_id=self.session_id,
+                        source_id=self.source_id,
+                        queue_capacity=self._queue_capacity,
+                        batch_size=self._batch_size,
+                    )
+                )
+        except BaseException:
+            for subscription in reversed(subscriptions):
+                subscription.unsubscribe()
+            raise
         return RuntimeEventSubscription(subscriptions, pending, state)
 
 

--- a/src/sdk/python/ratel_ai/runtime_events.py
+++ b/src/sdk/python/ratel_ai/runtime_events.py
@@ -2,11 +2,266 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+import asyncio
+import inspect
+import json
+import os
+import uuid
+from collections.abc import Awaitable, Callable, Coroutine, Sequence
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+from ._native import NativeEventSubscription
 
 if TYPE_CHECKING:
     from .catalog import ToolCatalog
     from .skill_catalog import SkillCatalog
+
+RuntimeEvent = dict[str, Any]
+RuntimeEventHandler = Callable[[list[RuntimeEvent]], None | Awaitable[None]]
+
+RUNTIME_EVENT_TYPES = (
+    "search",
+    "skill_search",
+    "gateway_search",
+    "invoke_start",
+    "invoke_end",
+    "invoke_error",
+    "gateway_invoke",
+    "gateway_error",
+    "skill_invoke",
+    "index_churn",
+    "skill_churn",
+    "upstream_register",
+    "upstream_invoke",
+    "upstream_error",
+    "auth_refresh",
+    "auth_needs",
+    "auth_flow_start",
+    "auth_flow_end",
+    "experiment_selection",
+    "experiment_results",
+    "experiment_comparison",
+    "experiment_skip",
+    "experiment_fallback",
+    "experiment_drop",
+    "experiment_invocation",
+    "experiment_outcome",
+    "events_dropped",
+)
+RUNTIME_EVENT_MAX_PAYLOAD_BYTES = 64 * 1_024
+RUNTIME_EVENT_MAX_QUERY_BYTES = 4 * 1_024
+RUNTIME_EVENT_MAX_HITS = 100
+
+_REQUIRED_ENVELOPE_FIELDS = {"v", "event_id", "ts", "session_id", "source_id", "type"}
+
+
+class _EventSource(Protocol):
+    def subscribe_events(
+        self,
+        handler: Callable[[list[RuntimeEvent]], object],
+        *,
+        session_id: str,
+        source_id: str,
+        queue_capacity: int,
+        batch_size: int,
+    ) -> NativeEventSubscription: ...
+
+
+class RuntimeEventSubscription:
+    """Handle over one merged bounded runtime-event subscription."""
+
+    def __init__(
+        self,
+        subscriptions: list[NativeEventSubscription],
+        pending: set[asyncio.Task[None]],
+        active: list[bool],
+    ) -> None:
+        """Create a subscription over native handles and pending handler work."""
+        self._subscriptions = subscriptions
+        self._pending = pending
+        self._active = active
+
+    async def flush(self) -> None:
+        """Wait until accepted native and async-handler work completes."""
+        await asyncio.gather(
+            *(asyncio.to_thread(subscription.flush) for subscription in self._subscriptions)
+        )
+        await asyncio.sleep(0)
+        while self._pending:
+            await asyncio.gather(*tuple(self._pending), return_exceptions=True)
+            await asyncio.sleep(0)
+
+    def unsubscribe(self) -> None:
+        """Stop accepting future events; already-running work is best-effort."""
+        if not self._active[0]:
+            return
+        self._active[0] = False
+        for subscription in self._subscriptions:
+            subscription.unsubscribe()
+
+    @property
+    def dropped_count(self) -> int:
+        """Envelopes displaced by this subscriber's native queues."""
+        return sum(subscription.dropped_count for subscription in self._subscriptions)
+
+
+class RuntimeEvents:
+    """Merged push stream over tool and skill catalogs."""
+
+    def __init__(
+        self,
+        sources: Sequence[_EventSource],
+        *,
+        session_id: str | None = None,
+        source_id: str | None = None,
+        queue_capacity: int = 1_024,
+        batch_size: int = 64,
+    ) -> None:
+        """Create a stream sharing one identity across all event sources."""
+        self.session_id = session_id or str(uuid.uuid4())
+        self.source_id = source_id or _default_source_id()
+        self._sources = tuple(sources)
+        self._queue_capacity = queue_capacity
+        self._batch_size = batch_size
+
+    def subscribe(self, handler: RuntimeEventHandler) -> RuntimeEventSubscription:
+        """Subscribe to bounded asynchronous runtime-event batches."""
+        active = [True]
+        pending: set[asyncio.Task[None]] = set()
+
+        if inspect.iscoroutinefunction(handler):
+            loop = asyncio.get_running_loop()
+            async_handler = cast(Callable[[list[RuntimeEvent]], Coroutine[Any, Any, None]], handler)
+
+            def deliver(batch: list[RuntimeEvent]) -> None:
+                normalized = [_normalize_runtime_event(event) for event in batch]
+
+                def schedule() -> None:
+                    if not active[0]:
+                        return
+                    task: asyncio.Task[None] = loop.create_task(async_handler(normalized))
+                    pending.add(task)
+                    task.add_done_callback(pending.discard)
+
+                loop.call_soon_threadsafe(schedule)
+
+        else:
+
+            def deliver(batch: list[RuntimeEvent]) -> None:
+                if not active[0]:
+                    return
+                try:
+                    handler([_normalize_runtime_event(event) for event in batch])
+                except Exception:
+                    pass
+
+        subscriptions = [
+            source.subscribe_events(
+                deliver,
+                session_id=self.session_id,
+                source_id=self.source_id,
+                queue_capacity=self._queue_capacity,
+                batch_size=self._batch_size,
+            )
+            for source in self._sources
+        ]
+        return RuntimeEventSubscription(subscriptions, pending, active)
+
+
+def _default_source_id() -> str:
+    if service_name := os.getenv("OTEL_SERVICE_NAME"):
+        return service_name
+    attributes = os.getenv("OTEL_RESOURCE_ATTRIBUTES", "")
+    for entry in attributes.split(","):
+        key, separator, value = entry.strip().partition("=")
+        if separator and key == "service.name" and value:
+            return value
+    return "ratel"
+
+
+def _normalize_runtime_event(event: RuntimeEvent) -> RuntimeEvent:
+    normalized = cast(RuntimeEvent, _sanitize_value(event))
+    if _serialized_size(normalized) <= RUNTIME_EVENT_MAX_PAYLOAD_BYTES:
+        return normalized
+
+    for key in tuple(normalized):
+        if key not in _REQUIRED_ENVELOPE_FIELDS and not _is_product_fact_field(key):
+            del normalized[key]
+            normalized["payload_truncated"] = True
+            if _serialized_size(normalized) <= RUNTIME_EVENT_MAX_PAYLOAD_BYTES:
+                return normalized
+
+    bounded = {key: normalized[key] for key in normalized if key in _REQUIRED_ENVELOPE_FIELDS}
+    bounded["payload_truncated"] = True
+    for key, value in normalized.items():
+        if key in _REQUIRED_ENVELOPE_FIELDS or not _is_product_fact_field(key):
+            continue
+        bounded[key] = _sanitize_bounded_value(value)
+        if _serialized_size(bounded) > RUNTIME_EVENT_MAX_PAYLOAD_BYTES:
+            del bounded[key]
+    return bounded
+
+
+def _sanitize_value(value: Any, key: str = "") -> Any:
+    if isinstance(value, str):
+        limit = RUNTIME_EVENT_MAX_QUERY_BYTES if key == "query" else 4_096
+        return _truncate_utf8(value, limit)
+    if isinstance(value, list):
+        return [_sanitize_value(item) for item in value[:RUNTIME_EVENT_MAX_HITS]]
+    if isinstance(value, dict):
+        return {
+            str(child_key): _sanitize_value(child_value, str(child_key))
+            for child_key, child_value in list(value.items())[:100]
+        }
+    return value
+
+
+def _sanitize_bounded_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return _truncate_utf8(value, 512)
+    if isinstance(value, list):
+        return [_sanitize_bounded_value(item) for item in value[:RUNTIME_EVENT_MAX_HITS]]
+    if isinstance(value, dict):
+        return {
+            str(key): _sanitize_bounded_value(child)
+            for key, child in list(value.items())[:32]
+        }
+    return value
+
+
+def _truncate_utf8(value: str, max_bytes: int) -> str:
+    encoded = value.encode()
+    if len(encoded) <= max_bytes:
+        return value
+    return encoded[:max_bytes].decode(errors="ignore")
+
+
+def _serialized_size(value: Any) -> int:
+    return len(json.dumps(value, separators=(",", ":")).encode())
+
+
+def _is_product_fact_field(key: str) -> bool:
+    return key.endswith(("_id", "_ids", "_ms", "_count", "_score", "_scores")) or key in {
+        "query",
+        "target",
+        "origin",
+        "top_k",
+        "hits",
+        "outcome",
+        "error",
+        "error_class",
+        "transport",
+        "role",
+        "cold",
+        "agreement",
+        "reason",
+        "label",
+        "score",
+        "attributed",
+        "rank",
+        "turn",
+        "action",
+    }
 
 
 class RuntimeCatalog:
@@ -19,6 +274,7 @@ class RuntimeCatalog:
         *,
         source_id: str,
     ) -> None:
+        """Create a snapshot view sharing the stream's stable source identity."""
         self._tools = tools
         self._skills = skills
         self._source_id = source_id

--- a/src/sdk/python/ratel_ai/runtime_events.py
+++ b/src/sdk/python/ratel_ai/runtime_events.py
@@ -12,7 +12,7 @@ import time
 import uuid
 import warnings
 from collections.abc import Awaitable, Callable, Coroutine, Sequence
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, Optional, Protocol, cast
 
 from ._native import NativeEventSubscription
 
@@ -21,7 +21,10 @@ if TYPE_CHECKING:
     from .skill_catalog import SkillCatalog
 
 RuntimeEvent = dict[str, Any]
-RuntimeEventHandler = Callable[[list[RuntimeEvent]], None | Awaitable[None]]
+# typing.Optional, not `None | ...`: this alias evaluates at import time, and PEP 604
+# unions raise TypeError on CPython 3.9 (`from __future__ import annotations` defers
+# only annotations, never assignments).
+RuntimeEventHandler = Callable[[list[RuntimeEvent]], Optional[Awaitable[None]]]
 
 RUNTIME_EVENT_TYPES = (
     "search",

--- a/src/sdk/python/ratel_ai/runtime_events.py
+++ b/src/sdk/python/ratel_ai/runtime_events.py
@@ -1,4 +1,4 @@
-"""Public runtime-event stream and catalog snapshot seams (ADR-0019)."""
+"""Public runtime-event stream and catalog snapshot seams (ADR-0020)."""
 
 from __future__ import annotations
 

--- a/src/sdk/python/ratel_ai/runtime_events.py
+++ b/src/sdk/python/ratel_ai/runtime_events.py
@@ -90,7 +90,7 @@ class RuntimeEventSubscription:
     def __init__(
         self,
         subscriptions: list[NativeEventSubscription],
-        pending: set[asyncio.Task[None]],
+        pending: set[asyncio.Future[None]],
         active: list[bool],
     ) -> None:
         """Create a subscription over native handles and pending handler work."""
@@ -144,10 +144,38 @@ class RuntimeEvents:
     def subscribe(self, handler: RuntimeEventHandler) -> RuntimeEventSubscription:
         """Subscribe to bounded asynchronous runtime-event batches."""
         active = [True]
-        pending: set[asyncio.Task[None]] = set()
+        pending: set[asyncio.Future[None]] = set()
+        try:
+            loop: asyncio.AbstractEventLoop | None = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        def schedule_awaitable(awaitable: Awaitable[None]) -> None:
+            if loop is None:
+                close = getattr(awaitable, "close", None)
+                if callable(close):
+                    close()
+                return
+
+            def schedule() -> None:
+                future = asyncio.ensure_future(awaitable, loop=loop)
+                pending.add(future)
+                future.add_done_callback(
+                    lambda finished: _finish_async_handler(finished, pending)
+                )
+
+            try:
+                on_target_loop = asyncio.get_running_loop() is loop
+            except RuntimeError:
+                on_target_loop = False
+            if on_target_loop:
+                schedule()
+            else:
+                loop.call_soon_threadsafe(schedule)
 
         if inspect.iscoroutinefunction(handler):
-            loop = asyncio.get_running_loop()
+            if loop is None:
+                raise RuntimeError("async runtime-event handlers require a running event loop")
             async_handler = cast(Callable[[list[RuntimeEvent]], Coroutine[Any, Any, None]], handler)
 
             def deliver(batch: list[RuntimeEvent]) -> None:
@@ -156,11 +184,7 @@ class RuntimeEvents:
                 def schedule() -> None:
                     if not active[0]:
                         return
-                    task: asyncio.Task[None] = loop.create_task(async_handler(normalized))
-                    pending.add(task)
-                    task.add_done_callback(
-                        lambda finished: _finish_async_handler(finished, pending)
-                    )
+                    schedule_awaitable(async_handler(normalized))
 
                 loop.call_soon_threadsafe(schedule)
 
@@ -170,7 +194,9 @@ class RuntimeEvents:
                 if not active[0]:
                     return
                 try:
-                    handler([_normalize_runtime_event(event) for event in batch])
+                    result = handler([_normalize_runtime_event(event) for event in batch])
+                    if inspect.isawaitable(result):
+                        schedule_awaitable(result)
                 except Exception:
                     pass
 
@@ -199,8 +225,8 @@ def _default_source_id() -> str:
 
 
 def _finish_async_handler(
-    task: asyncio.Task[None],
-    pending: set[asyncio.Task[None]],
+    task: asyncio.Future[None],
+    pending: set[asyncio.Future[None]],
 ) -> None:
     pending.discard(task)
     if task.cancelled():

--- a/src/sdk/python/ratel_ai/runtime_events.py
+++ b/src/sdk/python/ratel_ai/runtime_events.py
@@ -6,6 +6,8 @@ import asyncio
 import inspect
 import json
 import os
+import secrets
+import time
 import uuid
 from collections.abc import Awaitable, Callable, Coroutine, Sequence
 from typing import TYPE_CHECKING, Any, Protocol, cast
@@ -53,6 +55,21 @@ RUNTIME_EVENT_MAX_QUERY_BYTES = 4 * 1_024
 RUNTIME_EVENT_MAX_HITS = 100
 
 _REQUIRED_ENVELOPE_FIELDS = {"v", "event_id", "ts", "session_id", "source_id", "type"}
+
+
+def new_runtime_event_id(now_ms: int | None = None) -> str:
+    """Mint a client ULID for one runtime event and OTel projection."""
+    alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+    timestamp = now_ms if now_ms is not None else int(time.time() * 1_000)
+    encoded_time = ""
+    for _ in range(10):
+        encoded_time = alphabet[timestamp % 32] + encoded_time
+        timestamp //= 32
+    entropy = int.from_bytes(secrets.token_bytes(10), "big")
+    encoded_entropy = ""
+    for shift in range(75, -1, -5):
+        encoded_entropy += alphabet[(entropy >> shift) & 31]
+    return encoded_time + encoded_entropy
 
 
 class _EventSource(Protocol):

--- a/src/sdk/python/ratel_ai/runtime_events.py
+++ b/src/sdk/python/ratel_ai/runtime_events.py
@@ -1,0 +1,32 @@
+"""Public runtime-event stream and catalog snapshot seams (ADR-0019)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .catalog import ToolCatalog
+    from .skill_catalog import SkillCatalog
+
+
+class RuntimeCatalog:
+    """Complete serializable tool and skill state for snapshot publication."""
+
+    def __init__(
+        self,
+        tools: ToolCatalog,
+        skills: SkillCatalog,
+        *,
+        source_id: str,
+    ) -> None:
+        self._tools = tools
+        self._skills = skills
+        self._source_id = source_id
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return the current full replacement snapshot."""
+        return {
+            "source_id": self._source_id,
+            "tools": self._tools.snapshot(),
+            "skills": self._skills.snapshot(),
+        }

--- a/src/sdk/python/ratel_ai/skill_catalog.py
+++ b/src/sdk/python/ratel_ai/skill_catalog.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal, TypeVar, overload
 
 from ._native import IntentGraph as IntentGraph  # re-exported for `ratel_ai.IntentGraph`
-from ._native import SkillHit
+from ._native import NativeEventSubscription, SkillHit
 from ._native import SkillRegistry as _NativeSkillRegistry
 from .catalog import (
     _REGISTRY_BUSY,
@@ -418,6 +418,26 @@ class SkillRegistry:
     def record_event(self, event: dict[str, Any]) -> None:
         """Record an SDK-layer trace event."""
         self._native.record_event(event)
+
+    def subscribe_events(
+        self,
+        handler: Callable[[list[dict[str, Any]]], object],
+        *,
+        session_id: str,
+        source_id: str,
+        queue_capacity: int = 1_024,
+        batch_size: int = 64,
+    ) -> NativeEventSubscription:
+        """Attach one public batched runtime-event subscriber."""
+        with self._dense_state:
+            self._raise_if_busy()
+            return self._native.subscribe_trace_events(
+                handler,
+                session_id,
+                source_id,
+                queue_capacity,
+                batch_size,
+            )
 
     def set_trace_sink(
         self, kind: str, session_id: str | None = None, path: str | None = None
@@ -824,6 +844,24 @@ class SkillCatalog:
         See `ToolCatalog.record_event` for the event contract.
         """
         self._registry.record_event(event)
+
+    def subscribe_events(
+        self,
+        handler: Callable[[list[dict[str, Any]]], object],
+        *,
+        session_id: str,
+        source_id: str,
+        queue_capacity: int = 1_024,
+        batch_size: int = 64,
+    ) -> NativeEventSubscription:
+        """Attach one public runtime-event subscriber."""
+        return self._registry.subscribe_events(
+            handler,
+            session_id=session_id,
+            source_id=source_id,
+            queue_capacity=queue_capacity,
+            batch_size=batch_size,
+        )
 
     def experimental_enable_adaptive_ranking(
         self,

--- a/src/sdk/python/ratel_ai/skill_catalog.py
+++ b/src/sdk/python/ratel_ai/skill_catalog.py
@@ -8,6 +8,7 @@ relevance, and the matching body is fetched only on `invoke`.
 from __future__ import annotations
 
 import asyncio
+import copy
 import threading
 import time
 import warnings
@@ -798,6 +799,20 @@ class SkillCatalog:
     def get(self, skill_id: str) -> Skill | None:
         """Return the registered `Skill` for an id, or `None` if unknown."""
         return self._skills.get(skill_id)
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        """Return the complete deterministic public skill definitions."""
+        return [
+            {
+                "id": skill.id,
+                "name": skill.name,
+                "description": skill.description,
+                "tags": copy.deepcopy(skill.tags),
+                "tools": copy.deepcopy(skill.tools),
+                "metadata": copy.deepcopy(skill.metadata),
+            }
+            for skill in sorted(self._skills.values(), key=lambda item: item.id)
+        ]
 
     def size(self) -> int:
         """Return the number of registered skills."""

--- a/src/sdk/python/ratel_ai/skill_catalog.py
+++ b/src/sdk/python/ratel_ai/skill_catalog.py
@@ -34,7 +34,13 @@ from .embedding_artifact import (
     OnArtifactMiss,
     resolve_embedding_artifact,
 )
-from .telemetry import SEARCH_TARGET_SKILL, trace_search, trace_search_async, trace_skill_load
+from .telemetry import (
+    SEARCH_TARGET_SKILL,
+    RuntimeEventProjection,
+    trace_search,
+    trace_search_async,
+    trace_skill_load,
+)
 
 __all__ = [
     "PendingReplace",
@@ -305,9 +311,15 @@ class SkillRegistry:
         """Run synchronous, model-free BM25 retrieval."""
         return self._native.search(query, top_k)
 
-    def search_with_origin(self, query: str, top_k: int, origin: SearchOrigin) -> list[SkillHit]:
+    def search_with_origin(
+        self,
+        query: str,
+        top_k: int,
+        origin: SearchOrigin,
+        projection: RuntimeEventProjection | None = None,
+    ) -> list[SkillHit]:
         """Run BM25 retrieval with an explicit trace origin."""
-        return self._native.search_with_origin(query, top_k, origin)
+        return self._native.search_with_origin(query, top_k, origin, projection)
 
     def search_with_method(
         self, query: str, top_k: int, origin: SearchOrigin, method: SearchMethod
@@ -402,22 +414,30 @@ class SkillRegistry:
         top_k: int,
         origin: SearchOrigin = "direct",
         method: SearchMethod = "bm25",
+        projection: RuntimeEventProjection | None = None,
     ) -> list[SkillHit]:
         """Search immediately with BM25 or run dense retrieval on a worker thread."""
         if method not in ("bm25", "semantic", "hybrid"):
             raise ValueError(f"unknown search method: {method}")
         if method == "bm25":
-            return self.search_with_origin(query, top_k, origin)
+            return self.search_with_origin(query, top_k, origin, projection)
         if self._undriven_builds > 0:
             raise RuntimeError(_UNAWAITED_REGISTER)
         await self._maybe_rebuild_on_model_change()
         return await self._run_dense(
-            lambda: self._native._search_with_method(query, top_k, origin, method)
+            lambda: self._native._search_with_method(query, top_k, origin, method, projection)
         )
 
-    def record_event(self, event: dict[str, Any]) -> None:
+    def record_event(
+        self,
+        event: dict[str, Any],
+        projection: RuntimeEventProjection | None = None,
+    ) -> None:
         """Record an SDK-layer trace event."""
-        self._native.record_event(event)
+        if projection is None:
+            self._native.record_event(event)
+        else:
+            self._native.record_event_with_context(event, projection)
 
     def subscribe_events(
         self,
@@ -789,7 +809,9 @@ class SkillCatalog:
             query,
             top_k,
             origin,
-            lambda: self._registry.search_with_origin(query, top_k, origin),
+            lambda projection: self._registry.search_with_origin(
+                query, top_k, origin, projection
+            ),
         )
 
     async def search_async(
@@ -809,7 +831,9 @@ class SkillCatalog:
             query,
             top_k,
             origin,
-            lambda: self._registry.search_async(query, top_k, origin, resolved_method),
+            lambda projection: self._registry.search_async(
+                query, top_k, origin, resolved_method, projection
+            ),
         )
 
     def has(self, skill_id: str) -> bool:
@@ -838,12 +862,16 @@ class SkillCatalog:
         """Return the number of registered skills."""
         return len(self._skills)
 
-    def record_event(self, event: dict[str, Any]) -> None:
+    def record_event(
+        self,
+        event: dict[str, Any],
+        projection: RuntimeEventProjection | None = None,
+    ) -> None:
         """Record a trace event into the catalog's sink.
 
         See `ToolCatalog.record_event` for the event contract.
         """
-        self._registry.record_event(event)
+        self._registry.record_event(event, projection)
 
     def subscribe_events(
         self,
@@ -930,7 +958,7 @@ class SkillCatalog:
         if skill is None:
             raise ValueError(f"unknown skillId: {skill_id}")
 
-        def _run() -> str:
+        def _run(projection: RuntimeEventProjection) -> str:
             started = time.monotonic()
             body = skill.body
             self._registry.record_event(
@@ -938,7 +966,8 @@ class SkillCatalog:
                     "type": "skill_invoke",
                     "skill_id": skill_id,
                     "took_ms": int((time.monotonic() - started) * 1000),
-                }
+                },
+                projection,
             )
             return body
 

--- a/src/sdk/python/ratel_ai/telemetry.py
+++ b/src/sdk/python/ratel_ai/telemetry.py
@@ -61,7 +61,7 @@ try:
     try:
         from ratel_ai_telemetry import RATEL_EVENT_ID as _IMPORTED_RATEL_EVENT_ID
     except ImportError:
-        # Compatibility with telemetry helpers released before ADR-0019. The
+        # Compatibility with telemetry helpers released before ADR-0020. The
         # Python helper exports this constant on the same release train.
         RATEL_EVENT_ID = "ratel.event.id"
     else:

--- a/src/sdk/python/ratel_ai/telemetry.py
+++ b/src/sdk/python/ratel_ai/telemetry.py
@@ -57,6 +57,13 @@ try:
         content_capture_mode,
     )
 
+    try:
+        from ratel_ai_telemetry import RATEL_EVENT_ID
+    except ImportError:
+        # Compatibility with telemetry helpers released before ADR-0019. The
+        # Python helper exports this constant on the same release train.
+        RATEL_EVENT_ID = "ratel.event.id"
+
     _ENABLED = True
 except ModuleNotFoundError:
     _ENABLED = False
@@ -70,7 +77,6 @@ SEARCH_TARGET_SKILL = "skill"
 SEARCH_TARGET_FACT = "fact"
 
 T = TypeVar("T")
-RATEL_EVENT_ID = "ratel.event.id"
 
 
 class RuntimeEventProjection(TypedDict, total=False):

--- a/src/sdk/python/ratel_ai/telemetry.py
+++ b/src/sdk/python/ratel_ai/telemetry.py
@@ -26,6 +26,7 @@ from typing import Any, TypedDict, TypeVar
 from .runtime_events import new_runtime_event_id
 
 try:
+    import ratel_ai_telemetry as _telemetry_vocabulary
     from opentelemetry import _logs as _otel_logs
     from opentelemetry import trace as _otel_trace
     from opentelemetry.trace import SpanKind, Status, StatusCode
@@ -57,12 +58,9 @@ try:
         content_capture_mode,
     )
 
-    try:
-        from ratel_ai_telemetry import RATEL_EVENT_ID
-    except ImportError:
-        # Compatibility with telemetry helpers released before ADR-0019. The
-        # Python helper exports this constant on the same release train.
-        RATEL_EVENT_ID = "ratel.event.id"
+    # Compatibility with telemetry helpers released before ADR-0019. The
+    # Python helper exports this constant on the same release train.
+    RATEL_EVENT_ID: str = getattr(_telemetry_vocabulary, "RATEL_EVENT_ID", "ratel.event.id")
 
     _ENABLED = True
 except ModuleNotFoundError:

--- a/src/sdk/python/ratel_ai/telemetry.py
+++ b/src/sdk/python/ratel_ai/telemetry.py
@@ -26,7 +26,6 @@ from typing import Any, TypedDict, TypeVar
 from .runtime_events import new_runtime_event_id
 
 try:
-    import ratel_ai_telemetry as _telemetry_vocabulary
     from opentelemetry import _logs as _otel_logs
     from opentelemetry import trace as _otel_trace
     from opentelemetry.trace import SpanKind, Status, StatusCode
@@ -58,9 +57,15 @@ try:
         content_capture_mode,
     )
 
-    # Compatibility with telemetry helpers released before ADR-0019. The
-    # Python helper exports this constant on the same release train.
-    RATEL_EVENT_ID: str = getattr(_telemetry_vocabulary, "RATEL_EVENT_ID", "ratel.event.id")
+    RATEL_EVENT_ID: str
+    try:
+        from ratel_ai_telemetry import RATEL_EVENT_ID as _IMPORTED_RATEL_EVENT_ID
+    except ImportError:
+        # Compatibility with telemetry helpers released before ADR-0019. The
+        # Python helper exports this constant on the same release train.
+        RATEL_EVENT_ID = "ratel.event.id"
+    else:
+        RATEL_EVENT_ID = _IMPORTED_RATEL_EVENT_ID
 
     _ENABLED = True
 except ModuleNotFoundError:

--- a/src/sdk/python/ratel_ai/telemetry.py
+++ b/src/sdk/python/ratel_ai/telemetry.py
@@ -21,7 +21,9 @@ from __future__ import annotations
 import json
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from enum import Enum
-from typing import Any, TypeVar
+from typing import Any, TypedDict, TypeVar
+
+from .runtime_events import new_runtime_event_id
 
 try:
     from opentelemetry import _logs as _otel_logs
@@ -68,6 +70,16 @@ SEARCH_TARGET_SKILL = "skill"
 SEARCH_TARGET_FACT = "fact"
 
 T = TypeVar("T")
+RATEL_EVENT_ID = "ratel.event.id"
+
+
+class RuntimeEventProjection(TypedDict, total=False):
+    """Identity shared by one runtime envelope and its OTel projection."""
+
+    event_id: str
+    invocation_id: str
+    trace_id: str
+    span_id: str
 
 
 def _tracer() -> Any:
@@ -92,25 +104,48 @@ def _capture_content_on_event() -> bool:
 _UNSET: Any = object()
 
 
-def _add_tool_content_event(tool_id: str, args: Any, result: Any = _UNSET) -> None:
+def _event_projection(span: Any = None, invocation_id: str | None = None) -> RuntimeEventProjection:
+    projection = RuntimeEventProjection(event_id=new_runtime_event_id())
+    if invocation_id is not None:
+        projection["invocation_id"] = invocation_id
+    if span is None:
+        return projection
+    span.set_attribute(RATEL_EVENT_ID, projection["event_id"])
+    context = span.get_span_context()
+    if context.is_valid:
+        projection["trace_id"] = f"{context.trace_id:032x}"
+        projection["span_id"] = f"{context.span_id:016x}"
+    return projection
+
+
+def _add_tool_content_event(
+    tool_id: str,
+    args: Any,
+    event_id: str,
+    result: Any = _UNSET,
+) -> None:
     """Emit structured tool arguments and result as an OpenTelemetry EventRecord."""
     attributes = {
         GEN_AI_OPERATION_NAME: EXECUTE_TOOL,
         GEN_AI_TOOL_NAME: tool_id,
         GEN_AI_TOOL_CALL_ARGUMENTS: _safe_log_value(args),
+        RATEL_EVENT_ID: event_id,
     }
     if result is not _UNSET:
         attributes[GEN_AI_TOOL_CALL_RESULT] = _safe_log_value(result)
     _logger().emit(event_name=RATEL_TOOL_EXECUTION_DETAILS, attributes=attributes)
 
 
-def _add_search_results_event(query: str) -> None:
+def _add_search_results_event(query: str, event_id: str) -> None:
     """Emit the Opt-In ``ratel.search.results`` EventRecord carrying the search text.
 
     Hit ids/scores/BM25 timing are local-stream only; the OTLP glue carries the gated
     query it has (CONVENTIONS.md § ratel.search).
     """
-    _logger().emit(event_name=RATEL_SEARCH_RESULTS, attributes={RATEL_SEARCH_QUERY: query})
+    _logger().emit(
+        event_name=RATEL_SEARCH_RESULTS,
+        attributes={RATEL_SEARCH_QUERY: query, RATEL_EVENT_ID: event_id},
+    )
 
 
 def _args_size_bytes(args: Any) -> int:
@@ -169,7 +204,7 @@ def _normalize_content(value: Any) -> Any:
 async def trace_execute_tool(
     tool_id: str,
     args: dict[str, Any],
-    run: Callable[[], Awaitable[T]],
+    run: Callable[[RuntimeEventProjection], Awaitable[T]],
 ) -> T:
     """Wrap a tool invocation in a standard `execute_tool` span.
 
@@ -178,10 +213,13 @@ async def trace_execute_tool(
     No-op pass-through when telemetry is disabled.
     """
     if not _ENABLED:
-        return await run()
+        return await run(
+            _event_projection(invocation_id=new_runtime_event_id())
+        )
     with _tracer().start_as_current_span(
         f"{EXECUTE_TOOL} {tool_id}", kind=SpanKind.INTERNAL
     ) as span:
+        projection = _event_projection(span, new_runtime_event_id())
         span.set_attribute(GEN_AI_OPERATION_NAME, EXECUTE_TOOL)
         span.set_attribute(GEN_AI_TOOL_NAME, tool_id)
         span.set_attribute(RATEL_TOOL_ARGS_SIZE_BYTES, _args_size_bytes(args))
@@ -189,15 +227,15 @@ async def trace_execute_tool(
             span.set_attribute(GEN_AI_TOOL_CALL_ARGUMENTS, _safe_json(args))
         # start_as_current_span records the exception + sets ERROR status on raise.
         try:
-            result = await run()
+            result = await run(projection)
         except BaseException:
             if _capture_content_on_event():
-                _add_tool_content_event(tool_id, args)
+                _add_tool_content_event(tool_id, args, projection["event_id"])
             raise
         if _capture_content_on_span():
             span.set_attribute(GEN_AI_TOOL_CALL_RESULT, _safe_json(result))
         if _capture_content_on_event():
-            _add_tool_content_event(tool_id, args, result=result)
+            _add_tool_content_event(tool_id, args, projection["event_id"], result=result)
         span.set_status(Status(StatusCode.OK))
         return result
 
@@ -207,7 +245,7 @@ def trace_search(
     query: str,
     top_k: int,
     origin: str,
-    run: Callable[[], T],
+    run: Callable[[RuntimeEventProjection], T],
 ) -> T:
     """Wrap a capability search (tool or skill) in a `ratel.search` span.
 
@@ -215,17 +253,18 @@ def trace_search(
     `ratel.search.hit_count`.
     """
     if not _ENABLED:
-        return run()
+        return run(_event_projection())
     with _tracer().start_as_current_span(RATEL_SEARCH, kind=SpanKind.INTERNAL) as span:
+        projection = _event_projection(span)
         span.set_attribute(RATEL_SEARCH_TARGET, target)
         span.set_attribute(RATEL_SEARCH_TOP_K, top_k)
         span.set_attribute(RATEL_ORIGIN, origin)
         if _capture_content_on_span():
             span.set_attribute(RATEL_SEARCH_QUERY, query)
-        hits = run()
+        hits = run(projection)
         span.set_attribute(RATEL_SEARCH_HIT_COUNT, len(hits))  # type: ignore[arg-type]
         if _capture_content_on_event():
-            _add_search_results_event(query)
+            _add_search_results_event(query, projection["event_id"])
         span.set_status(Status(StatusCode.OK))
         return hits
 
@@ -235,32 +274,34 @@ async def trace_search_async(
     query: str,
     top_k: int,
     origin: str,
-    run: Callable[[], Awaitable[T]],
+    run: Callable[[RuntimeEventProjection], Awaitable[T]],
 ) -> T:
     """Wrap asynchronous BM25, semantic, or hybrid retrieval in a `ratel.search` span."""
     if not _ENABLED:
-        return await run()
+        return await run(_event_projection())
     with _tracer().start_as_current_span(RATEL_SEARCH, kind=SpanKind.INTERNAL) as span:
+        projection = _event_projection(span)
         span.set_attribute(RATEL_SEARCH_TARGET, target)
         span.set_attribute(RATEL_SEARCH_TOP_K, top_k)
         span.set_attribute(RATEL_ORIGIN, origin)
         if _capture_content_on_span():
             span.set_attribute(RATEL_SEARCH_QUERY, query)
-        hits = await run()
+        hits = await run(projection)
         span.set_attribute(RATEL_SEARCH_HIT_COUNT, len(hits))  # type: ignore[arg-type]
         if _capture_content_on_event():
-            _add_search_results_event(query)
+            _add_search_results_event(query, projection["event_id"])
         span.set_status(Status(StatusCode.OK))
         return hits
 
 
-def trace_skill_load(skill_id: str, run: Callable[[], T]) -> T:
+def trace_skill_load(skill_id: str, run: Callable[[RuntimeEventProjection], T]) -> T:
     """Wrap a skill-content load in a `ratel.skill.load` span."""
     if not _ENABLED:
-        return run()
+        return run(_event_projection())
     with _tracer().start_as_current_span(RATEL_SKILL_LOAD, kind=SpanKind.INTERNAL) as span:
+        projection = _event_projection(span)
         span.set_attribute(RATEL_SKILL_ID, skill_id)
-        body = run()
+        body = run(projection)
         span.set_status(Status(StatusCode.OK))
         return body
 
@@ -268,7 +309,7 @@ def trace_skill_load(skill_id: str, run: Callable[[], T]) -> T:
 async def trace_upstream_register(
     server: str,
     transport: str,
-    run: Callable[[Callable[[int], None]], Awaitable[T]],
+    run: Callable[[Callable[[int], None], RuntimeEventProjection], Awaitable[T]],
 ) -> T:
     """Wrap an upstream-MCP registration in a `ratel.upstream.register` span.
 
@@ -276,27 +317,33 @@ async def trace_upstream_register(
     `ratel.upstream.tool_count` once the tool list is known.
     """
     if not _ENABLED:
-        return await run(lambda _n: None)
+        return await run(lambda _n: None, _event_projection())
     with _tracer().start_as_current_span(RATEL_UPSTREAM_REGISTER, kind=SpanKind.INTERNAL) as span:
+        projection = _event_projection(span)
         span.set_attribute(RATEL_UPSTREAM_SERVER, server)
         span.set_attribute(RATEL_UPSTREAM_TRANSPORT, transport)
-        result = await run(lambda n: span.set_attribute(RATEL_UPSTREAM_TOOL_COUNT, n))
+        result = await run(
+            lambda n: span.set_attribute(RATEL_UPSTREAM_TOOL_COUNT, n),
+            projection,
+        )
         span.set_status(Status(StatusCode.OK))
         return result
 
 
-def record_auth_needed(server: str | None = None) -> None:
+def record_auth_needed(server: str | None = None) -> RuntimeEventProjection:
     """Mark an upstream tool call that failed with a 401 / needs-reauthorization.
 
     Emits a short `ratel.auth.flow` span carrying `ratel.auth.outcome = needs_auth`.
     """
     if not _ENABLED:
-        return
+        return _event_projection()
     span = _tracer().start_span(RATEL_AUTH_FLOW, kind=SpanKind.INTERNAL)
+    projection = _event_projection(span)
     if server:
         span.set_attribute(RATEL_UPSTREAM_SERVER, server)
     span.set_attribute(RATEL_AUTH_OUTCOME, AuthOutcome.NEEDS_AUTH.value)
     span.end()
+    return projection
 
 
 def _resolve_capture_override(

--- a/src/sdk/python/tests/test_adaptive_ranking.py
+++ b/src/sdk/python/tests/test_adaptive_ranking.py
@@ -200,7 +200,14 @@ class _FakeNative:
     def adaptive_ranking_status(self) -> tuple[str, str, str, bool]:
         return (self._status, "old-model", "new-model", False)
 
-    def _search_with_method(self, query: str, top_k: int, origin: str, method: str) -> list:
+    def _search_with_method(
+        self,
+        query: str,
+        top_k: int,
+        origin: str,
+        method: str,
+        context: object | None = None,
+    ) -> list:
         return []
 
 

--- a/src/sdk/python/tests/test_catalog.py
+++ b/src/sdk/python/tests/test_catalog.py
@@ -672,6 +672,28 @@ async def test_invoke_emits_error_telemetry_and_reraises() -> None:
     assert events[1]["error"] == "kaboom"
 
 
+async def test_cancelled_invoke_emits_error_telemetry_and_reraises() -> None:
+    started = asyncio.Event()
+
+    async def wait_forever(_args):
+        started.set()
+        await asyncio.Event().wait()
+
+    catalog = ToolCatalog(trace=TraceSinkConfig(kind="memory", session_id="s"))
+    await catalog.register(_read_file_tool(wait_forever))
+    catalog.drain_trace_events()
+    invocation = asyncio.create_task(catalog.invoke("read_file", {"path": "/a"}))
+    await started.wait()
+
+    invocation.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await invocation
+
+    events = catalog.drain_trace_events()
+    assert [event["type"] for event in events] == ["invoke_start", "invoke_error"]
+    assert events[1]["error"] == "CancelledError"
+
+
 async def test_re_register_replaces_in_place() -> None:
     # Re-registering an id replaces it in the native corpus, not appends a
     # duplicate: the id ranks once and the latest executor wins (RAT-378).

--- a/src/sdk/python/tests/test_index.py
+++ b/src/sdk/python/tests/test_index.py
@@ -27,6 +27,16 @@ def test_public_exports_present() -> None:
         "register_mcp_server",
         "McpServerHandle",
         "McpToolsListError",
+        # runtime facts + snapshot seam
+        "RuntimeCatalog",
+        "RuntimeEvent",
+        "RuntimeEventHandler",
+        "RuntimeEventSubscription",
+        "RuntimeEvents",
+        "RUNTIME_EVENT_TYPES",
+        "RUNTIME_EVENT_MAX_PAYLOAD_BYTES",
+        "RUNTIME_EVENT_MAX_QUERY_BYTES",
+        "RUNTIME_EVENT_MAX_HITS",
         # skills surface
         "SkillRegistry",
         "SkillHit",

--- a/src/sdk/python/tests/test_native_events.py
+++ b/src/sdk/python/tests/test_native_events.py
@@ -1,0 +1,112 @@
+"""Native push bridge tests; the public Python API lands in Phase 5."""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+from ratel_ai._native import IntentGraph, SkillRegistry, ToolRegistry
+
+
+def test_pushes_worker_thread_search_events_in_batches() -> None:
+    registry = ToolRegistry()
+    registry.register("read_file", "read_file", "Read a file", {}, {})
+    batches: list[list[dict[str, Any]]] = []
+    callback_threads: list[int] = []
+    subscription = registry.subscribe_trace_events(
+        lambda batch: (batches.append(batch), callback_threads.append(threading.get_ident())),
+        "session-python",
+        "source-python",
+        16,
+        8,
+    )
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        producer_thread = executor.submit(threading.get_ident).result()
+        executor.submit(
+            registry._search_with_method,
+            "read",
+            1,
+            "direct",
+            "bm25",
+        ).result()
+    subscription.flush()
+
+    event = next(event for batch in batches for event in batch if event["type"] == "search")
+    assert event | {
+        "v": 2,
+        "session_id": "session-python",
+        "source_id": "source-python",
+        "query": "read",
+    } == event
+    assert callback_threads
+    assert callback_threads[0] != producer_thread
+
+
+def test_pushes_skill_registry_events_through_the_same_seam() -> None:
+    registry = SkillRegistry()
+    registry.register("api-design", "api-design", "Design an API", [], [], {}, "Use nouns")
+    events: list[dict[str, Any]] = []
+    subscription = registry.subscribe_trace_events(
+        lambda batch: events.extend(batch),
+        "session-skill",
+    )
+
+    registry._search_with_method("api", 1, "direct", "bm25")
+    subscription.flush()
+
+    assert any(
+        event["type"] == "skill_search" and event["session_id"] == "session-skill"
+        for event in events
+    )
+
+
+def test_drops_oldest_and_reports_loss_while_python_callback_is_stalled() -> None:
+    registry = ToolRegistry()
+    callback_started = threading.Event()
+    release_callback = threading.Event()
+    events: list[dict[str, Any]] = []
+
+    def callback(batch: list[dict[str, Any]]) -> None:
+        events.extend(batch)
+        if not callback_started.is_set():
+            callback_started.set()
+            release_callback.wait(timeout=1)
+
+    subscription = registry.subscribe_trace_events(
+        callback,
+        "session-drop",
+        queue_capacity=2,
+        batch_size=1,
+    )
+    registry.search("first", 1)
+    assert callback_started.wait(timeout=1)
+
+    for index in range(64):
+        registry.search(f"query-{index}", 1)
+    release_callback.set()
+    subscription.flush()
+
+    assert subscription.dropped_count > 0
+    assert any(
+        event["type"] == "events_dropped" and event["reason"] == "queue_overflow"
+        for event in events
+    )
+
+
+def test_keeps_callbacks_and_usage_learning_across_base_sink_rewrap() -> None:
+    registry = ToolRegistry()
+    graph = IntentGraph()
+    registry.enable_adaptive_ranking(graph)
+    events: list[dict[str, Any]] = []
+    subscription = registry.subscribe_trace_events(
+        lambda batch: events.extend(batch),
+        "session-learner",
+    )
+    registry.set_trace_sink("memory", "session-learner")
+
+    registry.search("read file", 1)
+    registry.record_event({"type": "invoke_start", "tool_id": "read_file", "args_size_bytes": 0})
+    subscription.flush()
+
+    assert graph.cluster_count == 1
+    assert {event["type"] for event in events} >= {"search", "invoke_start"}

--- a/src/sdk/python/tests/test_native_events.py
+++ b/src/sdk/python/tests/test_native_events.py
@@ -1,10 +1,63 @@
 """Native push bridge tests; the public Python API lands in Phase 5."""
 
+import subprocess
+import sys
+import textwrap
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
+import pytest
+
 from ratel_ai._native import IntentGraph, SkillRegistry, ToolRegistry
+
+
+@pytest.mark.parametrize("accessor", ["subscription.unsubscribe()", "subscription.dropped_count"])
+def test_subscription_access_does_not_deadlock_a_callback_draining_flush(accessor: str) -> None:
+    script = textwrap.dedent(
+        f"""
+        import threading
+        import time
+
+        from ratel_ai._native import ToolRegistry
+
+        registry = ToolRegistry()
+        callback_started = threading.Event()
+
+        def callback(_batch):
+            if not callback_started.is_set():
+                callback_started.set()
+                time.sleep(0.5)
+
+        subscription = registry.subscribe_trace_events(
+            callback,
+            "session-flush-access",
+            queue_capacity=16,
+            batch_size=1,
+        )
+        registry.search("queued", 1)
+        assert callback_started.wait(timeout=1)
+        for index in range(100):
+            registry.search(f"queued-{{index}}", 1)
+
+        flushing = threading.Thread(target=subscription.flush)
+        flushing.start()
+        time.sleep(0.05)
+        {accessor}
+        flushing.join(timeout=2)
+        assert not flushing.is_alive()
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=4,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_pushes_worker_thread_search_events_in_batches() -> None:

--- a/src/sdk/python/tests/test_native_events.py
+++ b/src/sdk/python/tests/test_native_events.py
@@ -22,16 +22,25 @@ def test_pushes_worker_thread_search_events_in_batches() -> None:
 
     with ThreadPoolExecutor(max_workers=1) as executor:
         producer_thread = executor.submit(threading.get_ident).result()
-        executor.submit(
+        worker_search = executor.submit(
             registry._search_with_method,
             "read",
             1,
             "direct",
             "bm25",
-        ).result()
+        )
+        for index in range(8):
+            registry.search(f"burst-{index}", 1)
+        worker_search.result()
     subscription.flush()
 
-    event = next(event for batch in batches for event in batch if event["type"] == "search")
+    assert any(len(batch) > 1 for batch in batches)
+    event = next(
+        event
+        for batch in batches
+        for event in batch
+        if event["type"] == "search" and event["query"] == "read"
+    )
     assert event | {
         "v": 2,
         "session_id": "session-python",

--- a/src/sdk/python/tests/test_native_events.py
+++ b/src/sdk/python/tests/test_native_events.py
@@ -184,6 +184,28 @@ def test_unsubscribe_releases_the_callback_dispatcher() -> None:
     assert released.is_set()
 
 
+def test_keeps_base_sink_synchronous_and_independently_stamped_after_subscribing() -> None:
+    registry = ToolRegistry()
+    registry.set_trace_sink("memory", "base-session")
+    subscription = registry.subscribe_trace_events(
+        lambda batch: None,
+        "stream-session",
+        queue_capacity=1,
+        batch_size=1,
+    )
+
+    total = 5_000
+    for index in range(total):
+        registry.search(f"persist-{index}", 1)
+
+    drained = registry.drain_trace_events()
+    persisted = [event for event in drained if event["type"] == "search"]
+    assert len(persisted) == total
+    assert all(event["session_id"] == "base-session" for event in persisted)
+    assert not any(event["type"] == "events_dropped" for event in drained)
+    subscription.unsubscribe()
+
+
 def test_keeps_callbacks_and_usage_learning_across_base_sink_rewrap() -> None:
     registry = ToolRegistry()
     graph = IntentGraph()

--- a/src/sdk/python/tests/test_native_events.py
+++ b/src/sdk/python/tests/test_native_events.py
@@ -1,5 +1,6 @@
 """Native push bridge tests; the public Python API lands in Phase 5."""
 
+import gc
 import subprocess
 import sys
 import textwrap
@@ -148,11 +149,39 @@ def test_drops_oldest_and_reports_loss_while_python_callback_is_stalled() -> Non
     release_callback.set()
     subscription.flush()
 
-    assert subscription.dropped_count > 0
+    dropped_count = subscription.dropped_count
+    assert dropped_count > 0
     assert any(
         event["type"] == "events_dropped" and event["reason"] == "queue_overflow"
         for event in events
     )
+    subscription.unsubscribe()
+    assert subscription.dropped_count == dropped_count
+
+
+def test_unsubscribe_releases_the_callback_dispatcher() -> None:
+    registry = ToolRegistry()
+    released = threading.Event()
+
+    class Callback:
+        def __call__(self, _batch: list[dict[str, Any]]) -> None:
+            pass
+
+        def __del__(self) -> None:
+            released.set()
+
+    callback = Callback()
+    subscription = registry.subscribe_trace_events(callback, "session-dispatcher")
+    del callback
+
+    subscription.unsubscribe()
+
+    for _ in range(100):
+        _ = subscription.dropped_count
+        gc.collect()
+        if released.wait(timeout=0.01):
+            break
+    assert released.is_set()
 
 
 def test_keeps_callbacks_and_usage_learning_across_base_sink_rewrap() -> None:

--- a/src/sdk/python/tests/test_py39_compat.py
+++ b/src/sdk/python/tests/test_py39_compat.py
@@ -1,0 +1,62 @@
+"""Guard the declared Python 3.9 runtime floor (`requires-python >=3.9`).
+
+`from __future__ import annotations` defers annotations only; module- and
+class-level *assignments* (typing aliases like ``X = Callable[..., A | B]``)
+still evaluate at import time, and PEP 604 ``|`` unions raise ``TypeError``
+on CPython 3.9. This scan fails on any such alias so the package stays
+importable on every version the wheel claims to support (ADR-0006 ships
+abi3 wheels for >=3.9).
+"""
+
+import ast
+from pathlib import Path
+
+PACKAGE_DIR = Path(__file__).resolve().parent.parent / "ratel_ai"
+
+
+def test_no_runtime_evaluated_pep604_unions_at_import_time() -> None:
+    offenders: list[str] = []
+    for module_path in sorted(PACKAGE_DIR.rglob("*.py")):
+        tree = ast.parse(module_path.read_text(), filename=str(module_path))
+        for assignment in _import_time_assignments(tree):
+            for union in _pep604_unions(assignment):
+                offenders.append(
+                    f"{module_path.relative_to(PACKAGE_DIR)}:{union.lineno}: "
+                    f"{ast.unparse(union)}"
+                )
+    assert not offenders, (
+        "PEP 604 unions evaluated at import time break CPython 3.9 "
+        "(use typing.Optional/typing.Union in runtime-evaluated aliases):\n"
+        + "\n".join(offenders)
+    )
+
+
+def _import_time_assignments(tree: ast.Module) -> list[ast.expr]:
+    """Values of module- and class-level assignments — evaluated at import."""
+    values: list[ast.expr] = []
+    class_bodies = [
+        statement for node in tree.body if isinstance(node, ast.ClassDef) for statement in node.body
+    ]
+    for statement in [*tree.body, *class_bodies]:
+        if isinstance(statement, ast.Assign):
+            values.append(statement.value)
+        elif isinstance(statement, ast.AnnAssign) and statement.value is not None:
+            values.append(statement.value)
+    return values
+
+
+def _pep604_unions(value: ast.expr) -> list[ast.BinOp]:
+    """``a | b`` nodes that are type unions rather than integer/set bit-ors."""
+    return [
+        node
+        for node in ast.walk(value)
+        if isinstance(node, ast.BinOp)
+        and isinstance(node.op, ast.BitOr)
+        and any(_is_type_expression(operand) for operand in (node.left, node.right))
+    ]
+
+
+def _is_type_expression(node: ast.expr) -> bool:
+    if isinstance(node, ast.Constant) and node.value is None:
+        return True
+    return isinstance(node, ast.Subscript)

--- a/src/sdk/python/tests/test_runtime_events.py
+++ b/src/sdk/python/tests/test_runtime_events.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -244,6 +245,30 @@ async def test_marshals_async_handlers_to_the_subscribing_event_loop() -> None:
 
     assert [event["type"] for event in received] == ["search"]
     assert handler_threads == [event_loop_thread]
+    subscription.unsubscribe()
+
+
+def test_counts_and_warns_when_an_async_handlers_event_loop_is_closed() -> None:
+    tools = ToolCatalog()
+    events = RuntimeEvents([tools], batch_size=1)
+
+    async def handler(_batch: list[dict[str, object]]) -> None:
+        pass
+
+    async def subscribe():
+        return events.subscribe(handler)
+
+    subscription = asyncio.run(subscribe())
+
+    with pytest.warns(RuntimeWarning, match="event loop is closed") as warning_records:
+        tools.search("after-close", 1)
+        tools.search("still-closed", 1)
+        deadline = time.monotonic() + 1
+        while subscription.dropped_count < 2 and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+    assert subscription.dropped_count == 2
+    assert len(warning_records) == 1
     subscription.unsubscribe()
 
 

--- a/src/sdk/python/tests/test_runtime_events.py
+++ b/src/sdk/python/tests/test_runtime_events.py
@@ -170,6 +170,49 @@ def test_matches_frozen_cross_language_event_vocabulary() -> None:
     }
 
 
+def test_rolls_back_earlier_native_subscriptions_when_a_later_source_rejects() -> None:
+    unsubscribed: list[str] = []
+
+    class FirstSubscription:
+        dropped_count = 0
+
+        def unsubscribe(self) -> None:
+            unsubscribed.append("first")
+
+        def flush(self) -> None:
+            pass
+
+    class FirstSource:
+        def subscribe_events(
+            self,
+            handler: object,
+            *,
+            session_id: str,
+            source_id: str,
+            queue_capacity: int,
+            batch_size: int,
+        ) -> FirstSubscription:
+            return FirstSubscription()
+
+    class BusySource:
+        def subscribe_events(
+            self,
+            handler: object,
+            *,
+            session_id: str,
+            source_id: str,
+            queue_capacity: int,
+            batch_size: int,
+        ) -> FirstSubscription:
+            raise RuntimeError("registry busy")
+
+    events = RuntimeEvents([FirstSource(), BusySource()])  # type: ignore[list-item]
+
+    with pytest.raises(RuntimeError, match="registry busy"):
+        events.subscribe(lambda batch: None)
+    assert unsubscribed == ["first"]
+
+
 def test_unsubscribe_still_delivers_envelopes_already_queued_by_native() -> None:
     tools = ToolCatalog()
     events = RuntimeEvents([tools], queue_capacity=16, batch_size=1)

--- a/src/sdk/python/tests/test_runtime_events.py
+++ b/src/sdk/python/tests/test_runtime_events.py
@@ -1,4 +1,4 @@
-"""Public runtime-events and catalog-snapshot contract (ADR-0019)."""
+"""Public runtime-events and catalog-snapshot contract (ADR-0020)."""
 
 from __future__ import annotations
 

--- a/src/sdk/python/tests/test_runtime_events.py
+++ b/src/sdk/python/tests/test_runtime_events.py
@@ -169,6 +169,31 @@ def test_matches_frozen_cross_language_event_vocabulary() -> None:
     }
 
 
+def test_unsubscribe_still_delivers_envelopes_already_queued_by_native() -> None:
+    tools = ToolCatalog()
+    events = RuntimeEvents([tools], queue_capacity=16, batch_size=1)
+    first_batch_started = threading.Event()
+    release_first_batch = threading.Event()
+    queued_batch_delivered = threading.Event()
+
+    def handler(batch: list[dict[str, object]]) -> None:
+        if not first_batch_started.is_set():
+            first_batch_started.set()
+            release_first_batch.wait(timeout=1)
+        if any(event.get("query") == "already-queued" for event in batch):
+            queued_batch_delivered.set()
+
+    subscription = events.subscribe(handler)
+    tools.search("first", 1)
+    assert first_batch_started.wait(timeout=1)
+    tools.search("already-queued", 1)
+
+    subscription.unsubscribe()
+    release_first_batch.set()
+
+    assert queued_batch_delivered.wait(timeout=2)
+
+
 @pytest.mark.asyncio
 async def test_bounds_query_hits_and_payload_before_delivery() -> None:
     tools = ToolCatalog()

--- a/src/sdk/python/tests/test_runtime_events.py
+++ b/src/sdk/python/tests/test_runtime_events.py
@@ -156,6 +156,7 @@ def test_matches_frozen_cross_language_event_vocabulary() -> None:
         "max_payload_bytes": RUNTIME_EVENT_MAX_PAYLOAD_BYTES,
         "max_query_bytes": RUNTIME_EVENT_MAX_QUERY_BYTES,
         "max_hits": RUNTIME_EVENT_MAX_HITS,
+        "otel_event_id_attribute": "ratel.event.id",
         "required_envelope_fields": [
             "v",
             "event_id",

--- a/src/sdk/python/tests/test_runtime_events.py
+++ b/src/sdk/python/tests/test_runtime_events.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+import threading
+from pathlib import Path
 
 import pytest
 
 from ratel_ai import (
+    RUNTIME_EVENT_MAX_HITS,
+    RUNTIME_EVENT_MAX_PAYLOAD_BYTES,
+    RUNTIME_EVENT_MAX_QUERY_BYTES,
+    RUNTIME_EVENT_TYPES,
     ExecutableTool,
     RuntimeCatalog,
+    RuntimeEvents,
     Skill,
     SkillCatalog,
     ToolCatalog,
@@ -88,3 +96,126 @@ async def test_returns_complete_serializable_catalog_without_executable_content(
     encoded = json.dumps(snapshot)
     assert "execute" not in encoded
     assert "private instructions" not in encoded
+
+
+@pytest.mark.asyncio
+async def test_merges_tool_and_skill_events_for_sync_handlers_off_thread() -> None:
+    tools = ToolCatalog()
+    skills = SkillCatalog()
+    events = RuntimeEvents(
+        [tools, skills],
+        session_id="session-public",
+        source_id="source-public",
+        queue_capacity=16,
+        batch_size=8,
+    )
+    received: list[dict[str, object]] = []
+    handler_threads: list[int] = []
+    producer_thread = threading.get_ident()
+
+    def handler(batch: list[dict[str, object]]) -> None:
+        received.extend(batch)
+        handler_threads.append(threading.get_ident())
+
+    subscription = events.subscribe(handler)
+    await tools.register(
+        ExecutableTool(
+            id="read_file",
+            name="read_file",
+            description="Read a file",
+            execute=lambda _args: {},
+        )
+    )
+    await skills.register(
+        Skill(id="api-design", name="API design", description="Design an API", body="Private")
+    )
+    tools.search("read", 1)
+    skills.search("api", 1)
+
+    await subscription.flush()
+
+    assert {event["type"] for event in received} >= {
+        "index_churn",
+        "skill_churn",
+        "search",
+        "skill_search",
+    }
+    assert all(event["session_id"] == "session-public" for event in received)
+    assert all(event["source_id"] == "source-public" for event in received)
+    assert all(handler_thread != producer_thread for handler_thread in handler_threads)
+    subscription.unsubscribe()
+
+
+def test_matches_frozen_cross_language_event_vocabulary() -> None:
+    fixtures = json.loads(
+        (Path(__file__).parents[3] / "telemetry" / "conformance" / "fixtures.json").read_text()
+    )
+
+    assert fixtures["runtime_events"] == {
+        "version": 2,
+        "max_payload_bytes": RUNTIME_EVENT_MAX_PAYLOAD_BYTES,
+        "max_query_bytes": RUNTIME_EVENT_MAX_QUERY_BYTES,
+        "max_hits": RUNTIME_EVENT_MAX_HITS,
+        "required_envelope_fields": [
+            "v",
+            "event_id",
+            "ts",
+            "session_id",
+            "source_id",
+            "type",
+        ],
+        "event_types": list(RUNTIME_EVENT_TYPES),
+    }
+
+
+@pytest.mark.asyncio
+async def test_bounds_query_hits_and_payload_before_delivery() -> None:
+    tools = ToolCatalog()
+    skills = SkillCatalog()
+    events = RuntimeEvents([tools, skills])
+    received: list[dict[str, object]] = []
+    subscription = events.subscribe(lambda batch: received.extend(batch))
+    await tools.register(
+        [
+            ExecutableTool(
+                id=f"tool-{index:03d}",
+                name=f"Tool {index:03d}",
+                description="padding " * 1_000,
+                execute=lambda _args: {},
+            )
+            for index in range(120)
+        ]
+    )
+
+    tools.search("padding " * 1_000, 120)
+    await subscription.flush()
+
+    event = next(item for item in received if item["type"] == "search")
+    assert len(str(event["query"]).encode()) <= RUNTIME_EVENT_MAX_QUERY_BYTES
+    assert len(event["hits"]) == RUNTIME_EVENT_MAX_HITS  # type: ignore[arg-type]
+    assert len(json.dumps(event, separators=(",", ":")).encode()) <= RUNTIME_EVENT_MAX_PAYLOAD_BYTES
+    subscription.unsubscribe()
+
+
+@pytest.mark.asyncio
+async def test_marshals_async_handlers_to_the_subscribing_event_loop() -> None:
+    tools = ToolCatalog()
+    skills = SkillCatalog()
+    events = RuntimeEvents([tools, skills], session_id="session-async")
+    received: list[dict[str, object]] = []
+    handler_threads: list[int] = []
+    event_loop_thread = threading.get_ident()
+
+    async def handler(batch: list[dict[str, object]]) -> None:
+        await asyncio.sleep(0)
+        received.extend(batch)
+        handler_threads.append(threading.get_ident())
+
+    subscription = events.subscribe(handler)
+    tools.search("anything", 1)
+
+    await subscription.flush()
+
+    assert [event["type"] for event in received] == ["search"]
+    assert handler_threads == [event_loop_thread]
+    subscription.unsubscribe()

--- a/src/sdk/python/tests/test_runtime_events.py
+++ b/src/sdk/python/tests/test_runtime_events.py
@@ -1,0 +1,90 @@
+"""Public runtime-events and catalog-snapshot contract (ADR-0019)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ratel_ai import (
+    ExecutableTool,
+    RuntimeCatalog,
+    Skill,
+    SkillCatalog,
+    ToolCatalog,
+)
+
+
+@pytest.mark.asyncio
+async def test_returns_complete_serializable_catalog_without_executable_content() -> None:
+    tools = ToolCatalog()
+    skills = SkillCatalog()
+    await tools.register(
+        [
+            ExecutableTool(
+                id="z_tool",
+                name="Z tool",
+                description="Last by id",
+                input_schema={"type": "object", "properties": {"value": {"type": "string"}}},
+                output_schema={"type": "string"},
+                execute=lambda _args: {"secret": "must never escape"},
+            ),
+            ExecutableTool(
+                id="a_tool",
+                name="A tool",
+                description="First by id",
+                input_schema={"type": "object"},
+                output_schema={"type": "object"},
+                execute=lambda _args: {},
+            ),
+        ]
+    )
+    await skills.register(
+        Skill(
+            id="skill-a",
+            name="Skill A",
+            description="Public skill metadata",
+            tags=["public"],
+            tools=["a_tool"],
+            metadata={"stacks": ["python"]},
+            body="May contain private instructions",
+        )
+    )
+
+    snapshot = RuntimeCatalog(tools, skills, source_id="service-a").snapshot()
+
+    assert snapshot == {
+        "source_id": "service-a",
+        "tools": [
+            {
+                "id": "a_tool",
+                "name": "A tool",
+                "description": "First by id",
+                "input_schema": {"type": "object"},
+                "output_schema": {"type": "object"},
+            },
+            {
+                "id": "z_tool",
+                "name": "Z tool",
+                "description": "Last by id",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"value": {"type": "string"}},
+                },
+                "output_schema": {"type": "string"},
+            },
+        ],
+        "skills": [
+            {
+                "id": "skill-a",
+                "name": "Skill A",
+                "description": "Public skill metadata",
+                "tags": ["public"],
+                "tools": ["a_tool"],
+                "metadata": {"stacks": ["python"]},
+            }
+        ],
+    }
+    encoded = json.dumps(snapshot)
+    assert "execute" not in encoded
+    assert "private instructions" not in encoded

--- a/src/sdk/python/tests/test_runtime_events.py
+++ b/src/sdk/python/tests/test_runtime_events.py
@@ -219,3 +219,25 @@ async def test_marshals_async_handlers_to_the_subscribing_event_loop() -> None:
     assert [event["type"] for event in received] == ["search"]
     assert handler_threads == [event_loop_thread]
     subscription.unsubscribe()
+
+
+@pytest.mark.asyncio
+async def test_marshals_handlers_that_return_an_awaitable_to_the_event_loop() -> None:
+    tools = ToolCatalog()
+    events = RuntimeEvents([tools])
+    received: list[dict[str, object]] = []
+    handler_threads: list[int] = []
+    event_loop_thread = threading.get_ident()
+
+    async def async_handler(batch: list[dict[str, object]]) -> None:
+        received.extend(batch)
+        handler_threads.append(threading.get_ident())
+
+    subscription = events.subscribe(lambda batch: async_handler(batch))
+    tools.search("anything", 1)
+
+    await subscription.flush()
+
+    assert [event["type"] for event in received] == ["search"]
+    assert handler_threads == [event_loop_thread]
+    subscription.unsubscribe()

--- a/src/sdk/python/tests/test_telemetry.py
+++ b/src/sdk/python/tests/test_telemetry.py
@@ -35,6 +35,7 @@ from ratel_ai_telemetry import set_content_capture  # noqa: E402
 
 from ratel_ai import (  # noqa: E402
     ExecutableTool,
+    RuntimeEvents,
     Skill,
     SkillCatalog,
     ToolCatalog,
@@ -110,6 +111,54 @@ async def test_execute_tool_span_attributes(exporter: Any) -> None:
     assert attrs["gen_ai.tool.name"] == "read_file"
     assert attrs["ratel.tool.args_size_bytes"] > 0
     assert spans[0].status.status_code == StatusCode.OK
+
+
+@pytest.mark.asyncio
+async def test_search_span_shares_runtime_event_id(exporter: Any) -> None:
+    catalog = ToolCatalog()
+    skills = SkillCatalog()
+    events = RuntimeEvents([catalog, skills], session_id="session-join")
+    received: list[dict[str, Any]] = []
+    subscription = events.subscribe(lambda batch: received.extend(batch))
+    await catalog.register(_read_file())
+
+    catalog.search("read", 1)
+    await subscription.flush()
+
+    stream_event = next(
+        event for event in received if event["type"] == "search" and event["query"] == "read"
+    )
+    span = _spans_named(exporter, "ratel.search")[0]
+    assert span.attributes["ratel.event.id"] == stream_event["event_id"]
+    assert f"{span.context.trace_id:032x}" == stream_event["trace_id"]
+    assert f"{span.context.span_id:016x}" == stream_event["span_id"]
+    subscription.unsubscribe()
+
+
+@pytest.mark.asyncio
+async def test_invoke_span_and_log_share_runtime_event_id(
+    exporter: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(CAPTURE_ENV, "EVENT_ONLY")
+    catalog = ToolCatalog()
+    skills = SkillCatalog()
+    events = RuntimeEvents([catalog, skills], session_id="session-invoke")
+    received: list[dict[str, Any]] = []
+    subscription = events.subscribe(lambda batch: received.extend(batch))
+    await catalog.register(_read_file())
+
+    await catalog.invoke("read_file", {"path": "/tmp/x"})
+    await subscription.flush()
+
+    start = next(event for event in received if event["type"] == "invoke_start")
+    end = next(event for event in received if event["type"] == "invoke_end")
+    span = _spans_named(exporter, "execute_tool read_file")[0]
+    log = _log_events_named("ratel.tool.execution.details")[0]
+    assert span.attributes["ratel.event.id"] == start["event_id"]
+    assert log.attributes["ratel.event.id"] == start["event_id"]
+    assert start["invocation_id"] == end["invocation_id"]
+    assert start["event_id"] != end["event_id"]
+    subscription.unsubscribe()
 
 
 @pytest.mark.asyncio

--- a/src/sdk/ts/README.md
+++ b/src/sdk/ts/README.md
@@ -395,9 +395,9 @@ subscription.unsubscribe();
 ```
 
 Delivery is best effort, bounded, and fail-open: subscriber work never blocks catalog operations.
-`flush()` drains work already accepted by this process. The stream includes search, invocation,
-catalog churn, upstream/auth, experiment, and observable delivery-loss facts described by
-[ADR 0019](../../../docs/adr/0019-runtime-events-lane.md).
+`flush()` drains work already accepted by this process and waits for async handlers to settle.
+The stream includes search, invocation, catalog churn, upstream/auth, experiment, and observable
+delivery-loss facts described by [ADR 0019](../../../docs/adr/0019-runtime-events-lane.md).
 
 Experiments are SDK-owned facts. Pass the runtime stream as the second argument so their OTel and
 runtime projections share event IDs:

--- a/src/sdk/ts/README.md
+++ b/src/sdk/ts/README.md
@@ -397,7 +397,7 @@ subscription.unsubscribe();
 Delivery is best effort, bounded, and fail-open: subscriber work never blocks catalog operations.
 `flush()` drains work already accepted by this process and waits for async handlers to settle.
 The stream includes search, invocation, catalog churn, upstream/auth, experiment, and observable
-delivery-loss facts described by [ADR 0019](../../../docs/adr/0019-runtime-events-lane.md).
+delivery-loss facts described by [ADR 0020](../../../docs/adr/0020-runtime-events-lane.md).
 
 Experiments are SDK-owned facts. Pass the runtime stream as the second argument so their OTel and
 runtime projections share event IDs:

--- a/src/sdk/ts/README.md
+++ b/src/sdk/ts/README.md
@@ -434,4 +434,4 @@ Message and tool content is off by default; opt in with the `OTEL_INSTRUMENTATIO
 
 ## Package layout
 
-`src/` is the TypeScript surface (including `embedding-artifact.ts` for build/warm helpers), `native/` contains the NAPI binding, `npm/` holds platform packages, and tests live beside their source. From the repository root, run `pnpm --filter @ratel-ai/sdk... build` and `pnpm --filter @ratel-ai/sdk test`.
+`src/` is the TypeScript surface (including `embedding-artifact.ts` for build/warm helpers), `native/` contains the NAPI binding, `npm/` holds platform packages, and tests live beside their source. From the repository root, build with `pnpm --filter @ratel-ai/telemetry build && pnpm --filter @ratel-ai/sdk... build`; test with `pnpm --filter @ratel-ai/telemetry build && pnpm --filter @ratel-ai/sdk test`.

--- a/src/sdk/ts/README.md
+++ b/src/sdk/ts/README.md
@@ -377,6 +377,38 @@ describeAdapterConformance(myConformanceOptions(), { describe, it });
 Assertions use `node:assert`, so no test runner leaks into your published types;
 `referenceConformanceOptions` is a worked example to copy. Prefer full control? `adapterConformanceCases(options)` returns the named cases to run yourself.
 
+## Runtime events and catalog snapshots
+
+`ratel()` exposes a merged, asynchronous facts stream over its tool and skill registries. Every
+envelope has one session/source stamp and a client ULID. The matching OTel projection carries the
+same ID as `ratel.event.id`; OTel remains a parallel observability channel.
+
+```ts
+const r = ratel({ events: { sourceId: "checkout-api" } });
+const subscription = r.events.subscribe(async (batch) => publish(batch));
+
+// Full serializable state; tool executors and skill bodies are always omitted.
+const snapshot = r.catalog.snapshot();
+
+await subscription.flush();
+subscription.unsubscribe();
+```
+
+Delivery is best effort, bounded, and fail-open: subscriber work never blocks catalog operations.
+`flush()` drains work already accepted by this process. The stream includes search, invocation,
+catalog churn, upstream/auth, experiment, and observable delivery-loss facts described by
+[ADR 0019](../../../docs/adr/0019-runtime-events-lane.md).
+
+Experiments are SDK-owned facts. Pass the runtime stream as the second argument so their OTel and
+runtime projections share event IDs:
+
+```ts
+const experiment = experimentalDefineExperiment(config, r.events);
+```
+
+`catalog.snapshot()` is deliberately separate from the event stream: consumers publish it as an
+atomic full replacement under `snapshot.source_id`.
+
 ## Telemetry
 
 Telemetry is emit-only and always on: the SDK writes `ratel.*` / `gen_ai.*` spans and EventRecords to whatever OpenTelemetry providers are registered globally, and registers none itself — with no provider wired, every span is a no-op, so there is nothing to configure or switch off. Delivery is yours:

--- a/src/sdk/ts/native/src/lib.rs
+++ b/src/sdk/ts/native/src/lib.rs
@@ -49,6 +49,28 @@ pub struct TraceEventSubscriptionConfig {
     pub batch_size: Option<u32>,
 }
 
+/// Per-event identity and active OpenTelemetry correlation from TypeScript.
+#[napi(object)]
+pub struct TraceEventContextConfig {
+    pub event_id: Option<String>,
+    pub invocation_id: Option<String>,
+    pub trace_id: Option<String>,
+    pub span_id: Option<String>,
+}
+
+fn trace_event_context(config: Option<TraceEventContextConfig>) -> core::TraceEventContext {
+    let Some(config) = config else {
+        return core::TraceEventContext::default();
+    };
+    core::TraceEventContext {
+        event_id: config.event_id,
+        invocation_id: config.invocation_id,
+        trace_id: config.trace_id,
+        span_id: config.span_id,
+        ..core::TraceEventContext::default()
+    }
+}
+
 /// Handle for one native runtime-event callback subscription.
 #[napi]
 pub struct NativeEventSubscription {
@@ -419,6 +441,7 @@ pub struct ToolSearchTask {
     top_k: u32,
     origin: String,
     method: String,
+    context: core::TraceEventContext,
     _permit: Option<DenseOperationPermit>,
 }
 
@@ -436,6 +459,7 @@ pub struct SkillSearchTask {
     top_k: u32,
     origin: String,
     method: String,
+    context: core::TraceEventContext,
     _permit: Option<DenseOperationPermit>,
 }
 
@@ -567,11 +591,12 @@ impl Task for ToolSearchTask {
             .read()
             .map_err(|_| napi::Error::from_reason("tool registry lock poisoned"))?;
         registry
-            .search_with_method(
+            .search_with_method_and_context(
                 &self.query,
                 self.top_k as usize,
                 parsed_origin,
                 parsed_method,
+                self.context.clone(),
             )
             .map(|hits| {
                 hits.into_iter()
@@ -693,11 +718,12 @@ impl Task for SkillSearchTask {
             .read()
             .map_err(|_| napi::Error::from_reason("skill registry lock poisoned"))?;
         registry
-            .search_with_method(
+            .search_with_method_and_context(
                 &self.query,
                 self.top_k as usize,
                 parsed_origin,
                 parsed_method,
+                self.context.clone(),
             )
             .map(|hits| {
                 hits.into_iter()
@@ -1156,6 +1182,7 @@ impl ToolRegistry {
         top_k: u32,
         origin: String,
         method: String,
+        context: Option<TraceEventContextConfig>,
     ) -> napi::Result<Vec<SearchHit>> {
         let parsed_origin = match origin.as_str() {
             "agent" => Origin::Agent,
@@ -1176,7 +1203,13 @@ impl ToolRegistry {
             .inner
             .read()
             .map_err(|_| napi::Error::from_reason("tool registry lock poisoned"))?
-            .search_with_method(&query, top_k as usize, parsed_origin, parsed_method)
+            .search_with_method_and_context(
+                &query,
+                top_k as usize,
+                parsed_origin,
+                parsed_method,
+                trace_event_context(context),
+            )
             .map_err(|e| napi::Error::from_reason(e.to_string()))?;
         Ok(hits
             .into_iter()
@@ -1197,6 +1230,7 @@ impl ToolRegistry {
         top_k: u32,
         origin: String,
         method: String,
+        context: Option<TraceEventContextConfig>,
     ) -> AsyncTask<ToolSearchTask> {
         let is_dense = matches!(method.as_str(), "semantic" | "dense" | "hybrid");
         AsyncTask::new(ToolSearchTask {
@@ -1206,6 +1240,7 @@ impl ToolRegistry {
             top_k,
             origin,
             method,
+            context: trace_event_context(context),
             _permit: is_dense.then(|| DenseOperationPermit::new(self.pending_dense.clone())),
         })
     }
@@ -1277,6 +1312,22 @@ impl ToolRegistry {
             .read()
             .map_err(|_| napi::Error::from_reason("tool registry lock poisoned"))?
             .record_event(event);
+        Ok(())
+    }
+
+    /// Record an event with caller-supplied identity and OTel correlation.
+    #[napi]
+    pub fn record_event_with_context(
+        &self,
+        event: Value,
+        context: TraceEventContextConfig,
+    ) -> napi::Result<()> {
+        let event: TraceEvent = serde_json::from_value(event)
+            .map_err(|e| napi::Error::from_reason(format!("invalid trace event: {e}")))?;
+        self.inner
+            .read()
+            .map_err(|_| napi::Error::from_reason("tool registry lock poisoned"))?
+            .record_event_with_context(event, trace_event_context(Some(context)));
         Ok(())
     }
 
@@ -1986,6 +2037,7 @@ impl SkillRegistry {
         top_k: u32,
         origin: String,
         method: String,
+        context: Option<TraceEventContextConfig>,
     ) -> napi::Result<Vec<SkillHit>> {
         let parsed_origin = match origin.as_str() {
             "agent" => Origin::Agent,
@@ -2006,7 +2058,13 @@ impl SkillRegistry {
             .inner
             .read()
             .map_err(|_| napi::Error::from_reason("skill registry lock poisoned"))?
-            .search_with_method(&query, top_k as usize, parsed_origin, parsed_method)
+            .search_with_method_and_context(
+                &query,
+                top_k as usize,
+                parsed_origin,
+                parsed_method,
+                trace_event_context(context),
+            )
             .map_err(|e| napi::Error::from_reason(e.to_string()))?;
         Ok(hits
             .into_iter()
@@ -2027,6 +2085,7 @@ impl SkillRegistry {
         top_k: u32,
         origin: String,
         method: String,
+        context: Option<TraceEventContextConfig>,
     ) -> AsyncTask<SkillSearchTask> {
         let is_dense = matches!(method.as_str(), "semantic" | "dense" | "hybrid");
         AsyncTask::new(SkillSearchTask {
@@ -2036,6 +2095,7 @@ impl SkillRegistry {
             top_k,
             origin,
             method,
+            context: trace_event_context(context),
             _permit: is_dense.then(|| DenseOperationPermit::new(self.pending_dense.clone())),
         })
     }
@@ -2098,6 +2158,22 @@ impl SkillRegistry {
             .read()
             .map_err(|_| napi::Error::from_reason("skill registry lock poisoned"))?
             .record_event(event);
+        Ok(())
+    }
+
+    /// Record an event with caller-supplied identity and OTel correlation.
+    #[napi]
+    pub fn record_event_with_context(
+        &self,
+        event: Value,
+        context: TraceEventContextConfig,
+    ) -> napi::Result<()> {
+        let event: TraceEvent = serde_json::from_value(event)
+            .map_err(|e| napi::Error::from_reason(format!("invalid trace event: {e}")))?;
+        self.inner
+            .read()
+            .map_err(|_| napi::Error::from_reason("skill registry lock poisoned"))?
+            .record_event_with_context(event, trace_event_context(Some(context)));
         Ok(())
     }
 

--- a/src/sdk/ts/native/src/lib.rs
+++ b/src/sdk/ts/native/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate napi_derive;
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
 use std::sync::{Arc, Condvar, Mutex, RwLock, RwLockWriteGuard};
 use std::thread;
@@ -75,7 +75,10 @@ fn trace_event_context(config: Option<TraceEventContextConfig>) -> core::TraceEv
 #[napi]
 pub struct NativeEventSubscription {
     subscription: Arc<Mutex<Option<Arc<core::FanoutSubscription>>>>,
-    callback: Arc<EventCallbackSink>,
+    // Retain progress, not the sink: unsubscribe must release its sender so
+    // the callback dispatcher observes a disconnected receiver and exits.
+    progress: Arc<EventCallbackProgress>,
+    final_dropped_count: AtomicU64,
 }
 
 #[napi]
@@ -87,30 +90,30 @@ impl NativeEventSubscription {
     pub fn flush(&self) -> AsyncTask<FlushEventSubscriptionTask> {
         AsyncTask::new(FlushEventSubscriptionTask {
             subscription: self.subscription.clone(),
-            callback: self.callback.clone(),
+            progress: self.progress.clone(),
         })
     }
 
     /// Stop accepting new events. Envelopes already queued still drain.
     #[napi]
     pub fn unsubscribe(&self) {
-        if let Ok(mut subscription) = self.subscription.lock() {
-            subscription.take();
+        if let Ok(mut subscription) = self.subscription.lock()
+            && let Some(subscription) = subscription.take()
+        {
+            self.final_dropped_count
+                .store(subscription.dropped_count(), Ordering::Relaxed);
         }
     }
 
     /// Number of envelopes displaced by this subscriber's bounded queue.
     #[napi(getter)]
     pub fn dropped_count(&self) -> f64 {
-        self.subscription
-            .lock()
-            .ok()
-            .and_then(|subscription| {
-                subscription
-                    .as_ref()
-                    .map(|subscription| subscription.dropped_count())
-            })
-            .unwrap_or(0) as f64
+        let current = self.subscription.lock().ok().and_then(|subscription| {
+            subscription
+                .as_ref()
+                .map(|subscription| subscription.dropped_count())
+        });
+        current.unwrap_or_else(|| self.final_dropped_count.load(Ordering::Relaxed)) as f64
     }
 }
 
@@ -143,7 +146,7 @@ struct EventCallbackState {
 
 pub struct FlushEventSubscriptionTask {
     subscription: Arc<Mutex<Option<Arc<core::FanoutSubscription>>>>,
-    callback: Arc<EventCallbackSink>,
+    progress: Arc<EventCallbackProgress>,
 }
 
 impl EventStream {
@@ -201,10 +204,6 @@ impl EventCallbackSink {
         spawn_event_callback_dispatcher(receiver, callback, batch_size, progress);
         sink
     }
-
-    fn flush(&self) {
-        self.progress.flush();
-    }
 }
 
 impl EventCallbackProgress {
@@ -255,7 +254,7 @@ impl Task for FlushEventSubscriptionTask {
         if let Some(subscription) = subscription {
             subscription.flush();
         }
-        self.callback.flush();
+        self.progress.flush();
         Ok(())
     }
 
@@ -299,7 +298,8 @@ fn subscribe_event_callback(
         .subscribe(callback_sink.clone(), queue_capacity);
     Ok(NativeEventSubscription {
         subscription: Arc::new(Mutex::new(Some(Arc::new(subscription)))),
-        callback: callback_sink,
+        progress: callback_sink.progress.clone(),
+        final_dropped_count: AtomicU64::new(0),
     })
 }
 

--- a/src/sdk/ts/native/src/lib.rs
+++ b/src/sdk/ts/native/src/lib.rs
@@ -5,20 +5,29 @@ extern crate napi_derive;
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, RwLock, RwLockWriteGuard};
+use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
+use std::sync::{Arc, Condvar, Mutex, RwLock, RwLockWriteGuard};
+use std::thread;
+use std::time::Duration;
 
-use napi::bindgen_prelude::{AsyncTask, Buffer};
-use napi::{Env, Task};
+use napi::bindgen_prelude::{AsyncTask, Buffer, Function};
+use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
+use napi::{Env, Status, Task};
 use ratel_ai_core as core;
 use ratel_ai_core::{
     ArtifactError, EmbeddingModel, EmbeddingSpec, JsonlSink, MemorySink, NoopSink, OnArtifactMiss,
-    Origin, SearchMethod, TraceEvent, UsageLearner,
+    Origin, SearchMethod, TraceEnvelope, TraceEvent, UsageLearner,
 };
 use serde_json::{Value, json};
 
 /// A constructed sink plus the `MemorySink` handle when the kind is `"memory"`
 /// (so the owner can drain it later).
 type BuiltTraceSink = (Arc<dyn core::TraceSink>, Option<Arc<MemorySink>>);
+type EventCallback = ThreadsafeFunction<Vec<Value>, (), Vec<Value>, Status, false, false, 1>;
+
+const DEFAULT_EVENT_QUEUE_CAPACITY: usize = 1_024;
+const DEFAULT_EVENT_BATCH_SIZE: usize = 64;
+const EVENT_BATCH_DELAY: Duration = Duration::from_millis(1);
 
 const REGISTRY_BUSY_MESSAGE: &str =
     "registry busy; await the active operation before registering more items";
@@ -30,6 +39,283 @@ const ARTIFACT_WARM_ERROR_PREFIX: &str = "RATEL_ARTIFACT_WARM_ERROR:";
 /// Private NAPI→TypeScript transport prefix for artifact build/merge errors.
 /// Must stay identical to the constant in `src/sdk/ts/src/errors.ts`.
 const ARTIFACT_ERROR_PREFIX: &str = "RATEL_ARTIFACT_ERROR:";
+
+/// Private native configuration consumed by the public SDK in Phase 4.
+#[napi(object)]
+pub struct TraceEventSubscriptionConfig {
+    pub session_id: String,
+    pub source_id: Option<String>,
+    pub queue_capacity: Option<u32>,
+    pub batch_size: Option<u32>,
+}
+
+/// Handle for one native runtime-event callback subscription.
+#[napi]
+pub struct NativeEventSubscription {
+    subscription: Arc<Mutex<Option<core::FanoutSubscription>>>,
+    callback: Arc<EventCallbackSink>,
+}
+
+#[napi]
+impl NativeEventSubscription {
+    /// Wait off the JavaScript thread until all work accepted by this subscriber
+    /// has reached the callback. Events dropped before delivery remain reported
+    /// by an `events_dropped` envelope.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn flush(&self) -> AsyncTask<FlushEventSubscriptionTask> {
+        AsyncTask::new(FlushEventSubscriptionTask {
+            subscription: self.subscription.clone(),
+            callback: self.callback.clone(),
+        })
+    }
+
+    /// Stop future delivery. Already-running callback work is best-effort.
+    #[napi]
+    pub fn unsubscribe(&self) {
+        if let Ok(mut subscription) = self.subscription.lock() {
+            subscription.take();
+        }
+    }
+
+    /// Number of envelopes displaced by this subscriber's bounded queue.
+    #[napi(getter)]
+    pub fn dropped_count(&self) -> f64 {
+        self.subscription
+            .lock()
+            .ok()
+            .and_then(|subscription| {
+                subscription
+                    .as_ref()
+                    .map(core::FanoutSubscription::dropped_count)
+            })
+            .unwrap_or(0) as f64
+    }
+}
+
+struct EventStream {
+    fanout: Arc<core::FanoutSink>,
+    base_subscription: core::FanoutSubscription,
+    session_id: String,
+    source_id: Option<String>,
+}
+
+struct EventCallbackSink {
+    sender: SyncSender<TraceEnvelope>,
+    progress: Arc<EventCallbackProgress>,
+}
+
+struct EventCallbackProgress {
+    state: Mutex<EventCallbackState>,
+    changed: Condvar,
+}
+
+#[derive(Default)]
+struct EventCallbackState {
+    accepted: u64,
+    delivered: u64,
+}
+
+pub struct FlushEventSubscriptionTask {
+    subscription: Arc<Mutex<Option<core::FanoutSubscription>>>,
+    callback: Arc<EventCallbackSink>,
+}
+
+impl EventStream {
+    fn new(
+        session_id: String,
+        source_id: Option<String>,
+        base_sink: Arc<dyn core::TraceSink>,
+    ) -> Self {
+        let fanout = Arc::new(match source_id.as_ref() {
+            Some(source_id) => core::FanoutSink::with_source(&session_id, source_id),
+            None => core::FanoutSink::new(&session_id),
+        });
+        let base_subscription = fanout.subscribe(base_sink, DEFAULT_EVENT_QUEUE_CAPACITY);
+        Self {
+            fanout,
+            base_subscription,
+            session_id,
+            source_id,
+        }
+    }
+
+    fn validate_identity(&self, config: &TraceEventSubscriptionConfig) -> napi::Result<()> {
+        if self.session_id != config.session_id || self.source_id != config.source_id {
+            return Err(napi::Error::from_reason(
+                "runtime event stream already configured with a different sessionId/sourceId",
+            ));
+        }
+        Ok(())
+    }
+
+    fn replace_base_sink(&mut self, sink: Arc<dyn core::TraceSink>) {
+        self.base_subscription = self.fanout.subscribe(sink, DEFAULT_EVENT_QUEUE_CAPACITY);
+    }
+}
+
+impl EventCallbackSink {
+    fn new(callback: Arc<EventCallback>, batch_size: usize) -> Arc<Self> {
+        let (sender, receiver) = sync_channel(batch_size);
+        let progress = Arc::new(EventCallbackProgress {
+            state: Mutex::new(EventCallbackState::default()),
+            changed: Condvar::new(),
+        });
+        let sink = Arc::new(Self {
+            sender,
+            progress: progress.clone(),
+        });
+        spawn_event_callback_dispatcher(receiver, callback, batch_size, progress);
+        sink
+    }
+
+    fn flush(&self) {
+        self.progress.flush();
+    }
+}
+
+impl EventCallbackProgress {
+    fn flush(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while state.delivered < state.accepted {
+            state = self
+                .changed
+                .wait(state)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+    }
+
+    fn mark_delivered(&self, count: usize) {
+        if let Ok(mut state) = self.state.lock() {
+            state.delivered += count as u64;
+            self.changed.notify_all();
+        }
+    }
+}
+
+impl core::TraceSink for EventCallbackSink {
+    fn record(&self, _event: TraceEvent) {}
+
+    fn record_envelope(&self, envelope: TraceEnvelope) {
+        if let Ok(mut state) = self.progress.state.lock() {
+            state.accepted += 1;
+        }
+        if self.sender.send(envelope).is_err() {
+            self.progress.mark_delivered(1);
+        }
+    }
+}
+
+impl Task for FlushEventSubscriptionTask {
+    type Output = ();
+    type JsValue = ();
+
+    fn compute(&mut self) -> napi::Result<Self::Output> {
+        if let Ok(subscription) = self.subscription.lock()
+            && let Some(subscription) = subscription.as_ref()
+        {
+            subscription.flush();
+        }
+        self.callback.flush();
+        Ok(())
+    }
+
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> napi::Result<Self::JsValue> {
+        Ok(output)
+    }
+}
+
+fn subscribe_event_callback(
+    stream: &mut Option<EventStream>,
+    base_sink: Arc<dyn core::TraceSink>,
+    callback: Function<'_, Vec<Value>, ()>,
+    config: TraceEventSubscriptionConfig,
+) -> napi::Result<NativeEventSubscription> {
+    let queue_capacity = config
+        .queue_capacity
+        .map(|capacity| capacity as usize)
+        .unwrap_or(DEFAULT_EVENT_QUEUE_CAPACITY)
+        .max(1);
+    let batch_size = config
+        .batch_size
+        .map(|size| size as usize)
+        .unwrap_or(DEFAULT_EVENT_BATCH_SIZE)
+        .max(1);
+    let callback = Arc::new(
+        callback
+            .build_threadsafe_function::<Vec<Value>>()
+            .max_queue_size::<1>()
+            .build_callback(|context| Ok(context.value))?,
+    );
+    let callback_sink = EventCallbackSink::new(callback, batch_size);
+    let stream = match stream {
+        Some(stream) => {
+            stream.validate_identity(&config)?;
+            stream
+        }
+        slot @ None => slot.insert(EventStream::new(
+            config.session_id,
+            config.source_id,
+            base_sink,
+        )),
+    };
+    let subscription = stream
+        .fanout
+        .subscribe(callback_sink.clone(), queue_capacity);
+    Ok(NativeEventSubscription {
+        subscription: Arc::new(Mutex::new(Some(subscription))),
+        callback: callback_sink,
+    })
+}
+
+fn spawn_event_callback_dispatcher(
+    receiver: Receiver<TraceEnvelope>,
+    callback: Arc<EventCallback>,
+    batch_size: usize,
+    progress: Arc<EventCallbackProgress>,
+) {
+    thread::spawn(move || dispatch_event_callbacks(receiver, callback, batch_size, progress));
+}
+
+fn dispatch_event_callbacks(
+    receiver: Receiver<TraceEnvelope>,
+    callback: Arc<EventCallback>,
+    batch_size: usize,
+    progress: Arc<EventCallbackProgress>,
+) {
+    while let Ok(first) = receiver.recv() {
+        let mut envelopes = vec![first];
+        while envelopes.len() < batch_size {
+            match receiver.recv_timeout(EVENT_BATCH_DELAY) {
+                Ok(envelope) => envelopes.push(envelope),
+                Err(_) => break,
+            }
+        }
+        let delivered = envelopes.len();
+        let values = envelopes
+            .into_iter()
+            .filter_map(|envelope| serde_json::to_value(envelope).ok())
+            .collect();
+        let (acknowledged, wait_for_ack) = sync_channel(0);
+        let status = callback.call_with_return_value(
+            values,
+            ThreadsafeFunctionCallMode::NonBlocking,
+            move |_result, _env| {
+                let _ = acknowledged.send(());
+                Ok(())
+            },
+        );
+        if status == Status::Ok {
+            let _ = wait_for_ack.recv();
+        }
+        progress.mark_delivered(delivered);
+        if status == Status::Closing {
+            break;
+        }
+    }
+}
 
 fn artifact_error_variant_code(error: &ArtifactError) -> &'static str {
     match error {
@@ -472,6 +758,28 @@ fn build_trace_sink(config: TraceSinkConfig) -> napi::Result<BuiltTraceSink> {
     }
 }
 
+fn wrap_learner(
+    sink: Arc<dyn core::TraceSink>,
+    graph: Option<&Arc<RwLock<core::IntentGraph>>>,
+) -> Arc<dyn core::TraceSink> {
+    match graph {
+        Some(graph) => Arc::new(UsageLearner::new(graph.clone(), sink)),
+        None => sink,
+    }
+}
+
+fn active_trace_sink(
+    base_sink: &Arc<dyn core::TraceSink>,
+    graph: Option<&Arc<RwLock<core::IntentGraph>>>,
+    event_stream: &Option<EventStream>,
+) -> Arc<dyn core::TraceSink> {
+    let sink: Arc<dyn core::TraceSink> = match event_stream {
+        Some(stream) => stream.fanout.clone(),
+        None => base_sink.clone(),
+    };
+    wrap_learner(sink, graph)
+}
+
 /// A tool's searchable metadata: what the registry indexes and what a search
 /// hit resolves back to. Execution lives a layer up (the SDK's `ToolCatalog`
 /// pairs each `Tool` with its executor).
@@ -737,6 +1045,9 @@ pub struct ToolRegistry {
     /// Retained so `setTraceSink` can re-wrap the new sink in a learner —
     /// otherwise changing sinks would silently switch learning off.
     graph: Option<Arc<RwLock<core::IntentGraph>>>,
+    /// Created lazily by the private native subscription seam. The fan-out
+    /// remains the registry's root sink while callbacks and base sinks change.
+    event_stream: Option<EventStream>,
 }
 
 #[napi]
@@ -757,6 +1068,7 @@ impl ToolRegistry {
             memory_sink: None,
             base_sink: Arc::new(NoopSink),
             graph: None,
+            event_stream: None,
         })
     }
 
@@ -968,6 +1280,31 @@ impl ToolRegistry {
         Ok(())
     }
 
+    /// Attach a private batched push subscriber. The public SDK wraps this in
+    /// Phase 4; callback invocation always occurs on Node's JavaScript thread,
+    /// while worker-thread producers only enqueue into a bounded fan-out queue.
+    #[napi]
+    pub fn subscribe_trace_events(
+        &mut self,
+        callback: Function<'_, Vec<Value>, ()>,
+        config: TraceEventSubscriptionConfig,
+    ) -> napi::Result<NativeEventSubscription> {
+        let mut registry = write_registry(&self.inner, &self.pending_dense)?;
+        let subscription = subscribe_event_callback(
+            &mut self.event_stream,
+            self.base_sink.clone(),
+            callback,
+            config,
+        )?;
+        let stream = self
+            .event_stream
+            .as_ref()
+            .expect("event stream initialized by subscribe_event_callback");
+        let sink = wrap_learner(stream.fanout.clone(), self.graph.as_ref());
+        registry.set_trace_sink(sink);
+        Ok(subscription)
+    }
+
     /// Replace the trace sink; subsequent events go to the new destination,
     /// already-recorded ones are not replayed. Throws on an unknown `kind`, a
     /// missing `sessionId`/`path`, or a `"jsonl"` file that can't be opened.
@@ -977,14 +1314,10 @@ impl ToolRegistry {
         // Retain the raw sink so enable/disable can re-wrap or restore it —
         // rebuilding from `memory_sink` alone would drop a jsonl sink to noop.
         self.base_sink = sink.clone();
-        // Re-wrap: adaptive ranking learns by decorating the sink, so replacing
-        // the sink outright would quietly stop learning.
-        let sink = match &self.graph {
-            Some(graph) => {
-                Arc::new(UsageLearner::new(graph.clone(), sink)) as Arc<dyn core::TraceSink>
-            }
-            None => sink,
-        };
+        if let Some(stream) = self.event_stream.as_mut() {
+            stream.replace_base_sink(sink);
+        }
+        let sink = active_trace_sink(&self.base_sink, self.graph.as_ref(), &self.event_stream);
         let mut registry = write_registry(&self.inner, &self.pending_dense)?;
         registry.set_trace_sink(sink);
         drop(registry);
@@ -1006,10 +1339,9 @@ impl ToolRegistry {
     #[napi]
     pub fn enable_adaptive_ranking(&mut self, graph: &IntentGraph) -> napi::Result<()> {
         let handle = graph.inner.clone();
-        let inner_sink = self.base_sink.clone();
-        let learner = Arc::new(UsageLearner::new(handle.clone(), inner_sink));
+        let sink = active_trace_sink(&self.base_sink, Some(&handle), &self.event_stream);
         let mut registry = write_registry(&self.inner, &self.pending_dense)?;
-        registry.set_trace_sink(learner);
+        registry.set_trace_sink(sink);
         registry.set_intent_graph(Some(handle.clone()));
         drop(registry);
         self.graph = Some(handle);
@@ -1021,9 +1353,9 @@ impl ToolRegistry {
     /// resumes from what it already learned.
     #[napi]
     pub fn disable_adaptive_ranking(&mut self) -> napi::Result<()> {
-        let inner_sink = self.base_sink.clone();
+        let sink = active_trace_sink(&self.base_sink, None, &self.event_stream);
         let mut registry = write_registry(&self.inner, &self.pending_dense)?;
-        registry.set_trace_sink(inner_sink);
+        registry.set_trace_sink(sink);
         registry.set_intent_graph(None);
         drop(registry);
         self.graph = None;
@@ -1515,6 +1847,7 @@ pub struct SkillRegistry {
     /// Retained so `setTraceSink` can re-wrap the new sink in a learner —
     /// otherwise changing sinks would silently switch learning off.
     graph: Option<Arc<RwLock<core::IntentGraph>>>,
+    event_stream: Option<EventStream>,
 }
 
 #[napi]
@@ -1533,6 +1866,7 @@ impl SkillRegistry {
             memory_sink: None,
             base_sink: Arc::new(NoopSink),
             graph: None,
+            event_stream: None,
         })
     }
 
@@ -1764,6 +2098,30 @@ impl SkillRegistry {
         Ok(())
     }
 
+    /// Attach the private batched push seam — see
+    /// [`ToolRegistry::subscribe_trace_events`].
+    #[napi]
+    pub fn subscribe_trace_events(
+        &mut self,
+        callback: Function<'_, Vec<Value>, ()>,
+        config: TraceEventSubscriptionConfig,
+    ) -> napi::Result<NativeEventSubscription> {
+        let mut registry = write_registry(&self.inner, &self.pending_dense)?;
+        let subscription = subscribe_event_callback(
+            &mut self.event_stream,
+            self.base_sink.clone(),
+            callback,
+            config,
+        )?;
+        let stream = self
+            .event_stream
+            .as_ref()
+            .expect("event stream initialized by subscribe_event_callback");
+        let sink = wrap_learner(stream.fanout.clone(), self.graph.as_ref());
+        registry.set_trace_sink(sink);
+        Ok(subscription)
+    }
+
     /// Replace the trace sink — see `ToolRegistry.setTraceSink`.
     #[napi]
     pub fn set_trace_sink(&mut self, config: TraceSinkConfig) -> napi::Result<()> {
@@ -1771,14 +2129,10 @@ impl SkillRegistry {
         // Retain the raw sink so enable/disable can re-wrap or restore it —
         // rebuilding from `memory_sink` alone would drop a jsonl sink to noop.
         self.base_sink = sink.clone();
-        // Re-wrap: adaptive ranking learns by decorating the sink, so replacing
-        // the sink outright would quietly stop learning.
-        let sink = match &self.graph {
-            Some(graph) => {
-                Arc::new(UsageLearner::new(graph.clone(), sink)) as Arc<dyn core::TraceSink>
-            }
-            None => sink,
-        };
+        if let Some(stream) = self.event_stream.as_mut() {
+            stream.replace_base_sink(sink);
+        }
+        let sink = active_trace_sink(&self.base_sink, self.graph.as_ref(), &self.event_stream);
         let mut registry = write_registry(&self.inner, &self.pending_dense)?;
         registry.set_trace_sink(sink);
         drop(registry);
@@ -1800,10 +2154,9 @@ impl SkillRegistry {
     #[napi]
     pub fn enable_adaptive_ranking(&mut self, graph: &IntentGraph) -> napi::Result<()> {
         let handle = graph.inner.clone();
-        let inner_sink = self.base_sink.clone();
-        let learner = Arc::new(UsageLearner::new(handle.clone(), inner_sink));
+        let sink = active_trace_sink(&self.base_sink, Some(&handle), &self.event_stream);
         let mut registry = write_registry(&self.inner, &self.pending_dense)?;
-        registry.set_trace_sink(learner);
+        registry.set_trace_sink(sink);
         registry.set_intent_graph(Some(handle.clone()));
         drop(registry);
         self.graph = Some(handle);
@@ -1815,9 +2168,9 @@ impl SkillRegistry {
     /// resumes from what it already learned.
     #[napi]
     pub fn disable_adaptive_ranking(&mut self) -> napi::Result<()> {
-        let inner_sink = self.base_sink.clone();
+        let sink = active_trace_sink(&self.base_sink, None, &self.event_stream);
         let mut registry = write_registry(&self.inner, &self.pending_dense)?;
-        registry.set_trace_sink(inner_sink);
+        registry.set_trace_sink(sink);
         registry.set_intent_graph(None);
         drop(registry);
         self.graph = None;

--- a/src/sdk/ts/native/src/lib.rs
+++ b/src/sdk/ts/native/src/lib.rs
@@ -23,7 +23,7 @@ use serde_json::{Value, json};
 /// A constructed sink plus the `MemorySink` handle when the kind is `"memory"`
 /// (so the owner can drain it later).
 type BuiltTraceSink = (Arc<dyn core::TraceSink>, Option<Arc<MemorySink>>);
-type EventCallback = ThreadsafeFunction<Vec<Value>, (), Vec<Value>, Status, false, false, 1>;
+type EventCallback = ThreadsafeFunction<Vec<Value>, (), Vec<Value>, Status, false, true, 1>;
 
 const DEFAULT_EVENT_QUEUE_CAPACITY: usize = 1_024;
 const DEFAULT_EVENT_BATCH_SIZE: usize = 64;
@@ -91,7 +91,7 @@ impl NativeEventSubscription {
         })
     }
 
-    /// Stop future delivery. Already-running callback work is best-effort.
+    /// Stop accepting new events. Envelopes already queued still drain.
     #[napi]
     pub fn unsubscribe(&self) {
         if let Ok(mut subscription) = self.subscription.lock() {
@@ -268,6 +268,7 @@ fn subscribe_event_callback(
     let callback = Arc::new(
         callback
             .build_threadsafe_function::<Vec<Value>>()
+            .weak::<true>()
             .max_queue_size::<1>()
             .build_callback(|context| Ok(context.value))?,
     );

--- a/src/sdk/ts/native/src/lib.rs
+++ b/src/sdk/ts/native/src/lib.rs
@@ -1393,6 +1393,9 @@ impl ToolRegistry {
         let Some(sink) = self.memory_sink.as_ref() else {
             return Vec::new();
         };
+        if let Some(stream) = self.event_stream.as_ref() {
+            stream.base_subscription.flush();
+        }
         sink.drain()
             .into_iter()
             .filter_map(|env| serde_json::to_value(&env).ok())
@@ -2208,6 +2211,9 @@ impl SkillRegistry {
         let Some(sink) = self.memory_sink.as_ref() else {
             return Vec::new();
         };
+        if let Some(stream) = self.event_stream.as_ref() {
+            stream.base_subscription.flush();
+        }
         sink.drain()
             .into_iter()
             .filter_map(|env| serde_json::to_value(&env).ok())

--- a/src/sdk/ts/native/src/lib.rs
+++ b/src/sdk/ts/native/src/lib.rs
@@ -74,7 +74,7 @@ fn trace_event_context(config: Option<TraceEventContextConfig>) -> core::TraceEv
 /// Handle for one native runtime-event callback subscription.
 #[napi]
 pub struct NativeEventSubscription {
-    subscription: Arc<Mutex<Option<core::FanoutSubscription>>>,
+    subscription: Arc<Mutex<Option<Arc<core::FanoutSubscription>>>>,
     callback: Arc<EventCallbackSink>,
 }
 
@@ -108,7 +108,7 @@ impl NativeEventSubscription {
             .and_then(|subscription| {
                 subscription
                     .as_ref()
-                    .map(core::FanoutSubscription::dropped_count)
+                    .map(|subscription| subscription.dropped_count())
             })
             .unwrap_or(0) as f64
     }
@@ -116,9 +116,13 @@ impl NativeEventSubscription {
 
 struct EventStream {
     fanout: Arc<core::FanoutSink>,
-    base_subscription: core::FanoutSubscription,
     session_id: String,
     source_id: Option<String>,
+}
+
+struct RuntimeEventSink {
+    base: Arc<dyn core::TraceSink>,
+    fanout: Arc<core::FanoutSink>,
 }
 
 struct EventCallbackSink {
@@ -138,24 +142,18 @@ struct EventCallbackState {
 }
 
 pub struct FlushEventSubscriptionTask {
-    subscription: Arc<Mutex<Option<core::FanoutSubscription>>>,
+    subscription: Arc<Mutex<Option<Arc<core::FanoutSubscription>>>>,
     callback: Arc<EventCallbackSink>,
 }
 
 impl EventStream {
-    fn new(
-        session_id: String,
-        source_id: Option<String>,
-        base_sink: Arc<dyn core::TraceSink>,
-    ) -> Self {
+    fn new(session_id: String, source_id: Option<String>) -> Self {
         let fanout = Arc::new(match source_id.as_ref() {
             Some(source_id) => core::FanoutSink::with_source(&session_id, source_id),
             None => core::FanoutSink::new(&session_id),
         });
-        let base_subscription = fanout.subscribe(base_sink, DEFAULT_EVENT_QUEUE_CAPACITY);
         Self {
             fanout,
-            base_subscription,
             session_id,
             source_id,
         }
@@ -169,9 +167,23 @@ impl EventStream {
         }
         Ok(())
     }
+}
 
-    fn replace_base_sink(&mut self, sink: Arc<dyn core::TraceSink>) {
-        self.base_subscription = self.fanout.subscribe(sink, DEFAULT_EVENT_QUEUE_CAPACITY);
+impl core::TraceSink for RuntimeEventSink {
+    fn record(&self, event: TraceEvent) {
+        self.base.record(event.clone());
+        self.fanout.record(event);
+    }
+
+    fn record_with_context(&self, event: TraceEvent, context: core::TraceEventContext) {
+        self.base
+            .record_with_context(event.clone(), context.clone());
+        self.fanout.record_with_context(event, context);
+    }
+
+    fn record_envelope(&self, envelope: TraceEnvelope) {
+        self.base.record_envelope(envelope.clone());
+        self.fanout.record_envelope(envelope);
     }
 }
 
@@ -235,9 +247,12 @@ impl Task for FlushEventSubscriptionTask {
     type JsValue = ();
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
-        if let Ok(subscription) = self.subscription.lock()
-            && let Some(subscription) = subscription.as_ref()
-        {
+        let subscription = self
+            .subscription
+            .lock()
+            .ok()
+            .and_then(|subscription| subscription.clone());
+        if let Some(subscription) = subscription {
             subscription.flush();
         }
         self.callback.flush();
@@ -251,7 +266,6 @@ impl Task for FlushEventSubscriptionTask {
 
 fn subscribe_event_callback(
     stream: &mut Option<EventStream>,
-    base_sink: Arc<dyn core::TraceSink>,
     callback: Function<'_, Vec<Value>, ()>,
     config: TraceEventSubscriptionConfig,
 ) -> napi::Result<NativeEventSubscription> {
@@ -278,17 +292,13 @@ fn subscribe_event_callback(
             stream.validate_identity(&config)?;
             stream
         }
-        slot @ None => slot.insert(EventStream::new(
-            config.session_id,
-            config.source_id,
-            base_sink,
-        )),
+        slot @ None => slot.insert(EventStream::new(config.session_id, config.source_id)),
     };
     let subscription = stream
         .fanout
         .subscribe(callback_sink.clone(), queue_capacity);
     Ok(NativeEventSubscription {
-        subscription: Arc::new(Mutex::new(Some(subscription))),
+        subscription: Arc::new(Mutex::new(Some(Arc::new(subscription)))),
         callback: callback_sink,
     })
 }
@@ -801,7 +811,10 @@ fn active_trace_sink(
     event_stream: &Option<EventStream>,
 ) -> Arc<dyn core::TraceSink> {
     let sink: Arc<dyn core::TraceSink> = match event_stream {
-        Some(stream) => stream.fanout.clone(),
+        Some(stream) => Arc::new(RuntimeEventSink {
+            base: base_sink.clone(),
+            fanout: stream.fanout.clone(),
+        }),
         None => base_sink.clone(),
     };
     wrap_learner(sink, graph)
@@ -1342,17 +1355,8 @@ impl ToolRegistry {
         config: TraceEventSubscriptionConfig,
     ) -> napi::Result<NativeEventSubscription> {
         let mut registry = write_registry(&self.inner, &self.pending_dense)?;
-        let subscription = subscribe_event_callback(
-            &mut self.event_stream,
-            self.base_sink.clone(),
-            callback,
-            config,
-        )?;
-        let stream = self
-            .event_stream
-            .as_ref()
-            .expect("event stream initialized by subscribe_event_callback");
-        let sink = wrap_learner(stream.fanout.clone(), self.graph.as_ref());
+        let subscription = subscribe_event_callback(&mut self.event_stream, callback, config)?;
+        let sink = active_trace_sink(&self.base_sink, self.graph.as_ref(), &self.event_stream);
         registry.set_trace_sink(sink);
         Ok(subscription)
     }
@@ -1363,14 +1367,11 @@ impl ToolRegistry {
     #[napi]
     pub fn set_trace_sink(&mut self, config: TraceSinkConfig) -> napi::Result<()> {
         let (sink, memory) = build_trace_sink(config)?;
+        let mut registry = write_registry(&self.inner, &self.pending_dense)?;
         // Retain the raw sink so enable/disable can re-wrap or restore it —
         // rebuilding from `memory_sink` alone would drop a jsonl sink to noop.
         self.base_sink = sink.clone();
-        if let Some(stream) = self.event_stream.as_mut() {
-            stream.replace_base_sink(sink);
-        }
         let sink = active_trace_sink(&self.base_sink, self.graph.as_ref(), &self.event_stream);
-        let mut registry = write_registry(&self.inner, &self.pending_dense)?;
         registry.set_trace_sink(sink);
         drop(registry);
         self.memory_sink = memory;
@@ -1445,9 +1446,6 @@ impl ToolRegistry {
         let Some(sink) = self.memory_sink.as_ref() else {
             return Vec::new();
         };
-        if let Some(stream) = self.event_stream.as_ref() {
-            stream.base_subscription.flush();
-        }
         sink.drain()
             .into_iter()
             .filter_map(|env| serde_json::to_value(&env).ok())
@@ -2187,17 +2185,8 @@ impl SkillRegistry {
         config: TraceEventSubscriptionConfig,
     ) -> napi::Result<NativeEventSubscription> {
         let mut registry = write_registry(&self.inner, &self.pending_dense)?;
-        let subscription = subscribe_event_callback(
-            &mut self.event_stream,
-            self.base_sink.clone(),
-            callback,
-            config,
-        )?;
-        let stream = self
-            .event_stream
-            .as_ref()
-            .expect("event stream initialized by subscribe_event_callback");
-        let sink = wrap_learner(stream.fanout.clone(), self.graph.as_ref());
+        let subscription = subscribe_event_callback(&mut self.event_stream, callback, config)?;
+        let sink = active_trace_sink(&self.base_sink, self.graph.as_ref(), &self.event_stream);
         registry.set_trace_sink(sink);
         Ok(subscription)
     }
@@ -2206,14 +2195,11 @@ impl SkillRegistry {
     #[napi]
     pub fn set_trace_sink(&mut self, config: TraceSinkConfig) -> napi::Result<()> {
         let (sink, memory) = build_trace_sink(config)?;
+        let mut registry = write_registry(&self.inner, &self.pending_dense)?;
         // Retain the raw sink so enable/disable can re-wrap or restore it —
         // rebuilding from `memory_sink` alone would drop a jsonl sink to noop.
         self.base_sink = sink.clone();
-        if let Some(stream) = self.event_stream.as_mut() {
-            stream.replace_base_sink(sink);
-        }
         let sink = active_trace_sink(&self.base_sink, self.graph.as_ref(), &self.event_stream);
-        let mut registry = write_registry(&self.inner, &self.pending_dense)?;
         registry.set_trace_sink(sink);
         drop(registry);
         self.memory_sink = memory;
@@ -2288,9 +2274,6 @@ impl SkillRegistry {
         let Some(sink) = self.memory_sink.as_ref() else {
             return Vec::new();
         };
-        if let Some(stream) = self.event_stream.as_ref() {
-            stream.base_subscription.flush();
-        }
         sink.drain()
             .into_iter()
             .filter_map(|env| serde_json::to_value(&env).ok())

--- a/src/sdk/ts/src/capabilities.ts
+++ b/src/sdk/ts/src/capabilities.ts
@@ -659,12 +659,15 @@ function handleInvokeError(
   if (isUnauthorizedError(error)) {
     const upstream = upstreamFromToolId(toolId);
     const finish = () => {
-      recordAuthNeeded(upstream);
-      catalog.recordEvent({
-        type: "gateway_error",
-        tool_id: toolId,
-        error: "needs_auth",
-      });
+      const projection = recordAuthNeeded(upstream);
+      catalog.recordEvent(
+        {
+          type: "gateway_error",
+          tool_id: toolId,
+          error: "needs_auth",
+        },
+        projection,
+      );
       const payload: { error: string; isError: true; upstream?: string; hint: string } = {
         error: "needs_auth",
         isError: true,

--- a/src/sdk/ts/src/catalog.ts
+++ b/src/sdk/ts/src/catalog.ts
@@ -7,6 +7,8 @@ import {
   resolveEmbeddingArtifact,
 } from "./embedding-artifact.js";
 import { type IntentGraph, ToolRegistry } from "./registry.js";
+import type { RuntimeEvent, RuntimeEventsOptions } from "./runtime-events.js";
+import type { NativeEventSubscription } from "../native/index.cjs";
 import {
   argsSizeBytes,
   errorMessage,
@@ -64,6 +66,9 @@ export interface ExecutableTool extends Tool {
   /** Runs the tool. Called by {@link ToolCatalog.invoke} with args and optional context. */
   execute: Executor;
 }
+
+/** Serializable tool definition used by catalog snapshots (never an executor). */
+export type ToolDefinition = Tool;
 
 /**
  * Where the local trace stream (ADR-0007) goes. Distinct from the OTel spans in
@@ -380,6 +385,21 @@ export class ToolCatalog {
    */
   get(toolId: string): Tool | undefined {
     return this.tools.get(toolId);
+  }
+
+  /** Complete, deterministic, executor-free tool definition set. */
+  snapshot(): ToolDefinition[] {
+    return [...this.tools.values()]
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .map((tool) => structuredClone(tool));
+  }
+
+  /** @internal Attach one public runtime-event subscriber. */
+  subscribeEvents(
+    handler: (batch: RuntimeEvent[]) => void,
+    options: Required<RuntimeEventsOptions>,
+  ): NativeEventSubscription {
+    return this.registry.subscribeEvents(handler, options);
   }
 
   /**

--- a/src/sdk/ts/src/catalog.ts
+++ b/src/sdk/ts/src/catalog.ts
@@ -1,5 +1,5 @@
 import { SearchTarget } from "@ratel-ai/telemetry";
-import type { SearchHit, Tool } from "../native/index.cjs";
+import type { NativeEventSubscription, SearchHit, Tool } from "../native/index.cjs";
 import { warmFromEmbeddingArtifactSource } from "./artifact-source-warm.js";
 import { isAsyncIterable, isPromiseLike } from "./async.js";
 import {
@@ -9,10 +9,10 @@ import {
 import { type IntentGraph, ToolRegistry } from "./registry.js";
 import type { RuntimeEvent, RuntimeEventsOptions } from "./runtime-events.js";
 import { newRuntimeEventId } from "./runtime-events.js";
-import type { NativeEventSubscription } from "../native/index.cjs";
 import {
   argsSizeBytes,
   errorMessage,
+  type RuntimeEventProjection,
   traceExecuteTool,
   traceSearch,
   traceSearchAsync,
@@ -364,13 +364,7 @@ export class ToolCatalog {
     method?: SearchMethod,
   ): Promise<SearchHit[]> {
     return traceSearchAsync(SearchTarget.Tool, query, topK, origin, (projection) =>
-      this.registry.searchWithMethodAsync(
-        query,
-        topK,
-        origin,
-        method ?? this.method,
-        projection,
-      ),
+      this.registry.searchWithMethodAsync(query, topK, origin, method ?? this.method, projection),
     );
   }
 
@@ -460,8 +454,8 @@ export class ToolCatalog {
    * @param event - A tagged trace event in wire shape: `{ type: "...", ... }`
    *   with snake_case fields. Throws if the object is not a known trace event.
    */
-  recordEvent(event: object): void {
-    this.registry.recordEvent(event);
+  recordEvent(event: object, projection?: RuntimeEventProjection): void {
+    this.registry.recordEvent(event, projection);
   }
 
   /**
@@ -589,27 +583,36 @@ export function runToolInvocation<T>(
   // The `execute_tool` OTel span wraps the local trace stream; both record the
   // same invocation, on their two independent channels (ADR-0007).
   return traceExecuteTool(toolId, input, (projection) => {
-    catalog.recordEvent({
-      type: "invoke_start",
-      tool_id: toolId,
-      args_size_bytes: argsSizeBytes(input),
-    }, projection);
+    catalog.recordEvent(
+      {
+        type: "invoke_start",
+        tool_id: toolId,
+        args_size_bytes: argsSizeBytes(input),
+      },
+      projection,
+    );
     const started = Date.now();
 
     const succeed = (_result: unknown): void => {
-      catalog.recordEvent({
-        type: "invoke_end",
-        tool_id: toolId,
-        took_ms: Date.now() - started,
-      }, { ...projection, eventId: newRuntimeEventId() });
+      catalog.recordEvent(
+        {
+          type: "invoke_end",
+          tool_id: toolId,
+          took_ms: Date.now() - started,
+        },
+        { ...projection, eventId: newRuntimeEventId() },
+      );
     };
     const reject = (err: unknown): void => {
-      catalog.recordEvent({
-        type: "invoke_error",
-        tool_id: toolId,
-        took_ms: Date.now() - started,
-        error: errorMessage(err),
-      }, { ...projection, eventId: newRuntimeEventId() });
+      catalog.recordEvent(
+        {
+          type: "invoke_error",
+          tool_id: toolId,
+          took_ms: Date.now() - started,
+          error: errorMessage(err),
+        },
+        { ...projection, eventId: newRuntimeEventId() },
+      );
     };
 
     try {

--- a/src/sdk/ts/src/catalog.ts
+++ b/src/sdk/ts/src/catalog.ts
@@ -8,6 +8,7 @@ import {
 } from "./embedding-artifact.js";
 import { type IntentGraph, ToolRegistry } from "./registry.js";
 import type { RuntimeEvent, RuntimeEventsOptions } from "./runtime-events.js";
+import { newRuntimeEventId } from "./runtime-events.js";
 import type { NativeEventSubscription } from "../native/index.cjs";
 import {
   argsSizeBytes,
@@ -350,8 +351,8 @@ export class ToolCatalog {
     origin: SearchOrigin = "direct",
     method?: SearchMethod,
   ): SearchHit[] {
-    return traceSearch(SearchTarget.Tool, query, topK, origin, () =>
-      this.registry.searchWithMethod(query, topK, origin, method ?? this.method),
+    return traceSearch(SearchTarget.Tool, query, topK, origin, (projection) =>
+      this.registry.searchWithMethod(query, topK, origin, method ?? this.method, projection),
     );
   }
 
@@ -362,8 +363,14 @@ export class ToolCatalog {
     origin: SearchOrigin = "direct",
     method?: SearchMethod,
   ): Promise<SearchHit[]> {
-    return traceSearchAsync(SearchTarget.Tool, query, topK, origin, () =>
-      this.registry.searchWithMethodAsync(query, topK, origin, method ?? this.method),
+    return traceSearchAsync(SearchTarget.Tool, query, topK, origin, (projection) =>
+      this.registry.searchWithMethodAsync(
+        query,
+        topK,
+        origin,
+        method ?? this.method,
+        projection,
+      ),
     );
   }
 
@@ -581,12 +588,12 @@ export function runToolInvocation<T>(
 ): T {
   // The `execute_tool` OTel span wraps the local trace stream; both record the
   // same invocation, on their two independent channels (ADR-0007).
-  return traceExecuteTool(toolId, input, () => {
+  return traceExecuteTool(toolId, input, (projection) => {
     catalog.recordEvent({
       type: "invoke_start",
       tool_id: toolId,
       args_size_bytes: argsSizeBytes(input),
-    });
+    }, projection);
     const started = Date.now();
 
     const succeed = (_result: unknown): void => {
@@ -594,7 +601,7 @@ export function runToolInvocation<T>(
         type: "invoke_end",
         tool_id: toolId,
         took_ms: Date.now() - started,
-      });
+      }, { ...projection, eventId: newRuntimeEventId() });
     };
     const reject = (err: unknown): void => {
       catalog.recordEvent({
@@ -602,7 +609,7 @@ export function runToolInvocation<T>(
         tool_id: toolId,
         took_ms: Date.now() - started,
         error: errorMessage(err),
-      });
+      }, { ...projection, eventId: newRuntimeEventId() });
     };
 
     try {

--- a/src/sdk/ts/src/experiment-sink.ts
+++ b/src/sdk/ts/src/experiment-sink.ts
@@ -5,9 +5,14 @@ import type {
   ExperimentArmRole,
   ExperimentRankedItem,
 } from "./experiment-types.js";
+import { newRuntimeEventId, type RuntimeEvents } from "./runtime-events.js";
+
+interface ExperimentEventIdentity {
+  eventId?: string;
+}
 
 /** @internal Valid delayed outcome ready for telemetry emission. */
-export interface ExperimentOutcomeEvaluation {
+export interface ExperimentOutcomeEvaluation extends ExperimentEventIdentity {
   experimentId: string;
   selectionId: string;
   label?: string;
@@ -15,7 +20,8 @@ export interface ExperimentOutcomeEvaluation {
 }
 
 /** @internal Controlled identity and dispatch facts for one experiment arm. */
-export interface ExperimentArmEvaluation<Arm extends string = string> {
+export interface ExperimentArmEvaluation<Arm extends string = string>
+  extends ExperimentEventIdentity {
   experimentId: string;
   selectionId: string;
   unitHash: string;
@@ -26,7 +32,7 @@ export interface ExperimentArmEvaluation<Arm extends string = string> {
 }
 
 /** @internal Observable completion facts for one experiment arm. */
-export interface ExperimentArmCompletionEvaluation {
+export interface ExperimentArmCompletionEvaluation extends ExperimentEventIdentity {
   outcome: ExperimentArmOutcome;
   durationMs: number;
   hitCount?: number;
@@ -40,7 +46,7 @@ export interface ExperimentArmCompletionEvaluation {
 export interface ExperimentArmEvaluationHandle {
   run<T>(callback: () => T): T;
   complete(evaluation: ExperimentArmCompletionEvaluation): void;
-  event(eventName: string, attributes: Record<string, unknown>): void;
+  event(eventName: string, attributes: Record<string, unknown>, eventId?: string): void;
 }
 
 /** @internal Why an admitted peer shadow produced no comparison. */
@@ -52,7 +58,8 @@ export type ExperimentPeerDropReason =
   | "comparison-failed";
 
 /** @internal One completed served-vs-shadow ranking comparison. */
-export interface ExperimentComparisonEvaluation<Arm extends string = string> {
+export interface ExperimentComparisonEvaluation<Arm extends string = string>
+  extends ExperimentEventIdentity {
   selectionId: string;
   served: {
     arm: Arm;
@@ -70,26 +77,30 @@ export interface ExperimentComparisonEvaluation<Arm extends string = string> {
 }
 
 /** @internal One admitted shadow that could not produce a comparison. */
-export interface ExperimentDropEvaluation<Arm extends string = string> {
+export interface ExperimentDropEvaluation<Arm extends string = string>
+  extends ExperimentEventIdentity {
   selectionId: string;
   shadowArm: Arm;
   reason: ExperimentPeerDropReason;
 }
 
 /** @internal One shadow dispatch skipped because instance capacity was full. */
-export interface ExperimentSkipEvaluation<Arm extends string = string> {
+export interface ExperimentSkipEvaluation<Arm extends string = string>
+  extends ExperimentEventIdentity {
   skippedArm: Arm;
   concurrency: number;
 }
 
 /** @internal One successful fallback decision. */
-export interface ExperimentFallbackEvaluation<Arm extends string = string> {
+export interface ExperimentFallbackEvaluation<Arm extends string = string>
+  extends ExperimentEventIdentity {
   effectiveArm: Arm;
   reusedShadow: boolean;
 }
 
 /** @internal One invocation attribution ready for telemetry emission. */
-export interface ExperimentInvocationEvaluation<Arm extends string = string> {
+export interface ExperimentInvocationEvaluation<Arm extends string = string>
+  extends ExperimentEventIdentity {
   experimentId: string;
   unitHash: string;
   toolId: string;
@@ -112,4 +123,206 @@ export interface ExperimentEvaluationSink<Arm extends string = string> {
   ): void;
   invocation?(evaluation: ExperimentInvocationEvaluation<Arm>): void;
   outcome?(evaluation: ExperimentOutcomeEvaluation): void;
+}
+
+/** @internal Compose OTel and runtime-event projections while minting each identity once. */
+export function composeExperimentEvaluationSinks<Arm extends string>(
+  first: ExperimentEvaluationSink<Arm>,
+  second: ExperimentEvaluationSink<Arm>,
+): ExperimentEvaluationSink<Arm> {
+  const handles = new WeakMap<
+    ExperimentArmEvaluationHandle,
+    readonly [ExperimentArmEvaluationHandle | undefined, ExperimentArmEvaluationHandle | undefined]
+  >();
+  const pair = (handle?: ExperimentArmEvaluationHandle) =>
+    handle === undefined
+      ? ([undefined, undefined] as const)
+      : (handles.get(handle) ?? [handle, handle]);
+  const stamp = <T extends ExperimentEventIdentity>(evaluation: T): T & { eventId: string } => ({
+    ...evaluation,
+    eventId: evaluation.eventId ?? newRuntimeEventId(),
+  });
+
+  return {
+    arm(evaluation) {
+      const stamped = stamp(evaluation);
+      const firstHandle = first.arm?.(stamped);
+      const secondHandle = second.arm?.(stamped);
+      const handle: ExperimentArmEvaluationHandle = {
+        run(callback) {
+          const runSecond = () => secondHandle?.run(callback) ?? callback();
+          return firstHandle?.run(runSecond) ?? runSecond();
+        },
+        complete(completion) {
+          const stampedCompletion = stamp(completion);
+          firstHandle?.complete(stampedCompletion);
+          secondHandle?.complete(stampedCompletion);
+        },
+        event(eventName, attributes, eventId = newRuntimeEventId()) {
+          firstHandle?.event(eventName, attributes, eventId);
+          secondHandle?.event(eventName, attributes, eventId);
+        },
+      };
+      handles.set(handle, [firstHandle, secondHandle]);
+      return handle;
+    },
+    comparison(evaluation, handle) {
+      const stamped = stamp(evaluation);
+      const [firstHandle, secondHandle] = pair(handle);
+      first.comparison?.(stamped, firstHandle);
+      second.comparison?.(stamped, secondHandle);
+    },
+    drop(evaluation, handle) {
+      const stamped = stamp(evaluation);
+      const [firstHandle, secondHandle] = pair(handle);
+      first.drop?.(stamped, firstHandle);
+      second.drop?.(stamped, secondHandle);
+    },
+    skip(evaluation, handle) {
+      const stamped = stamp(evaluation);
+      const [firstHandle, secondHandle] = pair(handle);
+      first.skip?.(stamped, firstHandle);
+      second.skip?.(stamped, secondHandle);
+    },
+    fallback(evaluation, handle) {
+      const stamped = stamp(evaluation);
+      const [firstHandle, secondHandle] = pair(handle);
+      first.fallback?.(stamped, firstHandle);
+      second.fallback?.(stamped, secondHandle);
+    },
+    invocation(evaluation) {
+      const stamped = stamp(evaluation);
+      first.invocation?.(stamped);
+      second.invocation?.(stamped);
+    },
+    outcome(evaluation) {
+      const stamped = stamp(evaluation);
+      first.outcome?.(stamped);
+      second.outcome?.(stamped);
+    },
+  };
+}
+
+/** @internal Project experiment evaluation records into the public runtime vocabulary. */
+export function createExperimentRuntimeEventSink<Arm extends string>(
+  events: RuntimeEvents,
+): ExperimentEvaluationSink<Arm> {
+  const arms = new WeakMap<ExperimentArmEvaluationHandle, ExperimentArmEvaluation<Arm>>();
+  const emit = (type: string, eventId: string | undefined, fields: Record<string, unknown>) =>
+    events.emit({ type, ...(eventId === undefined ? {} : { event_id: eventId }), ...fields });
+  const armFields = (evaluation: ExperimentArmEvaluation<Arm>) => ({
+    experiment_id: evaluation.experimentId,
+    selection_id: evaluation.selectionId,
+    unit: evaluation.unitHash,
+    arm: evaluation.arm,
+    role: evaluation.role,
+  });
+  const fromHandle = (handle?: ExperimentArmEvaluationHandle) =>
+    handle === undefined ? undefined : arms.get(handle);
+
+  return {
+    arm(evaluation) {
+      emit("experiment_selection", evaluation.eventId, {
+        ...armFields(evaluation),
+        cold: evaluation.cold,
+        ...(evaluation.attributes === undefined ? {} : { attributes: evaluation.attributes }),
+      });
+      const handle: ExperimentArmEvaluationHandle = {
+        run: (callback) => callback(),
+        complete(completion) {
+          emit("experiment_results", completion.eventId, {
+            ...armFields(evaluation),
+            outcome: completion.outcome,
+            duration_ms: completion.durationMs,
+            ...(completion.hitCount === undefined ? {} : { hit_count: completion.hitCount }),
+            ...(completion.ranking === undefined
+              ? {}
+              : {
+                  result_ids: completion.ranking.map((item) => item.id),
+                  ...(completion.ranking.every((item) => item.score !== undefined)
+                    ? { result_scores: completion.ranking.map((item) => item.score) }
+                    : {}),
+                }),
+            ...(completion.failure === undefined
+              ? {}
+              : { error_class: errorClass(completion.failure.error) }),
+          });
+        },
+        event() {},
+      };
+      arms.set(handle, evaluation);
+      return handle;
+    },
+    comparison(evaluation, handle) {
+      const arm = fromHandle(handle);
+      emit("experiment_comparison", evaluation.eventId, {
+        ...(arm === undefined ? {} : armFields(arm)),
+        selection_id: evaluation.selectionId,
+        served_arm: evaluation.served.arm,
+        served_outcome: evaluation.served.outcome,
+        served_duration_ms: evaluation.served.durationMs,
+        served_hit_count: evaluation.served.hitCount,
+        shadow_arm: evaluation.shadow.arm,
+        shadow_outcome: evaluation.shadow.outcome,
+        shadow_duration_ms: evaluation.shadow.durationMs,
+        shadow_hit_count: evaluation.shadow.hitCount,
+        agreement: evaluation.agreement,
+      });
+    },
+    skip(evaluation, handle) {
+      const arm = fromHandle(handle);
+      emit("experiment_skip", evaluation.eventId, {
+        ...(arm === undefined ? {} : armFields(arm)),
+        skipped_arm: evaluation.skippedArm,
+        concurrency: evaluation.concurrency,
+        reason: "capacity",
+      });
+    },
+    fallback(evaluation, handle) {
+      const arm = fromHandle(handle);
+      emit("experiment_fallback", evaluation.eventId, {
+        ...(arm === undefined ? {} : armFields(arm)),
+        effective_arm: evaluation.effectiveArm,
+        reused_shadow: evaluation.reusedShadow,
+      });
+    },
+    drop(evaluation, handle) {
+      const arm = fromHandle(handle);
+      emit("experiment_drop", evaluation.eventId, {
+        ...(arm === undefined ? {} : armFields(arm)),
+        selection_id: evaluation.selectionId,
+        shadow_arm: evaluation.shadowArm,
+        reason: evaluation.reason,
+      });
+    },
+    invocation(evaluation) {
+      emit("experiment_invocation", evaluation.eventId, {
+        experiment_id: evaluation.experimentId,
+        unit: evaluation.unitHash,
+        tool_id: evaluation.toolId,
+        ...(evaluation.turn === undefined ? {} : { turn: evaluation.turn }),
+        attributed: evaluation.attribution.attributed,
+        ...(evaluation.attribution.attributed
+          ? {
+              selection_id: evaluation.attribution.selectionId,
+              effective_arm: evaluation.attribution.effectiveArm,
+              rank: evaluation.attribution.rank,
+              age_ms: evaluation.attribution.ageMs,
+            }
+          : {}),
+      });
+    },
+    outcome(evaluation) {
+      emit("experiment_outcome", evaluation.eventId, {
+        experiment_id: evaluation.experimentId,
+        selection_id: evaluation.selectionId,
+        ...(evaluation.label === undefined ? {} : { label: evaluation.label }),
+        ...(evaluation.score === undefined ? {} : { score: evaluation.score }),
+      });
+    },
+  };
+}
+
+function errorClass(error: unknown): string {
+  return error instanceof Error ? error.name : typeof error;
 }

--- a/src/sdk/ts/src/experiment-telemetry.test.ts
+++ b/src/sdk/ts/src/experiment-telemetry.test.ts
@@ -707,6 +707,7 @@ describe("experiment telemetry", () => {
 
     const [event] = experimentEvents("ratel.experiment.invocation");
     expect(event.attributes).toEqual({
+      "ratel.event.id": expect.stringMatching(/^[0-9A-HJKMNP-TV-Z]{26}$/),
       "ratel.experiment.id": "search-v2",
       "ratel.experiment.unit": "a763b7e51e4339b7",
       "ratel.experiment.invocation.attributed": false,
@@ -747,6 +748,7 @@ describe("experiment telemetry", () => {
     expect(events).toHaveLength(2);
     for (const event of events) {
       expect(event.attributes).toEqual({
+        "ratel.event.id": expect.stringMatching(/^[0-9A-HJKMNP-TV-Z]{26}$/),
         "ratel.experiment.id": "search-v2",
         "ratel.experiment.selection_id": "selection-1",
         "ratel.experiment.outcome.label": "accepted",

--- a/src/sdk/ts/src/experiment.ts
+++ b/src/sdk/ts/src/experiment.ts
@@ -18,13 +18,18 @@ import {
   type ServedEvaluationSignal,
   trackShadow,
 } from "./experiment-shadow.js";
-import type { ExperimentEvaluationSink } from "./experiment-sink.js";
+import {
+  composeExperimentEvaluationSinks,
+  createExperimentRuntimeEventSink,
+  type ExperimentEvaluationSink,
+} from "./experiment-sink.js";
 import type { Experiment, ExperimentConfig, ExperimentSelection } from "./experiment-types.js";
 import {
   assignArm,
   validateReportedOutcome,
   validateSplitCoverage,
 } from "./experiment-validation.js";
+import type { RuntimeEvents } from "./runtime-events.js";
 import { createExperimentTelemetrySink, validateExperimentAttributes } from "./telemetry.js";
 
 /**
@@ -32,12 +37,23 @@ import { createExperimentTelemetrySink, validateExperimentAttributes } from "./t
  *
  * Configuration errors throw synchronously. Each selection serves one arm, may run
  * other arms as bounded detached shadows, and exposes {@link Experiment.drain} for
- * orderly shutdown.
+ * orderly shutdown. Pass a {@link RuntimeEvents} instance to merge evaluation facts
+ * into that runtime's public stream while retaining the parallel OTel projection.
+ *
+ * @param config Experiment arms, assignment, and evaluation policy.
+ * @param events Optional `ratel().events` stream receiving experiment facts.
  */
 export function experimentalDefineExperiment<Params, Result, Arm extends string>(
   config: ExperimentConfig<Params, Result, Arm>,
+  events?: RuntimeEvents,
 ): Experiment<Params, Result, Arm> {
-  return defineExperimentInternal(config, createExperimentTelemetrySink());
+  const telemetry = createExperimentTelemetrySink<Arm>();
+  return defineExperimentInternal(
+    config,
+    events === undefined
+      ? telemetry
+      : composeExperimentEvaluationSinks(telemetry, createExperimentRuntimeEventSink(events)),
+  );
 }
 
 /** @internal Builds an experiment with an evaluation sink for package-level composition. */

--- a/src/sdk/ts/src/index.ts
+++ b/src/sdk/ts/src/index.ts
@@ -114,6 +114,15 @@ export { ratel } from "./ratel.js";
 export { IntentGraph, SkillRegistry, ToolRegistry } from "./registry.js";
 export type { PendingReplace, SkillCatalogOptions } from "./skill-catalog.js";
 export { SkillCatalog } from "./skill-catalog.js";
+export type { SkillDefinition } from "./skill-catalog.js";
+export type {
+  CatalogSnapshot,
+  RuntimeCatalog,
+  RuntimeEvent,
+  RuntimeEventSubscription,
+  RuntimeEventsOptions,
+} from "./runtime-events.js";
+export { RuntimeEvents } from "./runtime-events.js";
 export { GET_SKILL_CONTENT_ID, getSkillContentTool } from "./skill-tools.js";
 // OpenTelemetry emission of the ratel.*/gen_ai.* funnel. The SDK emits to whatever OTel
 // provider the host has registered and never registers one itself — delivery is the host's

--- a/src/sdk/ts/src/index.ts
+++ b/src/sdk/ts/src/index.ts
@@ -94,6 +94,19 @@ export type {
 // content plus the content-presence re-injection gate. Namespaced so dependence
 // on this unstable surface is explicit: `experimental.FactCatalog`.
 export * as experimental from "./experimental.js";
+export type {
+  Experiment,
+  ExperimentArmOutcome,
+  ExperimentArmRole,
+  ExperimentConfig,
+  ExperimentEvaluationReference,
+  ExperimentRankedItem,
+  ExperimentReportedOutcome,
+  ExperimentSelection,
+  ExperimentSelectOptions,
+  ExperimentSplit,
+} from "./experiment.js";
+export { experimentalDefineExperiment } from "./experiment.js";
 export type { McpServerHandle, McpToolsListErrorCode, RegisterMcpServerOptions } from "./mcp.js";
 export { McpToolsListError, registerMcpServer } from "./mcp.js";
 // The framework-adapter SPI and factory (ADR-0013): `ratel(config).adaptTo(adapter)`.

--- a/src/sdk/ts/src/index.ts
+++ b/src/sdk/ts/src/index.ts
@@ -94,19 +94,6 @@ export type {
 // content plus the content-presence re-injection gate. Namespaced so dependence
 // on this unstable surface is explicit: `experimental.FactCatalog`.
 export * as experimental from "./experimental.js";
-export { experimentalDefineExperiment } from "./experiment.js";
-export type {
-  Experiment,
-  ExperimentArmOutcome,
-  ExperimentArmRole,
-  ExperimentConfig,
-  ExperimentEvaluationReference,
-  ExperimentRankedItem,
-  ExperimentReportedOutcome,
-  ExperimentSelection,
-  ExperimentSelectOptions,
-  ExperimentSplit,
-} from "./experiment-types.js";
 export type { McpServerHandle, McpToolsListErrorCode, RegisterMcpServerOptions } from "./mcp.js";
 export { McpToolsListError, registerMcpServer } from "./mcp.js";
 // The framework-adapter SPI and factory (ADR-0013): `ratel(config).adaptTo(adapter)`.
@@ -125,18 +112,25 @@ export type {
 export { ratel } from "./ratel.js";
 /** Adaptive usage ranking: the shared read model of what users invoke (ADR-0014). */
 export { IntentGraph, SkillRegistry, ToolRegistry } from "./registry.js";
-export type { PendingReplace, SkillCatalogOptions } from "./skill-catalog.js";
-export { SkillCatalog } from "./skill-catalog.js";
-export type { SkillDefinition } from "./skill-catalog.js";
 export type {
   CatalogSnapshot,
   RuntimeCatalog,
   RuntimeEvent,
+  RuntimeEventHandler,
   RuntimeEventSubscription,
   RuntimeEventsOptions,
 } from "./runtime-events.js";
-export { RuntimeEvents } from "./runtime-events.js";
+export {
+  RUNTIME_EVENT_MAX_HITS,
+  RUNTIME_EVENT_MAX_PAYLOAD_BYTES,
+  RUNTIME_EVENT_MAX_QUERY_BYTES,
+  RUNTIME_EVENT_TYPES,
+  RuntimeEvents,
+} from "./runtime-events.js";
+export type { PendingReplace, SkillCatalogOptions, SkillDefinition } from "./skill-catalog.js";
+export { SkillCatalog } from "./skill-catalog.js";
 export { GET_SKILL_CONTENT_ID, getSkillContentTool } from "./skill-tools.js";
+export type { RuntimeEventProjection } from "./telemetry.js";
 // OpenTelemetry emission of the ratel.*/gen_ai.* funnel. The SDK emits to whatever OTel
 // provider the host has registered and never registers one itself — delivery is the host's
 // `new NodeSDK({ spanProcessors })`. `ContentCapture`/`setContentCapture`/

--- a/src/sdk/ts/src/index.ts
+++ b/src/sdk/ts/src/index.ts
@@ -94,6 +94,7 @@ export type {
 // content plus the content-presence re-injection gate. Namespaced so dependence
 // on this unstable surface is explicit: `experimental.FactCatalog`.
 export * as experimental from "./experimental.js";
+export { experimentalDefineExperiment } from "./experiment.js";
 export type {
   Experiment,
   ExperimentArmOutcome,
@@ -105,8 +106,7 @@ export type {
   ExperimentSelection,
   ExperimentSelectOptions,
   ExperimentSplit,
-} from "./experiment.js";
-export { experimentalDefineExperiment } from "./experiment.js";
+} from "./experiment-types.js";
 export type { McpServerHandle, McpToolsListErrorCode, RegisterMcpServerOptions } from "./mcp.js";
 export { McpToolsListError, registerMcpServer } from "./mcp.js";
 // The framework-adapter SPI and factory (ADR-0013): `ratel(config).adaptTo(adapter)`.

--- a/src/sdk/ts/src/mcp.ts
+++ b/src/sdk/ts/src/mcp.ts
@@ -181,7 +181,7 @@ export async function registerMcpServer(
 
   // The whole registration (connect + list + ingest) is one `ratel.upstream.register`
   // span; per-tool invocations later get their own `execute_tool` spans (ADR-0007).
-  return traceUpstreamRegister(name, transportLabel, async (reportToolCount) => {
+  return traceUpstreamRegister(name, transportLabel, async (reportToolCount, projection) => {
     const client = new Client({ name: "@ratel-ai/sdk", version: "0.0.0" });
     try {
       await client.connect(transport);
@@ -190,12 +190,15 @@ export async function registerMcpServer(
 
       const tools = await listAllMcpTools(client);
       reportToolCount(tools.length);
-      catalog.recordEvent({
-        type: "upstream_register",
-        server: name,
-        transport: transportLabel,
-        tool_count: tools.length,
-      });
+      catalog.recordEvent(
+        {
+          type: "upstream_register",
+          server: name,
+          transport: transportLabel,
+          tool_count: tools.length,
+        },
+        projection,
+      );
       const { toolIds, registered } = buildRegisteredMcpTools(catalog, client, name, tools);
       await catalog.register(registered);
 

--- a/src/sdk/ts/src/native-events.test.ts
+++ b/src/sdk/ts/src/native-events.test.ts
@@ -1,7 +1,28 @@
+import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import { IntentGraph, SkillRegistry, ToolRegistry } from "../native/index.cjs";
 
 describe("native runtime event bridge", () => {
+  it("does not keep the Node process alive while subscribed", () => {
+    const moduleUrl = new URL("../native/index.cjs", import.meta.url).href;
+    const script = `
+      import { ToolRegistry } from ${JSON.stringify(moduleUrl)};
+      const registry = new ToolRegistry();
+      globalThis.subscription = registry.subscribeTraceEvents(() => {}, {
+        sessionId: "session-exit",
+      });
+    `;
+
+    const result = spawnSync(process.execPath, ["--input-type=module", "-e", script], {
+      encoding: "utf8",
+      timeout: 2_000,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.status).toBe(0);
+  });
+
   it("pushes worker-thread search events to JavaScript in batches", async () => {
     const registry = new ToolRegistry();
     registry.register({

--- a/src/sdk/ts/src/native-events.test.ts
+++ b/src/sdk/ts/src/native-events.test.ts
@@ -121,13 +121,16 @@ describe("native runtime event bridge", () => {
     );
     await subscription.flush();
 
-    expect(subscription.droppedCount).toBeGreaterThan(0);
+    const droppedCount = subscription.droppedCount;
+    expect(droppedCount).toBeGreaterThan(0);
     expect(events).toContainEqual(
       expect.objectContaining({
         type: "events_dropped",
         reason: "queue_overflow",
       }),
     );
+    subscription.unsubscribe();
+    expect(subscription.droppedCount).toBe(droppedCount);
   });
 
   it("pushes skill-registry events through the same native seam", async () => {

--- a/src/sdk/ts/src/native-events.test.ts
+++ b/src/sdk/ts/src/native-events.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { IntentGraph, SkillRegistry, ToolRegistry } from "../native/index.cjs";
+
+describe("native runtime event bridge", () => {
+  it("pushes worker-thread search events to JavaScript in batches", async () => {
+    const registry = new ToolRegistry();
+    registry.register({
+      id: "read_file",
+      name: "read_file",
+      description: "Read a file",
+      inputSchema: {},
+      outputSchema: {},
+    });
+    const batches: Array<Array<Record<string, unknown>>> = [];
+    const subscription = registry.subscribeTraceEvents(
+      (batch: Array<Record<string, unknown>>) => batches.push(batch),
+      {
+        sessionId: "session-ts",
+        sourceId: "source-ts",
+        queueCapacity: 16,
+        batchSize: 8,
+      },
+    );
+
+    await registry.searchWithMethodAsync("read", 1, "direct", "bm25");
+    await subscription.flush();
+
+    expect(batches.some((batch) => batch.length > 0)).toBe(true);
+    const event = batches.flat().find((candidate) => candidate.type === "search");
+    expect(event).toMatchObject({
+      v: 2,
+      session_id: "session-ts",
+      source_id: "source-ts",
+      type: "search",
+      query: "read",
+    });
+  });
+
+  it("drops oldest events and reports loss while JavaScript is stalled", async () => {
+    const registry = new ToolRegistry();
+    const events: Array<Record<string, unknown>> = [];
+    let firstBatch = true;
+    const subscription = registry.subscribeTraceEvents(
+      (batch: Array<Record<string, unknown>>) => {
+        events.push(...batch);
+        if (firstBatch) {
+          firstBatch = false;
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
+        }
+      },
+      {
+        sessionId: "session-drop",
+        queueCapacity: 2,
+        batchSize: 1,
+      },
+    );
+
+    await Promise.all(
+      Array.from({ length: 64 }, (_, index) =>
+        registry.searchWithMethodAsync(`query-${index}`, 1, "direct", "bm25"),
+      ),
+    );
+    await subscription.flush();
+
+    expect(subscription.droppedCount).toBeGreaterThan(0);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "events_dropped",
+        reason: "queue_overflow",
+      }),
+    );
+  });
+
+  it("pushes skill-registry events through the same native seam", async () => {
+    const registry = new SkillRegistry();
+    registry.register({
+      id: "api-design",
+      name: "api-design",
+      description: "Design an API",
+      tags: ["backend"],
+      body: "Use resource nouns.",
+    });
+    const events: Array<Record<string, unknown>> = [];
+    const subscription = registry.subscribeTraceEvents(
+      (batch: Array<Record<string, unknown>>) => events.push(...batch),
+      { sessionId: "session-skill" },
+    );
+
+    await registry.searchWithMethodAsync("api", 1, "direct", "bm25");
+    await subscription.flush();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: "skill_search", session_id: "session-skill" }),
+    );
+  });
+
+  it("keeps callbacks and usage learning active across a base-sink re-wrap", async () => {
+    const registry = new ToolRegistry();
+    const graph = new IntentGraph();
+    registry.enableAdaptiveRanking(graph);
+    const events: Array<Record<string, unknown>> = [];
+    const subscription = registry.subscribeTraceEvents(
+      (batch: Array<Record<string, unknown>>) => events.push(...batch),
+      { sessionId: "session-learner" },
+    );
+    registry.setTraceSink({ kind: "memory", sessionId: "session-learner" });
+
+    registry.search("read file", 1);
+    registry.recordEvent({ type: "invoke_start", tool_id: "read_file", args_size_bytes: 0 });
+    await subscription.flush();
+
+    expect(graph.clusterCount).toBe(1);
+    expect(events.map((event) => event.type)).toEqual(
+      expect.arrayContaining(["search", "invoke_start"]),
+    );
+  });
+});

--- a/src/sdk/ts/src/native-events.test.ts
+++ b/src/sdk/ts/src/native-events.test.ts
@@ -113,5 +113,8 @@ describe("native runtime event bridge", () => {
     expect(events.map((event) => event.type)).toEqual(
       expect.arrayContaining(["search", "invoke_start"]),
     );
+    expect(registry.drainTraceEvents().map((event) => event.type)).toEqual(
+      expect.arrayContaining(["search", "invoke_start"]),
+    );
   });
 });

--- a/src/sdk/ts/src/native-events.test.ts
+++ b/src/sdk/ts/src/native-events.test.ts
@@ -1,8 +1,40 @@
 import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import { IntentGraph, SkillRegistry, ToolRegistry } from "../native/index.cjs";
+import { startDelayedEmbeddingServer } from "./test-support/delayed-embedding-server.js";
 
 describe("native runtime event bridge", () => {
+  it("allows unsubscribe while a flush is draining JavaScript callbacks", () => {
+    const moduleUrl = new URL("../native/index.cjs", import.meta.url).href;
+    const script = `
+      import { ToolRegistry } from ${JSON.stringify(moduleUrl)};
+      const registry = new ToolRegistry();
+      const subscription = registry.subscribeTraceEvents(() => {
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+      }, {
+        sessionId: "session-flush-unsubscribe",
+        queueCapacity: 512,
+        batchSize: 2,
+      });
+      for (let index = 0; index < 500; index += 1) {
+        registry.search(\`query-\${index}\`, 1);
+      }
+      const flushing = subscription.flush();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      subscription.unsubscribe();
+      await flushing;
+    `;
+
+    const result = spawnSync(process.execPath, ["--input-type=module", "-e", script], {
+      encoding: "utf8",
+      timeout: 4_000,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.status).toBe(0);
+  });
+
   it("does not keep the Node process alive while subscribed", () => {
     const moduleUrl = new URL("../native/index.cjs", import.meta.url).href;
     const script = `
@@ -143,5 +175,83 @@ describe("native runtime event bridge", () => {
     expect(registry.drainTraceEvents().map((event) => event.type)).toEqual(
       expect.arrayContaining(["search", "invoke_start"]),
     );
+  });
+
+  it("keeps the base sink synchronous and independently stamped after subscribing", () => {
+    const registry = new ToolRegistry();
+    registry.setTraceSink({ kind: "memory", sessionId: "base-session" });
+    const subscription = registry.subscribeTraceEvents(() => {}, {
+      sessionId: "stream-session",
+      queueCapacity: 1,
+      batchSize: 1,
+    });
+
+    for (let index = 0; index < 5_000; index += 1) {
+      registry.search(`persist-${index}`, 1);
+    }
+
+    const persisted = registry
+      .drainTraceEvents()
+      .filter((event) => event.type === "search") as Array<Record<string, unknown>>;
+    expect(persisted).toHaveLength(5_000);
+    expect(persisted.every((event) => event.session_id === "base-session")).toBe(true);
+    subscription.unsubscribe();
+  });
+
+  it.each([
+    {
+      kind: "tool",
+      create: (url: string) => {
+        const registry = new ToolRegistry({ url, model: "test-model" });
+        registry.register({
+          id: "read_file",
+          name: "read_file",
+          description: "Read a file",
+          inputSchema: {},
+          outputSchema: {},
+        });
+        return registry;
+      },
+    },
+    {
+      kind: "skill",
+      create: (url: string) => {
+        const registry = new SkillRegistry({ url, model: "test-model" });
+        registry.register({
+          id: "api-design",
+          name: "API design",
+          description: "Design an API",
+          tags: [],
+          body: "Use nouns",
+        });
+        return registry;
+      },
+    },
+  ])("keeps the $kind base sink when a busy registry rejects replacement", async ({ create }) => {
+    const server = await startDelayedEmbeddingServer();
+    try {
+      const registry = create(server.url);
+      registry.setTraceSink({ kind: "memory", sessionId: "base-session" });
+      const subscription = registry.subscribeTraceEvents(() => {}, {
+        sessionId: "stream-session",
+      });
+      await server.armBatchHold(1);
+      const building = registry.buildEmbeddings();
+      await server.waitForHeld();
+
+      expect(() =>
+        registry.setTraceSink({ kind: "memory", sessionId: "rejected-session" }),
+      ).toThrow(/registry busy; await/);
+      server.releaseHeld();
+      await building;
+
+      registry.search("after-busy", 1);
+      await subscription.flush();
+      expect(registry.drainTraceEvents()).toContainEqual(
+        expect.objectContaining({ type: expect.stringMatching(/search$/), query: "after-busy" }),
+      );
+    } finally {
+      await server.close();
+    }
   });
 });

--- a/src/sdk/ts/src/native-events.test.ts
+++ b/src/sdk/ts/src/native-events.test.ts
@@ -22,11 +22,17 @@ describe("native runtime event bridge", () => {
       },
     );
 
-    await registry.searchWithMethodAsync("read", 1, "direct", "bm25");
+    const workerSearch = registry.searchWithMethodAsync("read", 1, "direct", "bm25");
+    for (let index = 0; index < 8; index += 1) {
+      registry.search(`burst-${index}`, 1);
+    }
+    await workerSearch;
     await subscription.flush();
 
-    expect(batches.some((batch) => batch.length > 0)).toBe(true);
-    const event = batches.flat().find((candidate) => candidate.type === "search");
+    expect(batches.some((batch) => batch.length > 1)).toBe(true);
+    const event = batches
+      .flat()
+      .find((candidate) => candidate.type === "search" && candidate.query === "read");
     expect(event).toMatchObject({
       v: 2,
       session_id: "session-ts",

--- a/src/sdk/ts/src/ratel.ts
+++ b/src/sdk/ts/src/ratel.ts
@@ -61,7 +61,7 @@ export interface RatelConfig {
   factsTopK?: number;
   /** Local trace-stream destination for all catalogs (default: discard). */
   trace?: TraceSinkConfig;
-  /** Public runtime-event stream identity and bounded delivery options (ADR-0019). */
+  /** Public runtime-event stream identity and bounded delivery options (ADR-0020). */
   events?: RuntimeEventsOptions;
 }
 

--- a/src/sdk/ts/src/ratel.ts
+++ b/src/sdk/ts/src/ratel.ts
@@ -25,6 +25,11 @@ import type { GroundingResult, GroundingSnapshotItem, GroundOptions } from "./gr
 import { isPackageInstalled } from "./package-resolution.js";
 import { SkillCatalog } from "./skill-catalog.js";
 import { GET_SKILL_CONTENT_ID, getSkillContentTool } from "./skill-tools.js";
+import {
+  type RuntimeCatalog,
+  RuntimeEvents,
+  type RuntimeEventsOptions,
+} from "./runtime-events.js";
 
 /** Construction options for {@link ratel}. Shared by every adapter view of the core. */
 export interface RatelConfig {
@@ -60,6 +65,8 @@ export interface RatelConfig {
   factsTopK?: number;
   /** Local trace-stream destination for all catalogs (default: discard). */
   trace?: TraceSinkConfig;
+  /** Public runtime-event stream identity and bounded delivery options (ADR-0019). */
+  events?: RuntimeEventsOptions;
 }
 
 /**
@@ -255,6 +262,10 @@ export interface AdaptedBase<TTool, TMessage> {
   readonly skills: SkillCatalog;
   /** ⚠️ Experimental (facts, ADR-0017). The shared fact catalog — framework-neutral grounding content. */
   readonly facts: FactCatalog;
+  /** Merged runtime-event stream shared by every view of this core. */
+  readonly events: RuntimeEvents;
+  /** Complete executor-free tool + skill state for snapshot publication. */
+  readonly catalog: RuntimeCatalog;
   /**
    * The model-facing toolset in the framework's shape: this view's passthroughs
    * plus the three capability tools run through the adapter's `expose` codec.
@@ -318,6 +329,10 @@ export interface Ratel {
   readonly skills: SkillCatalog;
   /** ⚠️ Experimental (facts, ADR-0017). The shared fact catalog — constant grounding content, injected via {@link Ratel.ground}. */
   readonly facts: FactCatalog;
+  /** Merged runtime-event stream shared by tools, skills, and SDK-owned facts. */
+  readonly events: RuntimeEvents;
+  /** Complete executor-free tool + skill state for snapshot publication. */
+  readonly catalog: RuntimeCatalog;
   /**
    * The three capability tools (`search_capabilities`, `invoke_tool`,
    * `get_skill_content`) in native shape, for framework-free hosts. All three
@@ -434,6 +449,14 @@ export function ratel(config: RatelConfig = {}): Ratel {
     trace: config.trace,
     experimentalEmbeddingArtifact: embeddingArtifact,
   });
+  const events = new RuntimeEvents([catalog, skills], config.events);
+  const runtimeCatalog: RuntimeCatalog = {
+    snapshot: () => ({
+      sourceId: events.sourceId,
+      tools: catalog.snapshot(),
+      skills: skills.snapshot(),
+    }),
+  };
   // The fact catalog owns the grounding freshness state (its injected-body map),
   // so `r.ground` is a thin delegate to `facts.ground`. Constructed **lazily**:
   // facts are experimental, and building one eagerly would fire the
@@ -580,6 +603,8 @@ export function ratel(config: RatelConfig = {}): Ratel {
     const baseWithoutFacts: Omit<AdaptedBase<unknown, unknown>, "facts"> = {
       tools: adaptedTools,
       skills,
+      events,
+      catalog: runtimeCatalog,
       ground,
       groundSnapshot,
       modelTools() {
@@ -614,6 +639,8 @@ export function ratel(config: RatelConfig = {}): Ratel {
   return withLazyFacts(facts, {
     tools,
     skills,
+    events,
+    catalog: runtimeCatalog,
     modelTools,
     recall,
     ground,

--- a/src/sdk/ts/src/ratel.ts
+++ b/src/sdk/ts/src/ratel.ts
@@ -23,13 +23,9 @@ import type { ExperimentalEmbeddingArtifact } from "./embedding-artifact.js";
 import { FactCatalog } from "./fact-catalog.js";
 import type { GroundingResult, GroundingSnapshotItem, GroundOptions } from "./grounding.js";
 import { isPackageInstalled } from "./package-resolution.js";
+import { type RuntimeCatalog, RuntimeEvents, type RuntimeEventsOptions } from "./runtime-events.js";
 import { SkillCatalog } from "./skill-catalog.js";
 import { GET_SKILL_CONTENT_ID, getSkillContentTool } from "./skill-tools.js";
-import {
-  type RuntimeCatalog,
-  RuntimeEvents,
-  type RuntimeEventsOptions,
-} from "./runtime-events.js";
 
 /** Construction options for {@link ratel}. Shared by every adapter view of the core. */
 export interface RatelConfig {
@@ -452,7 +448,7 @@ export function ratel(config: RatelConfig = {}): Ratel {
   const events = new RuntimeEvents([catalog, skills], config.events);
   const runtimeCatalog: RuntimeCatalog = {
     snapshot: () => ({
-      sourceId: events.sourceId,
+      source_id: events.sourceId,
       tools: catalog.snapshot(),
       skills: skills.snapshot(),
     }),

--- a/src/sdk/ts/src/registry.ts
+++ b/src/sdk/ts/src/registry.ts
@@ -18,6 +18,7 @@ import type { EmbeddingSpec, SearchMethod, SearchOrigin, TraceSinkConfig } from 
 import { mapArtifactBuildError, mapArtifactWarmError, mapEmbedderError } from "./errors.js";
 import { assertValidFact, type Fact } from "./grounding.js";
 import type { RuntimeEvent, RuntimeEventsOptions } from "./runtime-events.js";
+import type { RuntimeEventProjection } from "./telemetry.js";
 
 export { IntentGraph };
 
@@ -164,8 +165,9 @@ export class ToolRegistry {
     topK: number,
     origin: SearchOrigin,
     method: SearchMethod,
+    projection?: RuntimeEventProjection,
   ): SearchHit[] {
-    return this.native.searchWithMethod(query, topK, origin, method);
+    return this.native.searchWithMethod(query, topK, origin, method, projection);
   }
 
   /** Search on a libuv worker; supports `"bm25"`, `"semantic"`, and `"hybrid"`. */
@@ -174,6 +176,7 @@ export class ToolRegistry {
     topK: number,
     origin: SearchOrigin,
     method: SearchMethod,
+    projection?: RuntimeEventProjection,
   ): Promise<SearchHit[]> {
     try {
       // Guard the await behind the flag so the default path stays synchronous
@@ -182,7 +185,7 @@ export class ToolRegistry {
       if (method !== "bm25" && this.#rebuildOnModelChange) {
         await this.#maybeRebuildOnModelChange();
       }
-      return await this.native.searchWithMethodAsync(query, topK, origin, method);
+      return await this.native.searchWithMethodAsync(query, topK, origin, method, projection);
     } catch (error) {
       throw mapEmbedderError(error);
     }
@@ -192,8 +195,12 @@ export class ToolRegistry {
    * Record a custom event on the local trace stream (ADR-0007). Throws on an
    * object that doesn't parse as a known trace event.
    */
-  recordEvent(event: object): void {
-    this.native.recordEvent(event);
+  recordEvent(event: object, projection?: RuntimeEventProjection): void {
+    if (projection) {
+      this.native.recordEventWithContext(event, projection);
+    } else {
+      this.native.recordEvent(event);
+    }
   }
 
   /** Replace the trace sink; subsequent events go to the new destination. */
@@ -435,8 +442,9 @@ export class SkillRegistry {
     topK: number,
     origin: SearchOrigin,
     method: SearchMethod,
+    projection?: RuntimeEventProjection,
   ): SkillHit[] {
-    return this.native.searchWithMethod(query, topK, origin, method);
+    return this.native.searchWithMethod(query, topK, origin, method, projection);
   }
 
   /** Search on a libuv worker — see `ToolRegistry.searchWithMethodAsync`. */
@@ -445,6 +453,7 @@ export class SkillRegistry {
     topK: number,
     origin: SearchOrigin,
     method: SearchMethod,
+    projection?: RuntimeEventProjection,
   ): Promise<SkillHit[]> {
     try {
       // Guard the await behind the flag so the default path stays synchronous
@@ -453,15 +462,19 @@ export class SkillRegistry {
       if (method !== "bm25" && this.#rebuildOnModelChange) {
         await this.#maybeRebuildOnModelChange();
       }
-      return await this.native.searchWithMethodAsync(query, topK, origin, method);
+      return await this.native.searchWithMethodAsync(query, topK, origin, method, projection);
     } catch (error) {
       throw mapEmbedderError(error);
     }
   }
 
   /** Record a custom event on the local trace stream (ADR-0007). */
-  recordEvent(event: object): void {
-    this.native.recordEvent(event);
+  recordEvent(event: object, projection?: RuntimeEventProjection): void {
+    if (projection) {
+      this.native.recordEventWithContext(event, projection);
+    } else {
+      this.native.recordEvent(event);
+    }
   }
 
   /** Replace the trace sink; subsequent events go to the new destination. */

--- a/src/sdk/ts/src/registry.ts
+++ b/src/sdk/ts/src/registry.ts
@@ -11,11 +11,13 @@ import {
   type Skill,
   type SkillHit,
   type Tool,
+  type NativeEventSubscription,
 } from "../native/index.cjs";
 import { assertNotArtifactBusy } from "./artifact-source-warm.js";
 import type { EmbeddingSpec, SearchMethod, SearchOrigin, TraceSinkConfig } from "./catalog.js";
 import { mapArtifactBuildError, mapArtifactWarmError, mapEmbedderError } from "./errors.js";
 import { assertValidFact, type Fact } from "./grounding.js";
+import type { RuntimeEvent, RuntimeEventsOptions } from "./runtime-events.js";
 
 export { IntentGraph };
 
@@ -197,6 +199,14 @@ export class ToolRegistry {
   /** Replace the trace sink; subsequent events go to the new destination. */
   setTraceSink(config: TraceSinkConfig): void {
     this.native.setTraceSink(config);
+  }
+
+  /** @internal Attach one public runtime-event subscriber. */
+  subscribeEvents(
+    handler: (batch: RuntimeEvent[]) => void,
+    options: Required<RuntimeEventsOptions>,
+  ): NativeEventSubscription {
+    return this.native.subscribeTraceEvents(handler, options);
   }
 
   /**
@@ -457,6 +467,14 @@ export class SkillRegistry {
   /** Replace the trace sink; subsequent events go to the new destination. */
   setTraceSink(config: TraceSinkConfig): void {
     this.native.setTraceSink(config);
+  }
+
+  /** @internal Attach one public runtime-event subscriber. */
+  subscribeEvents(
+    handler: (batch: RuntimeEvent[]) => void,
+    options: Required<RuntimeEventsOptions>,
+  ): NativeEventSubscription {
+    return this.native.subscribeTraceEvents(handler, options);
   }
 
   /**

--- a/src/sdk/ts/src/registry.ts
+++ b/src/sdk/ts/src/registry.ts
@@ -3,6 +3,7 @@ import {
   type FactHit,
   IntentGraph,
   type EmbeddingConfig as NativeEmbeddingConfig,
+  type NativeEventSubscription,
   FactRegistry as NativeFactRegistry,
   SkillRegistry as NativeSkillRegistry,
   ToolRegistry as NativeToolRegistry,
@@ -11,7 +12,6 @@ import {
   type Skill,
   type SkillHit,
   type Tool,
-  type NativeEventSubscription,
 } from "../native/index.cjs";
 import { assertNotArtifactBusy } from "./artifact-source-warm.js";
 import type { EmbeddingSpec, SearchMethod, SearchOrigin, TraceSinkConfig } from "./catalog.js";

--- a/src/sdk/ts/src/runtime-events.test.ts
+++ b/src/sdk/ts/src/runtime-events.test.ts
@@ -20,6 +20,7 @@ import {
   RUNTIME_EVENT_MAX_QUERY_BYTES,
   RUNTIME_EVENT_TYPES,
   type RuntimeEvent,
+  RuntimeEvents,
   ratel,
 } from "./index.js";
 
@@ -78,6 +79,28 @@ describe("public runtime events", () => {
     expect(Buffer.byteLength(JSON.stringify(event), "utf8")).toBeLessThanOrEqual(
       RUNTIME_EVENT_MAX_PAYLOAD_BYTES,
     );
+  });
+
+  it("rolls back earlier native subscriptions when a later source rejects", () => {
+    let firstUnsubscribed = false;
+    const first = {
+      subscribeEvents: () => ({
+        unsubscribe: () => {
+          firstUnsubscribed = true;
+        },
+        flush: async () => {},
+        droppedCount: 0,
+      }),
+    };
+    const second = {
+      subscribeEvents: () => {
+        throw new Error("registry busy");
+      },
+    };
+    const events = new RuntimeEvents([first, second] as never);
+
+    expect(() => events.subscribe(() => {})).toThrow("registry busy");
+    expect(firstUnsubscribed).toBe(true);
   });
 
   it("waits for async native-event handlers before flush resolves", async () => {

--- a/src/sdk/ts/src/runtime-events.test.ts
+++ b/src/sdk/ts/src/runtime-events.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { type RuntimeEvent, ratel } from "./index.js";
+
+describe("public runtime events", () => {
+  it("merges tool and skill streams under one session stamp", async () => {
+    const runtime = ratel({
+      events: {
+        sessionId: "session-public",
+        sourceId: "source-public",
+        queueCapacity: 16,
+        batchSize: 8,
+      },
+    });
+    const received: RuntimeEvent[] = [];
+    const subscription = runtime.events.subscribe((batch) => received.push(...batch));
+
+    await runtime.tools.register({
+      id: "read_file",
+      name: "read_file",
+      description: "Read a file",
+      inputSchema: { type: "object", properties: { path: { type: "string" } } },
+      outputSchema: { type: "object" },
+      execute: () => ({ ok: true }),
+    });
+    await runtime.skills.register({
+      id: "api-design",
+      name: "API design",
+      description: "Design an API",
+      tags: ["backend"],
+      metadata: { audience: ["developers"] },
+      body: "Private dispatch instructions",
+    });
+    runtime.tools.search("read", 1);
+    runtime.skills.search("api", 1);
+
+    await subscription.flush();
+
+    expect(received.map((event) => event.type)).toEqual(
+      expect.arrayContaining(["index_churn", "skill_churn", "search", "skill_search"]),
+    );
+    expect(received.every((event) => event.session_id === "session-public")).toBe(true);
+    expect(received.every((event) => event.source_id === "source-public")).toBe(true);
+    expect(received.every((event) => /^[0-9A-HJKMNP-TV-Z]{26}$/.test(event.event_id))).toBe(true);
+
+    subscription.unsubscribe();
+  });
+
+  it("returns the complete serializable catalog without executable content", async () => {
+    const runtime = ratel({ events: { sourceId: "service-a" } });
+    const execute = () => ({ secret: "must never escape" });
+    await runtime.tools.register({
+      id: "z_tool",
+      name: "Z tool",
+      description: "Last by id",
+      inputSchema: { type: "object", properties: { value: { type: "string" } } },
+      outputSchema: { type: "string" },
+      execute,
+    });
+    await runtime.tools.register({
+      id: "a_tool",
+      name: "A tool",
+      description: "First by id",
+      inputSchema: { type: "object" },
+      outputSchema: { type: "object" },
+      execute,
+    });
+    await runtime.skills.register({
+      id: "skill-a",
+      name: "Skill A",
+      description: "Public skill metadata",
+      tags: ["public"],
+      tools: ["a_tool"],
+      metadata: { stacks: ["typescript"] },
+      body: "May contain private instructions",
+    });
+
+    const snapshot = runtime.catalog.snapshot();
+
+    expect(snapshot).toEqual({
+      sourceId: "service-a",
+      tools: [
+        {
+          id: "a_tool",
+          name: "A tool",
+          description: "First by id",
+          inputSchema: { type: "object" },
+          outputSchema: { type: "object" },
+        },
+        {
+          id: "z_tool",
+          name: "Z tool",
+          description: "Last by id",
+          inputSchema: { type: "object", properties: { value: { type: "string" } } },
+          outputSchema: { type: "string" },
+        },
+      ],
+      skills: [
+        {
+          id: "skill-a",
+          name: "Skill A",
+          description: "Public skill metadata",
+          tags: ["public"],
+          tools: ["a_tool"],
+          metadata: { stacks: ["typescript"] },
+        },
+      ],
+    });
+    expect(JSON.stringify(snapshot)).not.toContain("execute");
+    expect(JSON.stringify(snapshot)).not.toContain("private instructions");
+  });
+});

--- a/src/sdk/ts/src/runtime-events.test.ts
+++ b/src/sdk/ts/src/runtime-events.test.ts
@@ -58,6 +58,54 @@ describe("public runtime events", () => {
     });
   });
 
+  it("delivers small events unchanged", () => {
+    const input = runtimeEvent({ query: "read docs", top_k: 3 });
+
+    expect(deliverRuntimeEvent(input)).toEqual({
+      v: 2,
+      event_id: "01K2KB4QN2A9XJY5VKQCN8ZM1P",
+      ts: 1_755_000_000_000,
+      session_id: "session-test",
+      source_id: "source-test",
+      type: "search",
+      query: "read docs",
+      top_k: 3,
+    });
+  });
+
+  it("preserves the existing oversize trimming result", () => {
+    const padding = Object.fromEntries(
+      Array.from({ length: 16 }, (_, index) => [
+        `padding_${index.toString().padStart(2, "0")}`,
+        "x".repeat(4_096),
+      ]),
+    );
+
+    const event = deliverRuntimeEvent(runtimeEvent(padding));
+
+    expect(event).toEqual(
+      runtimeEvent({
+        ...Object.fromEntries(Object.entries(padding).slice(1)),
+        payload_truncated: true,
+      }),
+    );
+  });
+
+  it("enforces the payload cap immediately above the exact boundary", () => {
+    const atLimit = runtimeEventWithSerializedSize(RUNTIME_EVENT_MAX_PAYLOAD_BYTES);
+    const aboveLimit = runtimeEventWithSerializedSize(RUNTIME_EVENT_MAX_PAYLOAD_BYTES + 1);
+
+    const atLimitDelivered = deliverRuntimeEvent(atLimit);
+    const aboveLimitDelivered = deliverRuntimeEvent(aboveLimit);
+
+    expect(atLimitDelivered).toEqual(atLimit);
+    expect(atLimitDelivered.payload_truncated).toBeUndefined();
+    expect(aboveLimitDelivered.payload_truncated).toBe(true);
+    expect(Buffer.byteLength(JSON.stringify(aboveLimitDelivered), "utf8")).toBeLessThanOrEqual(
+      RUNTIME_EVENT_MAX_PAYLOAD_BYTES,
+    );
+  });
+
   it("enforces public query, hit, and payload bounds before delivery", async () => {
     const runtime = ratel();
     const received: RuntimeEvent[] = [];
@@ -386,3 +434,50 @@ describe("public runtime events", () => {
     expect(JSON.stringify(snapshot)).not.toContain("private instructions");
   });
 });
+
+function runtimeEvent(fields: Record<string, unknown> = {}): RuntimeEvent {
+  return {
+    v: 2,
+    event_id: "01K2KB4QN2A9XJY5VKQCN8ZM1P",
+    ts: 1_755_000_000_000,
+    session_id: "session-test",
+    source_id: "source-test",
+    type: "search",
+    ...fields,
+  };
+}
+
+function deliverRuntimeEvent(input: RuntimeEvent): RuntimeEvent {
+  let deliver: (batch: RuntimeEvent[]) => void = () => {};
+  const source = {
+    subscribeEvents: (handler: (batch: RuntimeEvent[]) => void) => {
+      deliver = handler;
+      return { unsubscribe: () => {}, flush: async () => {}, droppedCount: 0 };
+    },
+  };
+  const events = new RuntimeEvents([source] as never);
+  let received: RuntimeEvent | undefined;
+  events.subscribe((batch) => {
+    received = batch[0];
+  });
+
+  deliver([input]);
+
+  if (!received) throw new Error("runtime event was not delivered");
+  return received;
+}
+
+function runtimeEventWithSerializedSize(size: number): RuntimeEvent {
+  const padding = Object.fromEntries(
+    Array.from({ length: 16 }, (_, index) => [`padding_${index.toString().padStart(2, "0")}`, ""]),
+  );
+  const event = runtimeEvent(padding);
+  let remaining = size - Buffer.byteLength(JSON.stringify(event), "utf8");
+  for (const key of Object.keys(padding)) {
+    const length = Math.min(remaining, 4_096);
+    event[key] = "x".repeat(length);
+    remaining -= length;
+  }
+  if (remaining !== 0) throw new Error(`cannot create a ${size}-byte runtime event`);
+  return event;
+}

--- a/src/sdk/ts/src/runtime-events.test.ts
+++ b/src/sdk/ts/src/runtime-events.test.ts
@@ -1,7 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { trace } from "@opentelemetry/api";
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { afterEach, describe, expect, it } from "vitest";
 import { type RuntimeEvent, ratel } from "./index.js";
 
 describe("public runtime events", () => {
+  afterEach(() => trace.disable());
+
   it("merges tool and skill streams under one session stamp", async () => {
     const runtime = ratel({
       events: {
@@ -43,6 +51,65 @@ describe("public runtime events", () => {
     expect(received.every((event) => /^[0-9A-HJKMNP-TV-Z]{26}$/.test(event.event_id))).toBe(true);
 
     subscription.unsubscribe();
+  });
+
+  it("stamps OTel search spans with the matching stream event id", async () => {
+    const exporter = new InMemorySpanExporter();
+    trace.setGlobalTracerProvider(
+      new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] }),
+    );
+    const runtime = ratel({ events: { sessionId: "session-join" } });
+    const received: RuntimeEvent[] = [];
+    const subscription = runtime.events.subscribe((batch) => received.push(...batch));
+    await runtime.tools.register({
+      id: "read_file",
+      name: "read_file",
+      description: "Read a file",
+      inputSchema: { type: "object" },
+      outputSchema: { type: "object" },
+      execute: () => ({ ok: true }),
+    });
+
+    runtime.tools.search("read", 1);
+    await subscription.flush();
+
+    const streamEvent = received.find(
+      (event) => event.type === "search" && event.query === "read",
+    );
+    const span = exporter.getFinishedSpans().find((candidate) => candidate.name === "ratel.search");
+    expect(span?.attributes["ratel.event.id"]).toBe(streamEvent?.event_id);
+    expect(streamEvent?.trace_id).toBe(span?.spanContext().traceId);
+    expect(streamEvent?.span_id).toBe(span?.spanContext().spanId);
+  });
+
+  it("stamps an invocation span with its matching invoke_start event id", async () => {
+    const exporter = new InMemorySpanExporter();
+    trace.setGlobalTracerProvider(
+      new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] }),
+    );
+    const runtime = ratel({ events: { sessionId: "session-invoke" } });
+    const received: RuntimeEvent[] = [];
+    const subscription = runtime.events.subscribe((batch) => received.push(...batch));
+    await runtime.tools.register({
+      id: "ping",
+      name: "ping",
+      description: "Ping",
+      inputSchema: { type: "object" },
+      outputSchema: { type: "object" },
+      execute: () => ({ ok: true }),
+    });
+
+    await runtime.tools.invoke("ping", {});
+    await subscription.flush();
+
+    const start = received.find((event) => event.type === "invoke_start");
+    const end = received.find((event) => event.type === "invoke_end");
+    const span = exporter
+      .getFinishedSpans()
+      .find((candidate) => candidate.name === "execute_tool ping");
+    expect(span?.attributes["ratel.event.id"]).toBe(start?.event_id);
+    expect(start?.invocation_id).toBe(end?.invocation_id);
+    expect(start?.event_id).not.toBe(end?.event_id);
   });
 
   it("returns the complete serializable catalog without executable content", async () => {

--- a/src/sdk/ts/src/runtime-events.test.ts
+++ b/src/sdk/ts/src/runtime-events.test.ts
@@ -1,14 +1,82 @@
+import { readFileSync } from "node:fs";
 import { trace } from "@opentelemetry/api";
+import { logs } from "@opentelemetry/api-logs";
+import {
+  InMemoryLogRecordExporter,
+  LoggerProvider,
+  SimpleLogRecordProcessor,
+} from "@opentelemetry/sdk-logs";
 import {
   BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
 import { afterEach, describe, expect, it } from "vitest";
-import { type RuntimeEvent, ratel } from "./index.js";
+import {
+  experimentalDefineExperiment,
+  RUNTIME_EVENT_MAX_HITS,
+  RUNTIME_EVENT_MAX_PAYLOAD_BYTES,
+  RUNTIME_EVENT_MAX_QUERY_BYTES,
+  RUNTIME_EVENT_TYPES,
+  type RuntimeEvent,
+  ratel,
+} from "./index.js";
+
+interface RuntimeEventsFixture {
+  runtime_events: {
+    version: number;
+    max_payload_bytes: number;
+    max_query_bytes: number;
+    max_hits: number;
+    required_envelope_fields: string[];
+    event_types: string[];
+  };
+}
+
+const conformance = JSON.parse(
+  readFileSync(new URL("../../../telemetry/conformance/fixtures.json", import.meta.url), "utf8"),
+) as RuntimeEventsFixture;
 
 describe("public runtime events", () => {
-  afterEach(() => trace.disable());
+  afterEach(() => {
+    logs.disable();
+    trace.disable();
+  });
+
+  it("matches the frozen cross-language event vocabulary", () => {
+    expect(conformance.runtime_events).toEqual({
+      version: 2,
+      max_payload_bytes: RUNTIME_EVENT_MAX_PAYLOAD_BYTES,
+      max_query_bytes: RUNTIME_EVENT_MAX_QUERY_BYTES,
+      max_hits: RUNTIME_EVENT_MAX_HITS,
+      required_envelope_fields: ["v", "event_id", "ts", "session_id", "source_id", "type"],
+      event_types: [...RUNTIME_EVENT_TYPES],
+    });
+  });
+
+  it("enforces public query, hit, and payload bounds before delivery", async () => {
+    const runtime = ratel();
+    const received: RuntimeEvent[] = [];
+    const subscription = runtime.events.subscribe((batch) => received.push(...batch));
+
+    runtime.events.emit({
+      type: "search",
+      search_id: "search-1",
+      query: "é".repeat(4_096),
+      hits: Array.from({ length: 120 }, (_, rank) => ({ id: `tool-${rank}`, rank, score: 1 })),
+      unrecognized_padding: "x".repeat(100_000),
+    });
+    await subscription.flush();
+
+    const [event] = received;
+    expect(Buffer.byteLength(String(event?.query), "utf8")).toBeLessThanOrEqual(
+      RUNTIME_EVENT_MAX_QUERY_BYTES,
+    );
+    expect(event?.hits).toHaveLength(RUNTIME_EVENT_MAX_HITS);
+    expect(Buffer.byteLength(JSON.stringify(event), "utf8")).toBeLessThanOrEqual(
+      RUNTIME_EVENT_MAX_PAYLOAD_BYTES,
+    );
+  });
 
   it("merges tool and skill streams under one session stamp", async () => {
     const runtime = ratel({
@@ -73,9 +141,7 @@ describe("public runtime events", () => {
     runtime.tools.search("read", 1);
     await subscription.flush();
 
-    const streamEvent = received.find(
-      (event) => event.type === "search" && event.query === "read",
-    );
+    const streamEvent = received.find((event) => event.type === "search" && event.query === "read");
     const span = exporter.getFinishedSpans().find((candidate) => candidate.name === "ratel.search");
     expect(span?.attributes["ratel.event.id"]).toBe(streamEvent?.event_id);
     expect(streamEvent?.trace_id).toBe(span?.spanContext().traceId);
@@ -112,6 +178,65 @@ describe("public runtime events", () => {
     expect(start?.event_id).not.toBe(end?.event_id);
   });
 
+  it("merges experiment evaluations through the OTel and runtime-event sinks", async () => {
+    const exporter = new InMemorySpanExporter();
+    const logExporter = new InMemoryLogRecordExporter();
+    trace.setGlobalTracerProvider(
+      new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] }),
+    );
+    logs.setGlobalLoggerProvider(
+      new LoggerProvider({
+        processors: [new SimpleLogRecordProcessor({ exporter: logExporter })],
+      }),
+    );
+    const runtime = ratel({ events: { sessionId: "session-experiment" } });
+    const received: RuntimeEvent[] = [];
+    const subscription = runtime.events.subscribe((batch) => received.push(...batch));
+    const experiment = experimentalDefineExperiment(
+      {
+        id: "search-v2",
+        arms: { stable: { select: async () => [{ id: "read_file", score: 0.9 }] } },
+        ranking: (result) => result,
+        evaluation: { references: ["peer-selection"], outcome: true },
+      },
+      runtime.events,
+    );
+
+    const selection = await experiment.select({}, { arm: "stable", unitId: "unit-a" });
+    experiment.reportOutcome({ selectionId: selection.selectionId, label: "accepted" });
+    await subscription.flush();
+
+    expect(received.map((event) => event.type)).toEqual([
+      "experiment_selection",
+      "experiment_results",
+      "experiment_outcome",
+    ]);
+    expect(received[0]).toMatchObject({
+      experiment_id: "search-v2",
+      selection_id: selection.selectionId,
+      arm: "stable",
+      role: "serving",
+    });
+    expect(received[1]).toMatchObject({
+      selection_id: selection.selectionId,
+      outcome: "ok",
+      result_ids: ["read_file"],
+      result_scores: [0.9],
+    });
+    expect(received[2]).toMatchObject({
+      selection_id: selection.selectionId,
+      label: "accepted",
+    });
+    const span = exporter
+      .getFinishedSpans()
+      .find((candidate) => candidate.name === "ratel.experiment.arm");
+    expect(span?.attributes["ratel.event.id"]).toBe(received[0]?.event_id);
+    const resultsLog = logExporter
+      .getFinishedLogRecords()
+      .find((record) => record.eventName === "ratel.experiment.results");
+    expect(resultsLog?.attributes["ratel.event.id"]).toBe(received[1]?.event_id);
+  });
+
   it("returns the complete serializable catalog without executable content", async () => {
     const runtime = ratel({ events: { sourceId: "service-a" } });
     const execute = () => ({ secret: "must never escape" });
@@ -144,7 +269,7 @@ describe("public runtime events", () => {
     const snapshot = runtime.catalog.snapshot();
 
     expect(snapshot).toEqual({
-      sourceId: "service-a",
+      source_id: "service-a",
       tools: [
         {
           id: "a_tool",

--- a/src/sdk/ts/src/runtime-events.test.ts
+++ b/src/sdk/ts/src/runtime-events.test.ts
@@ -11,6 +11,7 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
+import { RATEL_EVENT_ID } from "@ratel-ai/telemetry";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   experimentalDefineExperiment,
@@ -28,6 +29,7 @@ interface RuntimeEventsFixture {
     max_payload_bytes: number;
     max_query_bytes: number;
     max_hits: number;
+    otel_event_id_attribute: string;
     required_envelope_fields: string[];
     event_types: string[];
   };
@@ -49,6 +51,7 @@ describe("public runtime events", () => {
       max_payload_bytes: RUNTIME_EVENT_MAX_PAYLOAD_BYTES,
       max_query_bytes: RUNTIME_EVENT_MAX_QUERY_BYTES,
       max_hits: RUNTIME_EVENT_MAX_HITS,
+      otel_event_id_attribute: RATEL_EVENT_ID,
       required_envelope_fields: ["v", "event_id", "ts", "session_id", "source_id", "type"],
       event_types: [...RUNTIME_EVENT_TYPES],
     });
@@ -61,7 +64,6 @@ describe("public runtime events", () => {
 
     runtime.events.emit({
       type: "search",
-      search_id: "search-1",
       query: "é".repeat(4_096),
       hits: Array.from({ length: 120 }, (_, rank) => ({ id: `tool-${rank}`, rank, score: 1 })),
       unrecognized_padding: "x".repeat(100_000),
@@ -76,6 +78,66 @@ describe("public runtime events", () => {
     expect(Buffer.byteLength(JSON.stringify(event), "utf8")).toBeLessThanOrEqual(
       RUNTIME_EVENT_MAX_PAYLOAD_BYTES,
     );
+  });
+
+  it("waits for async native-event handlers before flush resolves", async () => {
+    const runtime = ratel();
+    let releaseHandler: () => void = () => {};
+    const handlerReleased = new Promise<void>((resolve) => {
+      releaseHandler = resolve;
+    });
+    let markHandlerStarted: () => void = () => {};
+    const handlerStarted = new Promise<void>((resolve) => {
+      markHandlerStarted = resolve;
+    });
+    let handlerCompleted = false;
+    const subscription = runtime.events.subscribe(async (batch) => {
+      if (!batch.some((event) => event.type === "search")) return;
+      markHandlerStarted();
+      await handlerReleased;
+      handlerCompleted = true;
+    });
+
+    runtime.tools.search("read", 1);
+    let flushCompleted = false;
+    const flushing = subscription.flush().then(() => {
+      flushCompleted = true;
+    });
+    await handlerStarted;
+    const flushState = await Promise.race([
+      flushing.then(() => "resolved" as const),
+      new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 100)),
+    ]);
+
+    releaseHandler();
+    await flushing;
+    expect(flushState).toBe("pending");
+    expect(flushCompleted).toBe(true);
+    expect(handlerCompleted).toBe(true);
+  });
+
+  it("protects envelope fields while preserving a shared event id", () => {
+    const runtime = ratel({
+      events: { sessionId: "session-owned", sourceId: "source-owned" },
+    });
+
+    const event = runtime.events.emit({
+      type: "experiment_outcome",
+      event_id: "01K2KB4QN2A9XJY5VKQCN8ZM1P",
+      v: 1,
+      ts: 0,
+      session_id: "session-forged",
+      source_id: "source-forged",
+    });
+
+    expect(event).toMatchObject({
+      type: "experiment_outcome",
+      event_id: "01K2KB4QN2A9XJY5VKQCN8ZM1P",
+      v: 2,
+      session_id: "session-owned",
+      source_id: "source-owned",
+    });
+    expect(event.ts).toBeGreaterThan(0);
   });
 
   it("merges tool and skill streams under one session stamp", async () => {

--- a/src/sdk/ts/src/runtime-events.ts
+++ b/src/sdk/ts/src/runtime-events.ts
@@ -1,0 +1,179 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import type { NativeEventSubscription } from "../native/index.cjs";
+import type { ToolDefinition } from "./catalog.js";
+import type { SkillDefinition } from "./skill-catalog.js";
+
+const DEFAULT_SOURCE_ID = "ratel";
+
+/** Stable envelope shared by every public runtime event (ADR-0019). */
+export interface RuntimeEvent {
+  readonly v: 2;
+  readonly event_id: string;
+  readonly ts: number;
+  readonly session_id: string;
+  readonly source_id: string;
+  readonly type: string;
+  readonly invocation_id?: string;
+  readonly catalog_version?: string;
+  readonly environment?: string;
+  readonly end_user_id?: string;
+  readonly trace_id?: string;
+  readonly span_id?: string;
+  readonly [field: string]: unknown;
+}
+
+/** Identity and bounded-delivery options for {@link RuntimeEvents}. */
+export interface RuntimeEventsOptions {
+  /** Stable identity for this process/session. Defaults to a fresh UUID. */
+  sessionId?: string;
+  /** Stable deployment source. Defaults to OTel `service.name`, then `"ratel"`. */
+  sourceId?: string;
+  /** Per-registry subscriber queue capacity. Defaults to the native bridge default. */
+  queueCapacity?: number;
+  /** Maximum envelopes per callback batch. Defaults to the native bridge default. */
+  batchSize?: number;
+}
+
+/** One runtime-events subscription. */
+export interface RuntimeEventSubscription {
+  /** Stop accepting future events for this subscriber. */
+  unsubscribe(): void;
+  /** Wait until work already accepted by both registry streams reaches the handler. */
+  flush(): Promise<void>;
+  /** Envelopes dropped from this subscriber's bounded native queues. */
+  readonly droppedCount: number;
+}
+
+/** Complete executor-free catalog state published separately from runtime events. */
+export interface CatalogSnapshot {
+  readonly sourceId: string;
+  readonly tools: readonly ToolDefinition[];
+  readonly skills: readonly SkillDefinition[];
+}
+
+/** Public catalog-state seam. */
+export interface RuntimeCatalog {
+  /** Return a current, serializable full replacement snapshot. */
+  snapshot(): CatalogSnapshot;
+}
+
+type RuntimeEventHandler = (
+  batch: readonly RuntimeEvent[],
+) => void | PromiseLike<void>;
+
+interface EventSource {
+  subscribeEvents(
+    handler: (batch: RuntimeEvent[]) => void,
+    options: Required<RuntimeEventsOptions>,
+  ): NativeEventSubscription;
+}
+
+/** Public merged push stream over tool, skill, and SDK-owned runtime facts. */
+export class RuntimeEvents {
+  readonly sessionId: string;
+  readonly sourceId: string;
+  readonly #options: Required<RuntimeEventsOptions>;
+  readonly #sources: readonly EventSource[];
+  readonly #sdkSubscribers = new Set<RuntimeEventHandler>();
+
+  /** @internal Constructed by {@link ratel}; consumers use `runtime.events`. */
+  constructor(sources: readonly EventSource[], options: RuntimeEventsOptions = {}) {
+    this.sessionId = options.sessionId ?? randomUUID();
+    this.sourceId = options.sourceId ?? defaultSourceId();
+    this.#options = {
+      sessionId: this.sessionId,
+      sourceId: this.sourceId,
+      queueCapacity: options.queueCapacity ?? 1_024,
+      batchSize: options.batchSize ?? 64,
+    };
+    this.#sources = sources;
+  }
+
+  /**
+   * Subscribe to merged runtime-event batches. Delivery is asynchronous and
+   * bounded; handler work never blocks the emitting registry operation.
+   */
+  subscribe(handler: RuntimeEventHandler): RuntimeEventSubscription {
+    const deliver = (batch: RuntimeEvent[]): void => {
+      try {
+        void Promise.resolve(handler(batch)).catch(() => {});
+      } catch {
+        // Runtime-event consumers are observational and fail open.
+      }
+    };
+    const subscriptions = this.#sources.map((source) =>
+      source.subscribeEvents(deliver, this.#options),
+    );
+    this.#sdkSubscribers.add(handler);
+    let active = true;
+    return {
+      unsubscribe: () => {
+        if (!active) return;
+        active = false;
+        this.#sdkSubscribers.delete(handler);
+        for (const subscription of subscriptions) subscription.unsubscribe();
+      },
+      flush: async () => {
+        await Promise.all(subscriptions.map((subscription) => subscription.flush()));
+      },
+      get droppedCount() {
+        return subscriptions.reduce((total, subscription) => total + subscription.droppedCount, 0);
+      },
+    };
+  }
+
+  /** @internal Merge an SDK-owned fact (experiments) into every public subscriber. */
+  emit(event: Record<string, unknown>): RuntimeEvent {
+    const envelope: RuntimeEvent = {
+      v: 2,
+      event_id: newUlid(),
+      ts: Date.now(),
+      session_id: this.sessionId,
+      source_id: this.sourceId,
+      type: String(event.type ?? "unknown"),
+      ...event,
+    };
+    for (const handler of this.#sdkSubscribers) {
+      queueMicrotask(() => {
+        try {
+          void Promise.resolve(handler([envelope])).catch(() => {});
+        } catch {
+          // Runtime-event consumers are observational and fail open.
+        }
+      });
+    }
+    return envelope;
+  }
+}
+
+function defaultSourceId(): string {
+  if (process.env.OTEL_SERVICE_NAME) return process.env.OTEL_SERVICE_NAME;
+  const serviceName = process.env.OTEL_RESOURCE_ATTRIBUTES?.split(",")
+    .map((entry) => entry.trim().split("=", 2))
+    .find(([key]) => key === "service.name")?.[1];
+  return serviceName || DEFAULT_SOURCE_ID;
+}
+
+/** Minimal monotonicity-free ULID generator: event uniqueness, time sorting, wire alphabet. */
+function newUlid(now = Date.now()): string {
+  const alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+  let time = now;
+  let encodedTime = "";
+  for (let index = 0; index < 10; index += 1) {
+    encodedTime = alphabet[time % 32] + encodedTime;
+    time = Math.floor(time / 32);
+  }
+  const entropy = randomBytes(10);
+  let buffer = 0;
+  let bits = 0;
+  let encodedEntropy = "";
+  for (const byte of entropy) {
+    buffer = (buffer << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      encodedEntropy += alphabet[(buffer >> bits) & 31];
+    }
+  }
+  return encodedTime + encodedEntropy;
+}

--- a/src/sdk/ts/src/runtime-events.ts
+++ b/src/sdk/ts/src/runtime-events.ts
@@ -13,7 +13,7 @@ const REQUIRED_ENVELOPE_FIELDS = new Set([
   "type",
 ]);
 
-/** Frozen remotely publishable v1 event names from ADR-0019. */
+/** Frozen remotely publishable v1 event names from ADR-0020. */
 export const RUNTIME_EVENT_TYPES = [
   "search",
   "skill_search",
@@ -51,7 +51,7 @@ export const RUNTIME_EVENT_MAX_QUERY_BYTES = 4 * 1_024;
 /** Maximum ranked hits carried by one public search event. */
 export const RUNTIME_EVENT_MAX_HITS = 100;
 
-/** Stable envelope shared by every public runtime event (ADR-0019). */
+/** Stable envelope shared by every public runtime event (ADR-0020). */
 export interface RuntimeEvent {
   /** Envelope schema version. */
   readonly v: 2;

--- a/src/sdk/ts/src/runtime-events.ts
+++ b/src/sdk/ts/src/runtime-events.ts
@@ -126,7 +126,7 @@ export class RuntimeEvents {
   emit(event: Record<string, unknown>): RuntimeEvent {
     const envelope: RuntimeEvent = {
       v: 2,
-      event_id: newUlid(),
+      event_id: newRuntimeEventId(),
       ts: Date.now(),
       session_id: this.sessionId,
       source_id: this.sourceId,
@@ -155,7 +155,8 @@ function defaultSourceId(): string {
 }
 
 /** Minimal monotonicity-free ULID generator: event uniqueness, time sorting, wire alphabet. */
-function newUlid(now = Date.now()): string {
+/** @internal Mint the canonical client event id before stream + OTel projection. */
+export function newRuntimeEventId(now = Date.now()): string {
   const alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
   let time = now;
   let encodedTime = "";

--- a/src/sdk/ts/src/runtime-events.ts
+++ b/src/sdk/ts/src/runtime-events.ts
@@ -165,9 +165,15 @@ export class RuntimeEvents {
     const deliver = (batch: RuntimeEvent[]): void => {
       trackHandlerWork(sdkSubscriber, batch.map(normalizeRuntimeEvent));
     };
-    const subscriptions = this.#sources.map((source) =>
-      source.subscribeEvents(deliver, this.#options),
-    );
+    const subscriptions: NativeEventSubscription[] = [];
+    try {
+      for (const source of this.#sources) {
+        subscriptions.push(source.subscribeEvents(deliver, this.#options));
+      }
+    } catch (error) {
+      for (const subscription of subscriptions.reverse()) subscription.unsubscribe();
+      throw error;
+    }
     this.#sdkSubscribers.add(sdkSubscriber);
     let active = true;
     return {

--- a/src/sdk/ts/src/runtime-events.ts
+++ b/src/sdk/ts/src/runtime-events.ts
@@ -272,18 +272,32 @@ export function newRuntimeEventId(now = Date.now()): string {
 
 function normalizeRuntimeEvent(input: Record<string, unknown>): RuntimeEvent {
   const normalized = sanitizeValue(input, "") as Record<string, unknown>;
-  if (serializedSize(normalized) <= RUNTIME_EVENT_MAX_PAYLOAD_BYTES) {
+  if (serializedSizeUpperBound(normalized) <= RUNTIME_EVENT_MAX_PAYLOAD_BYTES) {
+    return normalized as unknown as RuntimeEvent;
+  }
+
+  // The public subscribe API still delivers objects. Passing pre-serialized envelopes through so
+  // cloud-sdk can reuse them in its batcher is a deferred cross-repo design change.
+  let normalizedSize = serializedSize(normalized);
+  if (normalizedSize <= RUNTIME_EVENT_MAX_PAYLOAD_BYTES) {
     return normalized as unknown as RuntimeEvent;
   }
 
   for (const key of Object.keys(normalized)) {
     if (!REQUIRED_ENVELOPE_FIELDS.has(key) && !isProductFactField(key)) {
+      normalizedSize = sizeAfterDeletingProperty(normalized, key, normalizedSize);
       delete normalized[key];
+      normalizedSize = sizeAfterSettingProperty(
+        normalized,
+        "payload_truncated",
+        true,
+        normalizedSize,
+      );
       normalized.payload_truncated = true;
-      if (serializedSize(normalized) <= RUNTIME_EVENT_MAX_PAYLOAD_BYTES) break;
+      if (normalizedSize <= RUNTIME_EVENT_MAX_PAYLOAD_BYTES) break;
     }
   }
-  if (serializedSize(normalized) <= RUNTIME_EVENT_MAX_PAYLOAD_BYTES) {
+  if (normalizedSize <= RUNTIME_EVENT_MAX_PAYLOAD_BYTES) {
     return normalized as unknown as RuntimeEvent;
   }
 
@@ -291,10 +305,14 @@ function normalizeRuntimeEvent(input: Record<string, unknown>): RuntimeEvent {
     Object.entries(normalized).filter(([key]) => REQUIRED_ENVELOPE_FIELDS.has(key)),
   );
   bounded.payload_truncated = true;
+  let boundedSize = serializedSize(bounded);
   for (const [key, value] of Object.entries(normalized)) {
     if (REQUIRED_ENVELOPE_FIELDS.has(key) || !isProductFactField(key)) continue;
-    bounded[key] = sanitizeBoundedValue(value);
-    if (serializedSize(bounded) > RUNTIME_EVENT_MAX_PAYLOAD_BYTES) delete bounded[key];
+    const boundedValue = sanitizeBoundedValue(value);
+    const candidateSize = sizeAfterSettingProperty(bounded, key, boundedValue, boundedSize);
+    if (candidateSize > RUNTIME_EVENT_MAX_PAYLOAD_BYTES) continue;
+    bounded[key] = boundedValue;
+    boundedSize = candidateSize;
   }
   return bounded as unknown as RuntimeEvent;
 }
@@ -340,6 +358,65 @@ function truncateUtf8(value: string, maxBytes: number): string {
 
 function serializedSize(value: unknown): number {
   return Buffer.byteLength(JSON.stringify(value), "utf8");
+}
+
+function serializedSizeUpperBound(value: unknown, limit = RUNTIME_EVENT_MAX_PAYLOAD_BYTES): number {
+  if (value === null) return 4;
+  if (typeof value === "string") return Math.min(6 * value.length + 2, limit + 1);
+  if (typeof value === "number") return 32;
+  if (typeof value === "boolean") return 5;
+  if (typeof value !== "object") return limit + 1;
+
+  if (Array.isArray(value)) {
+    let size = 2;
+    for (const [index, child] of value.entries()) {
+      size += serializedSizeUpperBound(child, limit - size) + (index === 0 ? 0 : 1);
+      if (size > limit) return limit + 1;
+    }
+    return size;
+  }
+
+  let size = 2;
+  for (const [index, [key, child]] of Object.entries(value).entries()) {
+    size +=
+      6 * key.length + 3 + serializedSizeUpperBound(child, limit - size) + (index === 0 ? 0 : 1);
+    if (size > limit) return limit + 1;
+  }
+  return size;
+}
+
+function sizeAfterDeletingProperty(
+  value: Record<string, unknown>,
+  key: string,
+  currentSize: number,
+): number {
+  const propertySize = serializedPropertySize(key, value[key]);
+  if (propertySize === 0) return currentSize;
+  const commaSize = currentSize > propertySize + 2 ? 1 : 0;
+  return currentSize - propertySize - commaSize;
+}
+
+function sizeAfterSettingProperty(
+  value: Record<string, unknown>,
+  key: string,
+  nextValue: unknown,
+  currentSize: number,
+): number {
+  const nextPropertySize = serializedPropertySize(key, nextValue);
+  const currentPropertySize = Object.hasOwn(value, key)
+    ? serializedPropertySize(key, value[key])
+    : 0;
+  if (currentPropertySize > 0 && nextPropertySize > 0) {
+    return currentSize - currentPropertySize + nextPropertySize;
+  }
+  if (currentPropertySize > 0) {
+    return currentSize - currentPropertySize - (currentSize > currentPropertySize + 2 ? 1 : 0);
+  }
+  return currentSize + nextPropertySize + (currentSize > 2 && nextPropertySize > 0 ? 1 : 0);
+}
+
+function serializedPropertySize(key: string, value: unknown): number {
+  return serializedSize({ [key]: value }) - 2;
 }
 
 function isProductFactField(key: string): boolean {

--- a/src/sdk/ts/src/runtime-events.ts
+++ b/src/sdk/ts/src/runtime-events.ts
@@ -94,9 +94,9 @@ export interface RuntimeEventsOptions {
 
 /** One runtime-events subscription. */
 export interface RuntimeEventSubscription {
-  /** Stop accepting future events for this subscriber. */
+  /** Stop accepting new events; already-queued native envelopes still drain. */
   unsubscribe(): void;
-  /** Wait until work already accepted by both registry streams reaches the handler. */
+  /** Wait until accepted registry events reach the handler and async work settles. */
   flush(): Promise<void>;
   /** Envelopes dropped from this subscriber's bounded native queues. */
   readonly droppedCount: number;
@@ -161,17 +161,13 @@ export class RuntimeEvents {
    * bounded; handler work never blocks the emitting registry operation.
    */
   subscribe(handler: RuntimeEventHandler): RuntimeEventSubscription {
+    const sdkSubscriber: SdkSubscriber = { handler, pending: new Set() };
     const deliver = (batch: RuntimeEvent[]): void => {
-      try {
-        void Promise.resolve(handler(batch.map(normalizeRuntimeEvent))).catch(() => {});
-      } catch {
-        // Runtime-event consumers are observational and fail open.
-      }
+      trackHandlerWork(sdkSubscriber, batch.map(normalizeRuntimeEvent));
     };
     const subscriptions = this.#sources.map((source) =>
       source.subscribeEvents(deliver, this.#options),
     );
-    const sdkSubscriber: SdkSubscriber = { handler, pending: new Set() };
     this.#sdkSubscribers.add(sdkSubscriber);
     let active = true;
     return {
@@ -193,14 +189,15 @@ export class RuntimeEvents {
 
   /** @internal Merge an SDK-owned fact (experiments) into every public subscriber. */
   emit(event: Record<string, unknown>): RuntimeEvent {
+    const eventId = typeof event.event_id === "string" ? event.event_id : newRuntimeEventId();
     const envelope = normalizeRuntimeEvent({
+      ...event,
       v: 2,
-      event_id: newRuntimeEventId(),
+      event_id: eventId,
       ts: Date.now(),
       session_id: this.sessionId,
       source_id: this.sourceId,
       type: String(event.type ?? "unknown"),
-      ...event,
     });
     for (const subscriber of this.#sdkSubscribers) {
       const pending = new Promise<void>((resolve) => {
@@ -217,6 +214,21 @@ export class RuntimeEvents {
     }
     return envelope;
   }
+}
+
+function trackHandlerWork(subscriber: SdkSubscriber, batch: readonly RuntimeEvent[]): void {
+  let pending: Promise<void>;
+  try {
+    pending = Promise.resolve(subscriber.handler(batch)).then(
+      () => {},
+      () => {},
+    );
+  } catch {
+    // Runtime-event consumers are observational and fail open.
+    return;
+  }
+  subscriber.pending.add(pending);
+  void pending.then(() => subscriber.pending.delete(pending));
 }
 
 function defaultSourceId(): string {

--- a/src/sdk/ts/src/runtime-events.ts
+++ b/src/sdk/ts/src/runtime-events.ts
@@ -4,20 +4,78 @@ import type { ToolDefinition } from "./catalog.js";
 import type { SkillDefinition } from "./skill-catalog.js";
 
 const DEFAULT_SOURCE_ID = "ratel";
+const REQUIRED_ENVELOPE_FIELDS = new Set([
+  "v",
+  "event_id",
+  "ts",
+  "session_id",
+  "source_id",
+  "type",
+]);
+
+/** Frozen remotely publishable v1 event names from ADR-0019. */
+export const RUNTIME_EVENT_TYPES = [
+  "search",
+  "skill_search",
+  "gateway_search",
+  "invoke_start",
+  "invoke_end",
+  "invoke_error",
+  "gateway_invoke",
+  "gateway_error",
+  "skill_invoke",
+  "index_churn",
+  "skill_churn",
+  "upstream_register",
+  "upstream_invoke",
+  "upstream_error",
+  "auth_refresh",
+  "auth_needs",
+  "auth_flow_start",
+  "auth_flow_end",
+  "experiment_selection",
+  "experiment_results",
+  "experiment_comparison",
+  "experiment_skip",
+  "experiment_fallback",
+  "experiment_drop",
+  "experiment_invocation",
+  "experiment_outcome",
+  "events_dropped",
+] as const;
+
+/** Maximum serialized size of one public event envelope. */
+export const RUNTIME_EVENT_MAX_PAYLOAD_BYTES = 64 * 1_024;
+/** Maximum UTF-8 byte size of a public search query. */
+export const RUNTIME_EVENT_MAX_QUERY_BYTES = 4 * 1_024;
+/** Maximum ranked hits carried by one public search event. */
+export const RUNTIME_EVENT_MAX_HITS = 100;
 
 /** Stable envelope shared by every public runtime event (ADR-0019). */
 export interface RuntimeEvent {
+  /** Envelope schema version. */
   readonly v: 2;
+  /** Canonical client ULID used to deduplicate and join OTel. */
   readonly event_id: string;
+  /** Unix timestamp in milliseconds. */
   readonly ts: number;
+  /** Process/session identity shared by the merged stream. */
   readonly session_id: string;
+  /** Stable deployment source identity. */
   readonly source_id: string;
+  /** Additive event discriminator. */
   readonly type: string;
+  /** Lifecycle group for invocation start/end/error events. */
   readonly invocation_id?: string;
+  /** Catalog generation when supplied by the producer. */
   readonly catalog_version?: string;
+  /** Optional deployment environment. */
   readonly environment?: string;
+  /** Optional pseudonymous application user identity. */
   readonly end_user_id?: string;
+  /** Active OTel trace identity when a recording span exists. */
   readonly trace_id?: string;
+  /** Active OTel span identity when a recording span exists. */
   readonly span_id?: string;
   readonly [field: string]: unknown;
 }
@@ -46,8 +104,11 @@ export interface RuntimeEventSubscription {
 
 /** Complete executor-free catalog state published separately from runtime events. */
 export interface CatalogSnapshot {
-  readonly sourceId: string;
+  /** Stable deployment source shared with runtime envelopes. */
+  readonly source_id: string;
+  /** Complete serializable tool definitions, sorted by id. */
   readonly tools: readonly ToolDefinition[];
+  /** Complete public skill metadata, sorted by id and excluding bodies. */
   readonly skills: readonly SkillDefinition[];
 }
 
@@ -57,9 +118,13 @@ export interface RuntimeCatalog {
   snapshot(): CatalogSnapshot;
 }
 
-type RuntimeEventHandler = (
-  batch: readonly RuntimeEvent[],
-) => void | PromiseLike<void>;
+/** Asynchronous, fail-open consumer of one public event batch. */
+export type RuntimeEventHandler = (batch: readonly RuntimeEvent[]) => void | PromiseLike<void>;
+
+interface SdkSubscriber {
+  readonly handler: RuntimeEventHandler;
+  readonly pending: Set<Promise<void>>;
+}
 
 interface EventSource {
   subscribeEvents(
@@ -70,11 +135,13 @@ interface EventSource {
 
 /** Public merged push stream over tool, skill, and SDK-owned runtime facts. */
 export class RuntimeEvents {
+  /** Process/session identity stamped onto every delivered envelope. */
   readonly sessionId: string;
+  /** Stable deployment identity stamped onto events and catalog snapshots. */
   readonly sourceId: string;
   readonly #options: Required<RuntimeEventsOptions>;
   readonly #sources: readonly EventSource[];
-  readonly #sdkSubscribers = new Set<RuntimeEventHandler>();
+  readonly #sdkSubscribers = new Set<SdkSubscriber>();
 
   /** @internal Constructed by {@link ratel}; consumers use `runtime.events`. */
   constructor(sources: readonly EventSource[], options: RuntimeEventsOptions = {}) {
@@ -96,7 +163,7 @@ export class RuntimeEvents {
   subscribe(handler: RuntimeEventHandler): RuntimeEventSubscription {
     const deliver = (batch: RuntimeEvent[]): void => {
       try {
-        void Promise.resolve(handler(batch)).catch(() => {});
+        void Promise.resolve(handler(batch.map(normalizeRuntimeEvent))).catch(() => {});
       } catch {
         // Runtime-event consumers are observational and fail open.
       }
@@ -104,17 +171,19 @@ export class RuntimeEvents {
     const subscriptions = this.#sources.map((source) =>
       source.subscribeEvents(deliver, this.#options),
     );
-    this.#sdkSubscribers.add(handler);
+    const sdkSubscriber: SdkSubscriber = { handler, pending: new Set() };
+    this.#sdkSubscribers.add(sdkSubscriber);
     let active = true;
     return {
       unsubscribe: () => {
         if (!active) return;
         active = false;
-        this.#sdkSubscribers.delete(handler);
+        this.#sdkSubscribers.delete(sdkSubscriber);
         for (const subscription of subscriptions) subscription.unsubscribe();
       },
       flush: async () => {
         await Promise.all(subscriptions.map((subscription) => subscription.flush()));
+        await Promise.all([...sdkSubscriber.pending]);
       },
       get droppedCount() {
         return subscriptions.reduce((total, subscription) => total + subscription.droppedCount, 0);
@@ -124,7 +193,7 @@ export class RuntimeEvents {
 
   /** @internal Merge an SDK-owned fact (experiments) into every public subscriber. */
   emit(event: Record<string, unknown>): RuntimeEvent {
-    const envelope: RuntimeEvent = {
+    const envelope = normalizeRuntimeEvent({
       v: 2,
       event_id: newRuntimeEventId(),
       ts: Date.now(),
@@ -132,15 +201,19 @@ export class RuntimeEvents {
       source_id: this.sourceId,
       type: String(event.type ?? "unknown"),
       ...event,
-    };
-    for (const handler of this.#sdkSubscribers) {
-      queueMicrotask(() => {
-        try {
-          void Promise.resolve(handler([envelope])).catch(() => {});
-        } catch {
-          // Runtime-event consumers are observational and fail open.
-        }
+    });
+    for (const subscriber of this.#sdkSubscribers) {
+      const pending = new Promise<void>((resolve) => {
+        queueMicrotask(() => {
+          try {
+            void Promise.resolve(subscriber.handler([envelope])).then(resolve, resolve);
+          } catch {
+            resolve();
+          }
+        });
       });
+      subscriber.pending.add(pending);
+      void pending.finally(() => subscriber.pending.delete(pending));
     }
     return envelope;
   }
@@ -177,4 +250,108 @@ export function newRuntimeEventId(now = Date.now()): string {
     }
   }
   return encodedTime + encodedEntropy;
+}
+
+function normalizeRuntimeEvent(input: Record<string, unknown>): RuntimeEvent {
+  const normalized = sanitizeValue(input, "") as Record<string, unknown>;
+  if (serializedSize(normalized) <= RUNTIME_EVENT_MAX_PAYLOAD_BYTES) {
+    return normalized as unknown as RuntimeEvent;
+  }
+
+  for (const key of Object.keys(normalized)) {
+    if (!REQUIRED_ENVELOPE_FIELDS.has(key) && !isProductFactField(key)) {
+      delete normalized[key];
+      normalized.payload_truncated = true;
+      if (serializedSize(normalized) <= RUNTIME_EVENT_MAX_PAYLOAD_BYTES) break;
+    }
+  }
+  if (serializedSize(normalized) <= RUNTIME_EVENT_MAX_PAYLOAD_BYTES) {
+    return normalized as unknown as RuntimeEvent;
+  }
+
+  const bounded = Object.fromEntries(
+    Object.entries(normalized).filter(([key]) => REQUIRED_ENVELOPE_FIELDS.has(key)),
+  );
+  bounded.payload_truncated = true;
+  for (const [key, value] of Object.entries(normalized)) {
+    if (REQUIRED_ENVELOPE_FIELDS.has(key) || !isProductFactField(key)) continue;
+    bounded[key] = sanitizeBoundedValue(value);
+    if (serializedSize(bounded) > RUNTIME_EVENT_MAX_PAYLOAD_BYTES) delete bounded[key];
+  }
+  return bounded as unknown as RuntimeEvent;
+}
+
+function sanitizeValue(value: unknown, key: string): unknown {
+  if (typeof value === "string") {
+    return truncateUtf8(value, key === "query" ? RUNTIME_EVENT_MAX_QUERY_BYTES : 4_096);
+  }
+  if (Array.isArray(value)) {
+    return value.slice(0, RUNTIME_EVENT_MAX_HITS).map((item) => sanitizeValue(item, ""));
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .slice(0, 100)
+        .map(([childKey, childValue]) => [childKey, sanitizeValue(childValue, childKey)]),
+    );
+  }
+  return value;
+}
+
+function sanitizeBoundedValue(value: unknown): unknown {
+  if (typeof value === "string") return truncateUtf8(value, 512);
+  if (Array.isArray(value)) {
+    return value.slice(0, RUNTIME_EVENT_MAX_HITS).map((item) => sanitizeBoundedValue(item));
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .slice(0, 32)
+        .map(([key, child]) => [key, sanitizeBoundedValue(child)]),
+    );
+  }
+  return value;
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  if (Buffer.byteLength(value, "utf8") <= maxBytes) return value;
+  let result = Buffer.from(value, "utf8").subarray(0, maxBytes).toString("utf8");
+  while (Buffer.byteLength(result, "utf8") > maxBytes) result = result.slice(0, -1);
+  return result;
+}
+
+function serializedSize(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), "utf8");
+}
+
+function isProductFactField(key: string): boolean {
+  return (
+    key.endsWith("_id") ||
+    key.endsWith("_ids") ||
+    key.endsWith("_ms") ||
+    key.endsWith("_count") ||
+    key.endsWith("_score") ||
+    key.endsWith("_scores") ||
+    [
+      "query",
+      "target",
+      "origin",
+      "top_k",
+      "hits",
+      "outcome",
+      "error",
+      "error_class",
+      "transport",
+      "role",
+      "cold",
+      "agreement",
+      "reason",
+      "label",
+      "score",
+      "attributed",
+      "rank",
+      "turn",
+      "action",
+    ].includes(key)
+  );
 }

--- a/src/sdk/ts/src/runtime-events.ts
+++ b/src/sdk/ts/src/runtime-events.ts
@@ -84,7 +84,12 @@ export interface RuntimeEvent {
 export interface RuntimeEventsOptions {
   /** Stable identity for this process/session. Defaults to a fresh UUID. */
   sessionId?: string;
-  /** Stable deployment source. Defaults to OTel `service.name`, then `"ratel"`. */
+  /**
+   * Stable deployment source. Defaults to the env-var-configured OTel `service.name`
+   * (`OTEL_SERVICE_NAME`, then `service.name` in `OTEL_RESOURCE_ATTRIBUTES`), then
+   * `"ratel"`. A programmatically configured OTel resource is not read; pass this
+   * option explicitly in that case.
+   */
   sourceId?: string;
   /** Per-registry subscriber queue capacity. Defaults to the native bridge default. */
   queueCapacity?: number;

--- a/src/sdk/ts/src/skill-catalog.ts
+++ b/src/sdk/ts/src/skill-catalog.ts
@@ -8,6 +8,8 @@ import {
 } from "./embedding-artifact.js";
 import { type IntentGraph, SkillRegistry } from "./registry.js";
 import { traceSearch, traceSearchAsync, traceSkillLoad } from "./telemetry.js";
+import type { NativeEventSubscription } from "../native/index.cjs";
+import type { RuntimeEvent, RuntimeEventsOptions } from "./runtime-events.js";
 
 export type { ReplaceOutcome, Skill, SkillHit };
 
@@ -37,6 +39,9 @@ export type { ReplaceOutcome, Skill, SkillHit };
  * ```
  */
 export type PendingReplace = Promise<ReplaceOutcome> & ReplaceOutcome;
+
+/** Serializable skill definition used by catalog snapshots (never the private body). */
+export type SkillDefinition = Omit<Skill, "body">;
 
 /** Construction options for {@link SkillCatalog}. */
 export interface SkillCatalogOptions {
@@ -226,6 +231,21 @@ export class SkillCatalog {
    */
   get(skillId: string): Skill | undefined {
     return this.skills.get(skillId);
+  }
+
+  /** Complete, deterministic public skill definition set. */
+  snapshot(): SkillDefinition[] {
+    return [...this.skills.values()]
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .map(({ body: _body, ...skill }) => structuredClone(skill));
+  }
+
+  /** @internal Attach one public runtime-event subscriber. */
+  subscribeEvents(
+    handler: (batch: RuntimeEvent[]) => void,
+    options: Required<RuntimeEventsOptions>,
+  ): NativeEventSubscription {
+    return this.registry.subscribeEvents(handler, options);
   }
 
   /**

--- a/src/sdk/ts/src/skill-catalog.ts
+++ b/src/sdk/ts/src/skill-catalog.ts
@@ -1,5 +1,5 @@
 import { SearchTarget } from "@ratel-ai/telemetry";
-import type { ReplaceOutcome, Skill, SkillHit } from "../native/index.cjs";
+import type { NativeEventSubscription, ReplaceOutcome, Skill, SkillHit } from "../native/index.cjs";
 import { warmFromEmbeddingArtifactSource } from "./artifact-source-warm.js";
 import type { EmbeddingSpec, SearchMethod, SearchOrigin, TraceSinkConfig } from "./catalog.js";
 import {
@@ -7,9 +7,8 @@ import {
   resolveEmbeddingArtifact,
 } from "./embedding-artifact.js";
 import { type IntentGraph, SkillRegistry } from "./registry.js";
-import { traceSearch, traceSearchAsync, traceSkillLoad } from "./telemetry.js";
-import type { NativeEventSubscription } from "../native/index.cjs";
 import type { RuntimeEvent, RuntimeEventsOptions } from "./runtime-events.js";
+import { traceSearch, traceSearchAsync, traceSkillLoad } from "./telemetry.js";
 
 export type { ReplaceOutcome, Skill, SkillHit };
 
@@ -208,13 +207,7 @@ export class SkillCatalog {
     method?: SearchMethod,
   ): Promise<SkillHit[]> {
     return traceSearchAsync(SearchTarget.Skill, query, topK, origin, (projection) =>
-      this.registry.searchWithMethodAsync(
-        query,
-        topK,
-        origin,
-        method ?? this.method,
-        projection,
-      ),
+      this.registry.searchWithMethodAsync(query, topK, origin, method ?? this.method, projection),
     );
   }
 
@@ -345,11 +338,14 @@ export class SkillCatalog {
     return traceSkillLoad(skillId, (projection) => {
       const started = Date.now();
       const body = skill.body ?? "";
-      this.registry.recordEvent({
-        type: "skill_invoke",
-        skill_id: skillId,
-        took_ms: Date.now() - started,
-      }, projection);
+      this.registry.recordEvent(
+        {
+          type: "skill_invoke",
+          skill_id: skillId,
+          took_ms: Date.now() - started,
+        },
+        projection,
+      );
       return body;
     });
   }

--- a/src/sdk/ts/src/skill-catalog.ts
+++ b/src/sdk/ts/src/skill-catalog.ts
@@ -195,8 +195,8 @@ export class SkillCatalog {
     origin: SearchOrigin = "direct",
     method?: SearchMethod,
   ): SkillHit[] {
-    return traceSearch(SearchTarget.Skill, query, topK, origin, () =>
-      this.registry.searchWithMethod(query, topK, origin, method ?? this.method),
+    return traceSearch(SearchTarget.Skill, query, topK, origin, (projection) =>
+      this.registry.searchWithMethod(query, topK, origin, method ?? this.method, projection),
     );
   }
 
@@ -207,8 +207,14 @@ export class SkillCatalog {
     origin: SearchOrigin = "direct",
     method?: SearchMethod,
   ): Promise<SkillHit[]> {
-    return traceSearchAsync(SearchTarget.Skill, query, topK, origin, () =>
-      this.registry.searchWithMethodAsync(query, topK, origin, method ?? this.method),
+    return traceSearchAsync(SearchTarget.Skill, query, topK, origin, (projection) =>
+      this.registry.searchWithMethodAsync(
+        query,
+        topK,
+        origin,
+        method ?? this.method,
+        projection,
+      ),
     );
   }
 
@@ -336,14 +342,14 @@ export class SkillCatalog {
     if (!skill) {
       throw new Error(`unknown skillId: ${skillId}`);
     }
-    return traceSkillLoad(skillId, () => {
+    return traceSkillLoad(skillId, (projection) => {
       const started = Date.now();
       const body = skill.body ?? "";
       this.registry.recordEvent({
         type: "skill_invoke",
         skill_id: skillId,
         took_ms: Date.now() - started,
-      });
+      }, projection);
       return body;
     });
   }

--- a/src/sdk/ts/src/telemetry.ts
+++ b/src/sdk/ts/src/telemetry.ts
@@ -38,6 +38,7 @@ import {
   GEN_AI_TOOL_NAME,
   RATEL_AUTH_FLOW,
   RATEL_AUTH_OUTCOME,
+  RATEL_EVENT_ID,
   RATEL_EXPERIMENT_AGREEMENT_EXACT_ORDER,
   RATEL_EXPERIMENT_AGREEMENT_ITEM_ATTRS,
   RATEL_EXPERIMENT_AGREEMENT_JACCARD_AT_K,
@@ -171,7 +172,6 @@ const RESERVED_EXPERIMENT_ATTRIBUTES = new Set([
   RATEL_EXPERIMENT_TURN,
   RATEL_EXPERIMENT_UNIT,
 ]);
-const RATEL_EVENT_ID = "ratel.event.id";
 
 /** @internal Identity shared by one runtime envelope and its OTel projection. */
 export interface RuntimeEventProjection {

--- a/src/sdk/ts/src/telemetry.ts
+++ b/src/sdk/ts/src/telemetry.ts
@@ -226,51 +226,68 @@ export function createExperimentTelemetrySink<Arm extends string>(): ExperimentE
       return startExperimentArm(evaluation);
     },
     comparison(evaluation, arm) {
-      arm?.event(RATEL_EXPERIMENT_COMPARISON, {
-        [RATEL_EXPERIMENT_SERVED_ARM]: evaluation.served.arm,
-        [RATEL_EXPERIMENT_SERVED_OUTCOME]: evaluation.served.outcome,
-        [RATEL_EXPERIMENT_SERVED_DURATION_MS]: evaluation.served.durationMs,
-        [RATEL_EXPERIMENT_SERVED_HIT_COUNT]: evaluation.served.hitCount,
-        [RATEL_EXPERIMENT_SHADOW_ARM]: evaluation.shadow.arm,
-        [RATEL_EXPERIMENT_SHADOW_OUTCOME]: evaluation.shadow.outcome,
-        [RATEL_EXPERIMENT_SHADOW_DURATION_MS]: evaluation.shadow.durationMs,
-        [RATEL_EXPERIMENT_SHADOW_HIT_COUNT]: evaluation.shadow.hitCount,
-        [RATEL_EXPERIMENT_AGREEMENT_TOP1]: evaluation.agreement.top1,
-        [RATEL_EXPERIMENT_AGREEMENT_EXACT_ORDER]: evaluation.agreement.exactOrder,
-        [RATEL_EXPERIMENT_AGREEMENT_OVERLAP_COUNT]: evaluation.agreement.overlapCount,
-        [RATEL_EXPERIMENT_AGREEMENT_JACCARD_AT_K]: evaluation.agreement.jaccardAtK,
-        [RATEL_EXPERIMENT_AGREEMENT_K]: evaluation.agreement.k,
-        ...(evaluation.agreement.itemAttrs === undefined
-          ? {}
-          : { [RATEL_EXPERIMENT_AGREEMENT_ITEM_ATTRS]: evaluation.agreement.itemAttrs }),
-        ...(evaluation.agreement.resultAttrs === undefined
-          ? {}
-          : { [RATEL_EXPERIMENT_AGREEMENT_RESULT_ATTRS]: evaluation.agreement.resultAttrs }),
-      });
+      arm?.event(
+        RATEL_EXPERIMENT_COMPARISON,
+        {
+          [RATEL_EXPERIMENT_SERVED_ARM]: evaluation.served.arm,
+          [RATEL_EXPERIMENT_SERVED_OUTCOME]: evaluation.served.outcome,
+          [RATEL_EXPERIMENT_SERVED_DURATION_MS]: evaluation.served.durationMs,
+          [RATEL_EXPERIMENT_SERVED_HIT_COUNT]: evaluation.served.hitCount,
+          [RATEL_EXPERIMENT_SHADOW_ARM]: evaluation.shadow.arm,
+          [RATEL_EXPERIMENT_SHADOW_OUTCOME]: evaluation.shadow.outcome,
+          [RATEL_EXPERIMENT_SHADOW_DURATION_MS]: evaluation.shadow.durationMs,
+          [RATEL_EXPERIMENT_SHADOW_HIT_COUNT]: evaluation.shadow.hitCount,
+          [RATEL_EXPERIMENT_AGREEMENT_TOP1]: evaluation.agreement.top1,
+          [RATEL_EXPERIMENT_AGREEMENT_EXACT_ORDER]: evaluation.agreement.exactOrder,
+          [RATEL_EXPERIMENT_AGREEMENT_OVERLAP_COUNT]: evaluation.agreement.overlapCount,
+          [RATEL_EXPERIMENT_AGREEMENT_JACCARD_AT_K]: evaluation.agreement.jaccardAtK,
+          [RATEL_EXPERIMENT_AGREEMENT_K]: evaluation.agreement.k,
+          ...(evaluation.agreement.itemAttrs === undefined
+            ? {}
+            : { [RATEL_EXPERIMENT_AGREEMENT_ITEM_ATTRS]: evaluation.agreement.itemAttrs }),
+          ...(evaluation.agreement.resultAttrs === undefined
+            ? {}
+            : { [RATEL_EXPERIMENT_AGREEMENT_RESULT_ATTRS]: evaluation.agreement.resultAttrs }),
+        },
+        evaluation.eventId,
+      );
     },
     skip(evaluation, arm) {
-      arm?.event(RATEL_EXPERIMENT_SKIP, {
-        [RATEL_EXPERIMENT_SKIP_ARM]: evaluation.skippedArm,
-        [RATEL_EXPERIMENT_SKIP_CONCURRENCY]: evaluation.concurrency,
-        [RATEL_EXPERIMENT_SKIP_REASON]: "capacity",
-      });
+      arm?.event(
+        RATEL_EXPERIMENT_SKIP,
+        {
+          [RATEL_EXPERIMENT_SKIP_ARM]: evaluation.skippedArm,
+          [RATEL_EXPERIMENT_SKIP_CONCURRENCY]: evaluation.concurrency,
+          [RATEL_EXPERIMENT_SKIP_REASON]: "capacity",
+        },
+        evaluation.eventId,
+      );
     },
     fallback(evaluation, arm) {
-      arm?.event(RATEL_EXPERIMENT_FALLBACK, {
-        [RATEL_EXPERIMENT_FALLBACK_EFFECTIVE_ARM]: evaluation.effectiveArm,
-        [RATEL_EXPERIMENT_FALLBACK_REUSED_SHADOW]: evaluation.reusedShadow,
-      });
+      arm?.event(
+        RATEL_EXPERIMENT_FALLBACK,
+        {
+          [RATEL_EXPERIMENT_FALLBACK_EFFECTIVE_ARM]: evaluation.effectiveArm,
+          [RATEL_EXPERIMENT_FALLBACK_REUSED_SHADOW]: evaluation.reusedShadow,
+        },
+        evaluation.eventId,
+      );
     },
     drop(evaluation, arm) {
-      arm?.event(RATEL_EXPERIMENT_DROP, {
-        [RATEL_EXPERIMENT_DROP_REASON]: evaluation.reason,
-      });
+      arm?.event(
+        RATEL_EXPERIMENT_DROP,
+        {
+          [RATEL_EXPERIMENT_DROP_REASON]: evaluation.reason,
+        },
+        evaluation.eventId,
+      );
     },
     invocation(evaluation) {
       const attribution = evaluation.attribution;
       getLogger().emit({
         eventName: RATEL_EXPERIMENT_INVOCATION,
         attributes: {
+          [RATEL_EVENT_ID]: evaluation.eventId ?? newRuntimeEventId(),
           [RATEL_EXPERIMENT_ID]: evaluation.experimentId,
           [RATEL_EXPERIMENT_UNIT]: evaluation.unitHash,
           [GEN_AI_TOOL_NAME]: evaluation.toolId,
@@ -292,6 +309,7 @@ export function createExperimentTelemetrySink<Arm extends string>(): ExperimentE
       getLogger().emit({
         eventName: RATEL_EXPERIMENT_OUTCOME,
         attributes: {
+          [RATEL_EVENT_ID]: evaluation.eventId ?? newRuntimeEventId(),
           [RATEL_EXPERIMENT_ID]: evaluation.experimentId,
           [RATEL_EXPERIMENT_SELECTION_ID]: evaluation.selectionId,
           ...(evaluation.label === undefined
@@ -333,6 +351,7 @@ function startExperimentArm<Arm extends string>(
       kind: SpanKind.INTERNAL,
       attributes: {
         ...attributes,
+        [RATEL_EVENT_ID]: evaluation.eventId ?? newRuntimeEventId(),
         [RATEL_EXPERIMENT_COLD]: evaluation.cold,
       },
     },
@@ -343,8 +362,8 @@ function startExperimentArm<Arm extends string>(
   return {
     run: (callback) => context.with(armContext, callback),
     complete: (completion) => completeExperimentArm(span, armContext, attributes, completion),
-    event: (eventName, eventAttributes) =>
-      addExperimentEvent(eventName, attributes, eventAttributes, armContext),
+    event: (eventName, eventAttributes, eventId) =>
+      addExperimentEvent(eventName, attributes, eventAttributes, armContext, eventId),
   };
 }
 
@@ -353,10 +372,15 @@ function addExperimentEvent(
   armAttributes: Record<string, string | number | boolean>,
   eventAttributes: Record<string, unknown>,
   armContext: OtelContext,
+  eventId?: string,
 ): void {
   getLogger().emit({
     eventName,
-    attributes: { ...armAttributes, ...eventAttributes } as AnyValueMap,
+    attributes: {
+      ...armAttributes,
+      ...eventAttributes,
+      [RATEL_EVENT_ID]: eventId ?? newRuntimeEventId(),
+    } as AnyValueMap,
     context: armContext,
   });
 }
@@ -407,6 +431,7 @@ function completeExperimentArm(
         attributes,
         armContext,
         itemAttributes?.eventValue,
+        completion.eventId,
       );
     }
   } finally {
@@ -419,12 +444,14 @@ function addExperimentResultsEvent(
   attributes: Record<string, string | number | boolean>,
   armContext: OtelContext,
   resultAttributes?: AnyValue,
+  eventId?: string,
 ): void {
   const scores = ranking.map((item) => item.score);
   getLogger().emit({
     eventName: RATEL_EXPERIMENT_RESULTS,
     attributes: {
       ...attributes,
+      [RATEL_EVENT_ID]: eventId ?? newRuntimeEventId(),
       [RATEL_EXPERIMENT_RESULT_IDS]: ranking.map((item) => item.id),
       ...(scores.every(
         (score): score is number => typeof score === "number" && Number.isFinite(score),
@@ -789,16 +816,20 @@ export function traceSkillLoad<T>(
 export function traceUpstreamRegister<T>(
   server: string,
   transport: string,
-  run: (reportToolCount: (n: number) => void) => Promise<T>,
+  run: (reportToolCount: (n: number) => void, projection: RuntimeEventProjection) => Promise<T>,
 ): Promise<T> {
   return getTracer().startActiveSpan(
     RATEL_UPSTREAM_REGISTER,
     { kind: SpanKind.INTERNAL },
     async (span) => {
+      const projection = eventProjection(span);
       span.setAttribute(RATEL_UPSTREAM_SERVER, server);
       span.setAttribute(RATEL_UPSTREAM_TRANSPORT, transport);
       try {
-        const result = await run((n) => span.setAttribute(RATEL_UPSTREAM_TOOL_COUNT, n));
+        const result = await run(
+          (n) => span.setAttribute(RATEL_UPSTREAM_TOOL_COUNT, n),
+          projection,
+        );
         span.setStatus({ code: SpanStatusCode.OK });
         return result;
       } catch (err) {
@@ -815,11 +846,13 @@ export function traceUpstreamRegister<T>(
  * Mark an upstream tool call that failed with a 401 / needs-reauthorization: a
  * short `ratel.auth.flow` span carrying `ratel.auth.outcome = needs_auth`.
  */
-export function recordAuthNeeded(server?: string): void {
+export function recordAuthNeeded(server?: string): RuntimeEventProjection {
   const span = getTracer().startSpan(RATEL_AUTH_FLOW, { kind: SpanKind.INTERNAL });
+  const projection = eventProjection(span);
   if (server) span.setAttribute(RATEL_UPSTREAM_SERVER, server);
   span.setAttribute(RATEL_AUTH_OUTCOME, AuthOutcome.NeedsAuth);
   span.end();
+  return projection;
 }
 
 // Re-exported so hosts configuring capture don't need a second import from

--- a/src/sdk/ts/src/telemetry.ts
+++ b/src/sdk/ts/src/telemetry.ts
@@ -119,6 +119,7 @@ import type {
   ExperimentEvaluationSink,
 } from "./experiment-sink.js";
 import type { ExperimentRankedItem } from "./experiment-types.js";
+import { newRuntimeEventId } from "./runtime-events.js";
 
 const TRACER_NAME = "@ratel-ai/sdk";
 const LOGGER_NAME = "@ratel-ai/sdk";
@@ -170,6 +171,28 @@ const RESERVED_EXPERIMENT_ATTRIBUTES = new Set([
   RATEL_EXPERIMENT_TURN,
   RATEL_EXPERIMENT_UNIT,
 ]);
+const RATEL_EVENT_ID = "ratel.event.id";
+
+/** @internal Identity shared by one runtime envelope and its OTel projection. */
+export interface RuntimeEventProjection {
+  eventId: string;
+  invocationId?: string;
+  traceId?: string;
+  spanId?: string;
+}
+
+function eventProjection(span: Span, invocationId?: string): RuntimeEventProjection {
+  const eventId = newRuntimeEventId();
+  const spanContext = span.spanContext();
+  span.setAttribute(RATEL_EVENT_ID, eventId);
+  return {
+    eventId,
+    ...(invocationId === undefined ? {} : { invocationId }),
+    ...(spanContext.isRemote || /^0+$/.test(spanContext.traceId)
+      ? {}
+      : { traceId: spanContext.traceId, spanId: spanContext.spanId }),
+  };
+}
 
 function getTracer() {
   return trace.getTracer(TRACER_NAME);
@@ -477,11 +500,13 @@ function addToolContentEvent(
   toolId: string,
   args: unknown,
   eventContext: OtelContext,
+  eventId: string,
   result?: { value: unknown },
 ): void {
   const attributes = {
     [GEN_AI_OPERATION_NAME]: EXECUTE_TOOL,
     [GEN_AI_TOOL_NAME]: toolId,
+    [RATEL_EVENT_ID]: eventId,
     [GEN_AI_TOOL_CALL_ARGUMENTS]: toLogValue(args),
     ...(result ? { [GEN_AI_TOOL_CALL_RESULT]: toLogValue(result.value) } : {}),
   };
@@ -496,10 +521,10 @@ function addToolContentEvent(
  * Emit the Opt-In `ratel.search.results` EventRecord carrying the search text.
  * Hit ids/scores/BM25 timing are local-stream only.
  */
-function addSearchResultsEvent(query: string, eventContext: OtelContext): void {
+function addSearchResultsEvent(query: string, eventContext: OtelContext, eventId: string): void {
   getLogger().emit({
     eventName: RATEL_SEARCH_RESULTS,
-    attributes: { [RATEL_SEARCH_QUERY]: query },
+    attributes: { [RATEL_SEARCH_QUERY]: query, [RATEL_EVENT_ID]: eventId },
     context: eventContext,
   });
 }
@@ -554,12 +579,17 @@ function fail(span: Span, err: unknown): void {
  * (ADR-0007). Preserves the executor's immediate return shape and keeps the
  * span open through `AsyncIterable` completion, cancellation, or failure.
  */
-export function traceExecuteTool<T>(toolId: string, args: unknown, run: () => T): T {
+export function traceExecuteTool<T>(
+  toolId: string,
+  args: unknown,
+  run: (projection: RuntimeEventProjection) => T,
+): T {
   return getTracer().startActiveSpan(
     `${EXECUTE_TOOL} ${toolId}`,
     { kind: SpanKind.INTERNAL },
     (span) => {
       const activeContext = trace.setSpan(context.active(), span);
+      const projection = eventProjection(span, newRuntimeEventId());
       span.setAttribute(GEN_AI_OPERATION_NAME, EXECUTE_TOOL);
       span.setAttribute(GEN_AI_TOOL_NAME, toolId);
       const upstream = upstreamFromToolId(toolId);
@@ -570,19 +600,21 @@ export function traceExecuteTool<T>(toolId: string, args: unknown, run: () => T)
       const succeed = (result: unknown): void => {
         if (captureContentOnSpan()) span.setAttribute(GEN_AI_TOOL_CALL_RESULT, safeJson(result));
         if (captureContentOnEvent()) {
-          addToolContentEvent(toolId, args, activeContext, { value: result });
+          addToolContentEvent(toolId, args, activeContext, projection.eventId, { value: result });
         }
         span.setStatus({ code: SpanStatusCode.OK });
         span.end();
       };
       const reject = (err: unknown): void => {
-        if (captureContentOnEvent()) addToolContentEvent(toolId, args, activeContext);
+        if (captureContentOnEvent()) {
+          addToolContentEvent(toolId, args, activeContext, projection.eventId);
+        }
         fail(span, err);
         span.end();
       };
 
       try {
-        return observeExecutionResult(run(), succeed, reject, activeContext) as T;
+        return observeExecutionResult(run(projection), succeed, reject, activeContext) as T;
       } catch (err) {
         reject(err);
         throw err;
@@ -674,18 +706,19 @@ export function traceSearch<T extends { length: number }>(
   query: string,
   topK: number,
   origin: SearchOrigin,
-  run: () => T,
+  run: (projection: RuntimeEventProjection) => T,
 ): T {
   return getTracer().startActiveSpan(RATEL_SEARCH, { kind: SpanKind.INTERNAL }, (span) => {
     const eventContext = trace.setSpan(context.active(), span);
+    const projection = eventProjection(span);
     span.setAttribute(RATEL_SEARCH_TARGET, target);
     span.setAttribute(RATEL_SEARCH_TOP_K, topK);
     span.setAttribute(RATEL_ORIGIN, origin);
     if (captureContentOnSpan()) span.setAttribute(RATEL_SEARCH_QUERY, query);
     try {
-      const hits = run();
+      const hits = run(projection);
       span.setAttribute(RATEL_SEARCH_HIT_COUNT, hits.length);
-      if (captureContentOnEvent()) addSearchResultsEvent(query, eventContext);
+      if (captureContentOnEvent()) addSearchResultsEvent(query, eventContext, projection.eventId);
       span.setStatus({ code: SpanStatusCode.OK });
       return hits;
     } catch (err) {
@@ -703,18 +736,19 @@ export function traceSearchAsync<T extends { length: number }>(
   query: string,
   topK: number,
   origin: SearchOrigin,
-  run: () => Promise<T>,
+  run: (projection: RuntimeEventProjection) => Promise<T>,
 ): Promise<T> {
   return getTracer().startActiveSpan(RATEL_SEARCH, { kind: SpanKind.INTERNAL }, async (span) => {
     const eventContext = trace.setSpan(context.active(), span);
+    const projection = eventProjection(span);
     span.setAttribute(RATEL_SEARCH_TARGET, target);
     span.setAttribute(RATEL_SEARCH_TOP_K, topK);
     span.setAttribute(RATEL_ORIGIN, origin);
     if (captureContentOnSpan()) span.setAttribute(RATEL_SEARCH_QUERY, query);
     try {
-      const hits = await run();
+      const hits = await run(projection);
       span.setAttribute(RATEL_SEARCH_HIT_COUNT, hits.length);
-      if (captureContentOnEvent()) addSearchResultsEvent(query, eventContext);
+      if (captureContentOnEvent()) addSearchResultsEvent(query, eventContext, projection.eventId);
       span.setStatus({ code: SpanStatusCode.OK });
       return hits;
     } catch (err) {
@@ -727,11 +761,15 @@ export function traceSearchAsync<T extends { length: number }>(
 }
 
 /** Wrap a skill-content load in a `ratel.skill.load` span. */
-export function traceSkillLoad<T>(skillId: string, run: () => T): T {
+export function traceSkillLoad<T>(
+  skillId: string,
+  run: (projection: RuntimeEventProjection) => T,
+): T {
   return getTracer().startActiveSpan(RATEL_SKILL_LOAD, { kind: SpanKind.INTERNAL }, (span) => {
+    const projection = eventProjection(span);
     span.setAttribute(RATEL_SKILL_ID, skillId);
     try {
-      const body = run();
+      const body = run(projection);
       span.setStatus({ code: SpanStatusCode.OK });
       return body;
     } catch (err) {

--- a/src/telemetry/CONVENTIONS.md
+++ b/src/telemetry/CONVENTIONS.md
@@ -10,12 +10,12 @@ dashboards, a self-hosted receiver) reads against; the per-language helpers unde
 Decision of record: [ADR-0007, Telemetry: core-owned local trace stream, OTel remote conventions](../../docs/adr/0007-telemetry-two-streams.md).
 This spec is the concrete mapping that ADR locks; it does not re-decide anything the ADR decided.
 
-[ADR-0019, Runtime events lane](../../docs/adr/0019-runtime-events-lane.md) defines the
+[ADR-0020, Runtime events lane](../../docs/adr/0020-runtime-events-lane.md) defines the
 parallel subscribable facts contract. OTel stays independently emitted; the shared
 `ratel.event.id` below is their deduplication and join key.
 
 Scope is the **OTel projection** only. The runtime event wire and its local JSONL/direct
-delivery paths are specified by ADR-0019 and are not restated here. Runtime events and OTel
+delivery paths are specified by ADR-0020 and are not restated here. Runtime events and OTel
 remain parallel projections on purpose.
 
 ## The pin

--- a/src/telemetry/CONVENTIONS.md
+++ b/src/telemetry/CONVENTIONS.md
@@ -10,9 +10,13 @@ dashboards, a self-hosted receiver) reads against; the per-language helpers unde
 Decision of record: [ADR-0007, Telemetry: core-owned local trace stream, OTel remote conventions](../../docs/adr/0007-telemetry-two-streams.md).
 This spec is the concrete mapping that ADR locks; it does not re-decide anything the ADR decided.
 
-Scope is the **remote** stream only. The local JSONL trace stream (ADR-0007: `src/core/src/trace/`,
-consumed by the statusline / savings report) is untouched and is **not** part of
-this contract. Local and remote are two streams on purpose.
+[ADR-0019, Runtime events lane](../../docs/adr/0019-runtime-events-lane.md) defines the
+parallel subscribable facts contract. OTel stays independently emitted; the shared
+`ratel.event.id` below is their deduplication and join key.
+
+Scope is the **OTel projection** only. The runtime event wire and its local JSONL/direct
+delivery paths are specified by ADR-0019 and are not restated here. Runtime events and OTel
+remain parallel projections on purpose.
 
 ## The pin
 
@@ -45,6 +49,16 @@ same active host span land in one trace, told apart by namespace and joined on t
 
 `ratel.*` follows ADR-0007's schema discipline: **adding** a span or attribute is non-breaking; **renaming or
 removing** one is breaking and needs a superseding note.
+
+### Runtime-event correlation
+
+| Attribute | Type | On | Contract |
+|---|---|---|---|
+| `ratel.event.id` | string | every Ratel-owned span or Logs EventRecord that projects a runtime event | Exact client ULID from the runtime envelope's `event_id`; minted once and reused across both projections, batching, and retries. |
+
+`ratel.event.id` is not a trace id or invocation id. It identifies one runtime event. A logical
+invocation may produce several events with distinct event ids joined by the envelope's
+`invocation_id`; `trace_id` / `span_id` provide optional observability correlation.
 
 ---
 

--- a/src/telemetry/conformance/fixtures.json
+++ b/src/telemetry/conformance/fixtures.json
@@ -6,6 +6,7 @@
     "max_payload_bytes": 65536,
     "max_query_bytes": 4096,
     "max_hits": 100,
+    "otel_event_id_attribute": "ratel.event.id",
     "required_envelope_fields": ["v", "event_id", "ts", "session_id", "source_id", "type"],
     "event_types": [
       "search",

--- a/src/telemetry/conformance/fixtures.json
+++ b/src/telemetry/conformance/fixtures.json
@@ -1,6 +1,42 @@
 {
   "semconv_version": "1.42.0",
   "description": "Contract-against-the-pin fixtures shared across the language helpers. Each fixture names a scenario, the span to open, span attributes to set, optional OpenTelemetry EventRecords to emit through the Logs API with structured attributes, and the exact wire output required by CONVENTIONS.md.",
+  "runtime_events": {
+    "version": 2,
+    "max_payload_bytes": 65536,
+    "max_query_bytes": 4096,
+    "max_hits": 100,
+    "required_envelope_fields": ["v", "event_id", "ts", "session_id", "source_id", "type"],
+    "event_types": [
+      "search",
+      "skill_search",
+      "gateway_search",
+      "invoke_start",
+      "invoke_end",
+      "invoke_error",
+      "gateway_invoke",
+      "gateway_error",
+      "skill_invoke",
+      "index_churn",
+      "skill_churn",
+      "upstream_register",
+      "upstream_invoke",
+      "upstream_error",
+      "auth_refresh",
+      "auth_needs",
+      "auth_flow_start",
+      "auth_flow_end",
+      "experiment_selection",
+      "experiment_results",
+      "experiment_comparison",
+      "experiment_skip",
+      "experiment_fallback",
+      "experiment_drop",
+      "experiment_invocation",
+      "experiment_outcome",
+      "events_dropped"
+    ]
+  },
   "fixtures": [
     {
       "name": "tool invocation rides an execute_tool span enriched with ratel.*",

--- a/src/telemetry/core/src/lib.rs
+++ b/src/telemetry/core/src/lib.rs
@@ -65,6 +65,8 @@ pub const GEN_AI_INFERENCE_DETAILS: &str = "gen_ai.client.inference.operation.de
 // `ratel.*` attribute keys (CONVENTIONS.md, Tier 2)
 // ---------------------------------------------------------------------------
 
+/// `ratel.event.id` — runtime-event/OTel deduplication and join key.
+pub const RATEL_EVENT_ID: &str = "ratel.event.id";
 /// `ratel.origin` — direct library call vs agent-synthesized (shared attribute).
 pub const RATEL_ORIGIN: &str = "ratel.origin";
 /// `ratel.search.target` — `tool`, `skill`, or `fact` (see [`SearchTarget`]).
@@ -444,6 +446,7 @@ mod tests {
 
     #[test]
     fn ratel_attribute_keys_match_the_pin() {
+        assert_eq!(RATEL_EVENT_ID, "ratel.event.id");
         assert_eq!(RATEL_ORIGIN, "ratel.origin");
         assert_eq!(RATEL_SEARCH_TARGET, "ratel.search.target");
         assert_eq!(RATEL_SEARCH_TOP_K, "ratel.search.top_k");

--- a/src/telemetry/python/ratel_ai_telemetry/__init__.py
+++ b/src/telemetry/python/ratel_ai_telemetry/__init__.py
@@ -86,6 +86,9 @@ GEN_AI_INFERENCE_DETAILS: Final = "gen_ai.client.inference.operation.details"
 #: ratel.origin — direct library call vs agent-synthesized (shared attribute).
 RATEL_ORIGIN: Final = "ratel.origin"
 
+#: ratel.event.id — runtime-event/OTel deduplication and join key.
+RATEL_EVENT_ID: Final = "ratel.event.id"
+
 #: ratel.search.target — "tool", "skill", or "fact" (see SearchTarget).
 RATEL_SEARCH_TARGET: Final = "ratel.search.target"
 

--- a/src/telemetry/python/tests/test_constants.py
+++ b/src/telemetry/python/tests/test_constants.py
@@ -14,6 +14,7 @@ from ratel_ai_telemetry import (
     GEN_AI_TOOL_NAME,
     RATEL_AUTH_FLOW,
     RATEL_AUTH_OUTCOME,
+    RATEL_EVENT_ID,
     RATEL_EXPERIMENT_AGREEMENT_EXACT_ORDER,
     RATEL_EXPERIMENT_AGREEMENT_ITEM_ATTRS,
     RATEL_EXPERIMENT_AGREEMENT_JACCARD_AT_K,
@@ -108,6 +109,10 @@ def test_names_the_ratel_spans_per_the_pin() -> None:
     assert RATEL_SKILL_LOAD == "ratel.skill.load"
     assert RATEL_UPSTREAM_REGISTER == "ratel.upstream.register"
     assert RATEL_AUTH_FLOW == "ratel.auth.flow"
+
+
+def test_names_the_runtime_event_join_key() -> None:
+    assert RATEL_EVENT_ID == "ratel.event.id"
 
 
 def test_names_the_event_records_per_the_pin() -> None:

--- a/src/telemetry/ts/src/index.ts
+++ b/src/telemetry/ts/src/index.ts
@@ -106,6 +106,9 @@ export const GEN_AI_INFERENCE_DETAILS = "gen_ai.client.inference.operation.detai
 /** `ratel.origin` — direct library call vs agent-synthesized (shared attribute). */
 export const RATEL_ORIGIN = "ratel.origin";
 
+/** `ratel.event.id` — runtime-event/OTel deduplication and join key. */
+export const RATEL_EVENT_ID = "ratel.event.id";
+
 /** `ratel.search.target` — `tool`, `skill`, or `fact` (see {@link SearchTarget}). */
 export const RATEL_SEARCH_TARGET = "ratel.search.target";
 


### PR DESCRIPTION
## Goal

Give the Ratel SDK a first-class, subscribable runtime-events stream — Rust core plus TS and Python seams — with stable IDs shared with the OTel projection, so `@ratel-ai/cloud-sdk` can attach as a consumer and Ratel Cloud stops depending on OTel sampling/content-capture for product facts. OTel emission stays unchanged (parallel projection, never rebased on the stream).

Plan: [Runtime events lane — Multi-Phase Plan](https://app.kestral.ai/workspace/10V6J6nL/documents/1IEI1bL0) · Effort task: [RS-79](https://app.kestral.ai/workspace/10V6J6nL/task/1IENAQuT)

## Phases (all merged; per-phase verify + effort verify green at each merge)

1. **ADR: runtime-events lane** + amend ADR-0007/0003/0014, CONVENTIONS.md `ratel.event.id` — [RS-80](https://app.kestral.ai/workspace/10V6J6nL/task/1IEQQV0e) · `694409e4`
2. **Envelope v2 stable IDs + fan-out sink** (`event_id`/`invocation_id`/`source_id`, bounded queues, drop-oldest, `events_dropped`) — [RS-81](https://app.kestral.ai/workspace/10V6J6nL/task/1IERL63v) · `f3b11514`
3. **FFI push bridge** — napi ThreadsafeFunction (TS) + pyo3 callback sink (Python), batched off-hot-path — [RS-82](https://app.kestral.ai/workspace/10V6J6nL/task/1IESDCyQ) · `2beba041`
4. **TS SDK: `events.subscribe` + `catalog.snapshot`**, `ratel.event.id` stamped on OTel projection, composite experiment sink, conformance fixtures — [RS-83](https://app.kestral.ai/workspace/10V6J6nL/task/1IET6c5i) · `d8dd3d5e`
5. **Python SDK mirror** — same subscribe/snapshot seam, `call_soon_threadsafe` marshaling — [RS-84](https://app.kestral.ai/workspace/10V6J6nL/task/1IETxXLU) · `fb11a25b`

## Progress digest

- Integration branch cut from `main` @ `e7d2933a`; 5 lane branches merged serially, effort verify (`cargo test --workspace && pnpm --filter @ratel-ai/sdk test`) green at each merge.
- Phase 5 merge initially reported a semantic-conflict false alarm (fresh integration venv lacked mypy); env fixed, typing tests pass, merge intact.
- Loop run id: `loop-runtime-events-sdk-2026-08-13-171939` (5 phases, 0 HIL pauses).
