### PR TITLE
ci: adapter sdk peer range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
               - '.github/workflows/ci.yml'
+              - '.github/workflows/release.yml'
             # maturin builds the Python native binding from the Rust core; the SDK job
             # also installs the telemetry sibling and exercises the pydantic-ai example.
             python:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -572,21 +572,15 @@ jobs:
       - name: Build TS
         run: pnpm --filter "@ratel-ai/mastra..." run build
       # npm keeps `workspace:` specifiers verbatim, so pin the @ratel-ai/sdk peer AND
-      # dev deps to the concrete co-released version before publishing (ephemeral CI
+      # dev deps to the ADR-0020 floor range before publishing (ephemeral CI
       # edit; not committed). Keeps the npm-OIDC dir publish + provenance identical to
       # the other units rather than switching to `pnpm publish`.
       - name: Pin the @ratel-ai/sdk peer and dev dependencies for publish
         shell: bash
         run: |
           set -e
-          sdk_ver=$(node -p "require('./src/sdk/ts/package.json').version")
-          SDK_VER="$sdk_ver" node -e "const fs=require('fs'); const f='./src/adapters/ts-mastra/package.json'; const p=require(f); const v='^'+process.env.SDK_VER; p.peerDependencies['@ratel-ai/sdk']=v; p.devDependencies['@ratel-ai/sdk']=v; fs.writeFileSync(f, JSON.stringify(p, null, 2) + '\n')"
+          node scripts/pin-adapter-sdk-peer.mjs ./src/adapters/ts-mastra/package.json
           echo "pinned @ratel-ai/sdk -> $(node -p "const p=require('./src/adapters/ts-mastra/package.json'); p.peerDependencies['@ratel-ai/sdk'] + ' (peer), ' + p.devDependencies['@ratel-ai/sdk'] + ' (dev)'")"
-          # npm installs peers automatically, so a range the registry can't satisfy is an
-          # ETARGET for every consumer rather than a warning. Same check as the
-          # vercel-ai-sdk job: publish sdk-ts first or fail before the immutable publish.
-          npm view "@ratel-ai/sdk@^${sdk_ver}" version >/dev/null 2>&1 \
-            || { echo "::error::@ratel-ai/sdk@^${sdk_ver} is not on npm — publish sdk-ts before mastra"; exit 1; }
       # Pin the new @ratel-ai/telemetry runtime dependency too. npm publishes a
       # directory's literal `workspace:^`, so leaving it unchanged would make
       # every registry install fail even though the local dry-run succeeds.
@@ -660,21 +654,15 @@ jobs:
       - name: Build TS
         run: pnpm --filter "@ratel-ai/vercel-ai-sdk..." run build
       # npm keeps `workspace:` specifiers verbatim, so pin the @ratel-ai/sdk peer AND
-      # dev deps to the concrete co-released version before publishing (ephemeral CI
+      # dev deps to the ADR-0020 floor range before publishing (ephemeral CI
       # edit; not committed). Keeps the npm-OIDC dir publish + provenance identical to
       # the other units rather than switching to `pnpm publish`.
       - name: Pin the @ratel-ai/sdk peer and dev dependencies for publish
         shell: bash
         run: |
           set -e
-          sdk_ver=$(node -p "require('./src/sdk/ts/package.json').version")
-          SDK_VER="$sdk_ver" node -e "const fs=require('fs'); const f='./src/adapters/ts-vercel-ai-sdk/package.json'; const p=require(f); const v='^'+process.env.SDK_VER; p.peerDependencies['@ratel-ai/sdk']=v; p.devDependencies['@ratel-ai/sdk']=v; fs.writeFileSync(f, JSON.stringify(p, null, 2) + '\n')"
+          node scripts/pin-adapter-sdk-peer.mjs ./src/adapters/ts-vercel-ai-sdk/package.json
           echo "pinned @ratel-ai/sdk -> $(node -p "const p=require('./src/adapters/ts-vercel-ai-sdk/package.json'); p.peerDependencies['@ratel-ai/sdk'] + ' (peer), ' + p.devDependencies['@ratel-ai/sdk'] + ' (dev)'")"
-          # A peer is not the soft constraint it used to be: npm installs peers
-          # automatically, so a range the registry can't satisfy is an ETARGET for
-          # every consumer, not a warning. Same immutability, same release ordering.
-          npm view "@ratel-ai/sdk@^${sdk_ver}" version >/dev/null 2>&1 \
-            || { echo "::error::@ratel-ai/sdk@^${sdk_ver} is not on npm — publish sdk-ts before vercel-ai-sdk"; exit 1; }
       # Same treatment for the @ratel-ai/telemetry *runtime* dep: left alone, npm ships
       # the literal `workspace:^`, which no consumer can resolve — the adapter is then
       # uninstallable, not merely mis-ranged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Independently-versioned units publish from this repo (ADR-0008): `ratel-ai-core`
 
 Two rules the unit list doesn't show:
 
-- **Publish in dependency order.** `@ratel-ai/telemetry` before `@ratel-ai/sdk`, and `@ratel-ai/sdk` before either adapter. `workspace:^` specifiers are rewritten to a concrete `^X.Y.Z` at pack time, so a tag cut out of order publishes an immutable version whose dependency is not on the registry yet. The publish jobs check the pinned range against npm and fail before publishing rather than after.
+- **Publish in dependency order.** `@ratel-ai/telemetry` before `@ratel-ai/sdk`, and `@ratel-ai/sdk` before either adapter. Adapter `@ratel-ai/sdk` peers are rewritten at pack time to the floor range in [ADR-0020](docs/adr/0020-adapter-sdk-peer-floor.md), not `^X.Y.Z`. Telemetry runtime deps still become `^X.Y.Z` of the in-repo telemetry version, so a tag cut before `telemetry-ts` publishes an immutable version whose telemetry dependency is not on the registry yet. The adapter publish jobs check that telemetry pin against npm and fail before publishing rather than after.
 - **At 0.x, a breaking change takes a MINOR bump** (`0.4.1` → `0.5.0`), never a major and never a patch. Removing or narrowing a public surface is what makes a change breaking; adding to it is not, however large the addition.
 
 To cut a release — one unit at a time; see [RELEASING.md](RELEASING.md) for the full flow:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -46,12 +46,13 @@ locally (no prebuilt artifacts).
 
 The **framework adapters** (`vercel-ai-sdk` → `@ratel-ai/vercel-ai-sdk`, `mastra` →
 `@ratel-ai/mastra`; more to come) are npm-only, pure-language units that peer-depend on
-`@ratel-ai/sdk` via `workspace:^`. `vercel-ai-sdk` additionally depends on
+`@ratel-ai/sdk` via `workspace:^` (rewritten at publish to the
+[ADR-0020](docs/adr/0020-adapter-sdk-peer-floor.md) floor range). Both additionally depend on
 `@ratel-ai/telemetry` at publish time — a real runtime `dependencies` entry, not a peer, so
-`telemetry-ts` must be released **before** it or the adapter's pinned range names a version
-that is not on npm yet. `mastra` has no such dependency. Like `telemetry-ts`, the manual
-helper builds them locally, then `pnpm pack`s them (the pack rewrites every `workspace:`
-specifier, peer and runtime alike, to a concrete range); they need no prebuilt artifact.
+`telemetry-ts` must be released **before** either adapter or the pinned telemetry range names
+a version that is not on npm yet. Like `telemetry-ts`, the manual helper builds them locally,
+pins the SDK peer, then `pnpm pack`s them (the pack rewrites the remaining `workspace:`
+specifiers); they need no prebuilt artifact.
 
 `@ratel-ai/mcp-server` ships from a sibling repo, [ratel-ai/ratel-mcp](https://github.com/ratel-ai/ratel-mcp), on its own cadence.
 
@@ -166,9 +167,11 @@ payload without applying. Run the E2E locally per `e2e/README.md`.
 ### Publish order
 
 Units version independently but do **not** publish independently when they depend on each
-other. `workspace:^` is rewritten to a concrete `^X.Y.Z` at pack time from whatever the
-workspace manifest says, so a tag cut out of order ships an immutable version pointing at a
-version that is not on the registry:
+other. Adapter `@ratel-ai/sdk` peers are rewritten to the
+[ADR-0020](docs/adr/0020-adapter-sdk-peer-floor.md) floor range, which does not name the
+in-repo SDK version. Telemetry `workspace:^` is still rewritten to `^X.Y.Z` of the workspace
+telemetry manifest, so a tag cut before `telemetry-ts` ships an immutable version pointing at
+a version that is not on the registry:
 
 ```
 telemetry-ts  →  sdk-ts  →  vercel-ai-sdk, mastra
@@ -176,11 +179,22 @@ telemetry-py  →  sdk-py
 telemetry-core, core                                   (independent)
 ```
 
-Wait for each publish to land on its registry before tagging the next. `publish-sdk-ts`,
-`publish-mastra`, and `publish-vercel-ai-sdk` each verify their pinned range resolves on npm
-and fail the job *before* publishing. Nothing else catches this: the preflight
+Wait for each publish to land on its registry before tagging the next. `publish-sdk-ts`
+verifies its telemetry pin resolves on npm; `publish-mastra` and `publish-vercel-ai-sdk`
+verify their **telemetry** pin (the SDK peer is the ADR-0020 floor range and no longer names
+the in-repo SDK version). Nothing else catches a missing telemetry: the preflight
 `npm publish --dry-run` packs locally without contacting the registry, `tag-version-check`
 only inspects the tagged unit, and `verify-install` runs after an immutable publish.
+
+When cutting an adapter release, set `SDK_ADAPTER_PEER_FLOOR` to the SDK version the adapters
+are built against. Never lower it — the floor is a support commitment, true by construction
+only if it matches what the adapters build against. The mechanism is 0.x-only: when the SDK
+reaches 1.0.0, delete it rather than carrying the floor forward (ADR-0020).
+
+After an adapter **GA** publish, move the npm `rc` dist-tag onto that GA version
+(`npm dist-tag add @ratel-ai/vercel-ai-sdk@<ga> rc`, same for mastra) so `@rc` does not keep
+serving a stale prerelease whose SDK peer is the old caret. OIDC does not cover `dist-tag`;
+this is a manual post-publish step (ADR-0020).
 
 On PyPI the constraint is stricter. `ratel-ai` floors `ratel-ai-telemetry>=0.1.3`, and under
 PEP 440 `>=0.1.3` does **not** admit `0.1.3rc1`, even with `--pre`. An RC of `sdk-py`

--- a/docs/adr/0008-release-engineering.md
+++ b/docs/adr/0008-release-engineering.md
@@ -13,6 +13,9 @@ ADR-0016 (per-package versions and releases, 2026-07-04), and ADR-0018 (defer th
 Amended 2026-07-26 to drop the `telemetry-ts-otlp` unit with the `@ratel-ai/telemetry-otlp`
 package, to record the `mastra` adapter unit, and to generalize the cross-unit publish order
 (it binds `sdk-ts` too, not only the adapters) with its PyPI pre-release caveat.
+Amended 2026-08-14 to record that adapter SDK peers publish as the ADR-0020 floor range
+(not `^<in-repo SDK>`), that both adapters runtime-depend on telemetry, and that only the
+telemetry pin still has an npm-view publish-order guard.
 
 ## Context
 
@@ -57,18 +60,21 @@ automatically, so a range naming a version the registry does not have is an `ETA
 install time and not a warning — for a runtime dependency and a peer alike. npm versions are
 immutable, so publishing out of order ships a permanently uninstallable release. The order is
 `telemetry-ts` → `sdk-ts` → {`vercel-ai-sdk`, `mastra`}: `sdk-ts` takes `@ratel-ai/telemetry`
-as a runtime dependency, and both adapters peer on `@ratel-ai/sdk` (`vercel-ai-sdk` also
-depends on `@ratel-ai/telemetry` at runtime). Each of the three dependent publish jobs
-verifies its pinned range resolves on npm and fails before publishing; nothing downstream
-catches it, since the preflight `npm publish --dry-run` packs locally, `tag-version-check`
-inspects only the tagged unit, and `verify-install` runs after the publish is already
-immutable. PyPI adds a stricter case: `ratel-ai` floors `ratel-ai-telemetry>=0.1.3`, and under
+as a runtime dependency, and both adapters peer on `@ratel-ai/sdk` **and** depend on
+`@ratel-ai/telemetry` at runtime. Adapter SDK peers are rewritten to the floor range in
+[ADR-0020](0020-adapter-sdk-peer-floor.md), which does **not** name the
+in-repo SDK version — there is no SDK `npm view` on the adapter publish jobs. Telemetry pins
+stay `'^' +` the in-repo telemetry version; those jobs still `npm view` the pinned telemetry
+range and fail before publishing. Nothing downstream catches a missing telemetry: the
+preflight `npm publish --dry-run` packs locally, `tag-version-check` inspects only the tagged
+unit, and `verify-install` runs after the publish is already immutable. PyPI adds a stricter
+case: `ratel-ai` floors `ratel-ai-telemetry>=0.1.3`, and under
 PEP 440 that does not admit `0.1.3rc1` even with `--pre`, so an RC of `sdk-py` requires
 telemetry-py at GA rather than at a matching RC.
 
 The `vercel-ai-sdk` framework adapter is an independent, pure-TypeScript unit. Its release
-changes only the adapter version, while both workspace specifiers are replaced with the
-compatible published ranges.
+changes only the adapter version, while the SDK peer is rewritten to the ADR-0020 floor range
+and the telemetry runtime dep is rewritten to `'^' +` the in-repo telemetry version.
 It publishes over OIDC from `release.yml`'s `publish-vercel-ai-sdk` job. That job publishes the
 package directory, not a `pnpm pack` tarball, so the substitution is explicit pin steps in the
 job rather than something the pack step does for free. Only the first publish went through

--- a/docs/adr/0020-adapter-sdk-peer-floor.md
+++ b/docs/adr/0020-adapter-sdk-peer-floor.md
@@ -1,0 +1,62 @@
+# 20. Adapter `@ratel-ai/sdk` peer is a 0.x floor range, not a caret of the current minor
+
+Date: 2026-08-14
+
+## Status
+
+Accepted
+
+Builds on [ADR-0008](0008-release-engineering.md) and [ADR-0013](0013-framework-adapter-spi.md).
+
+## Context
+
+`@ratel-ai/vercel-ai-sdk` and `@ratel-ai/mastra` declare `@ratel-ai/sdk` as `workspace:^` in
+source. At publish, `release.yml` used to rewrite that to `'^' + <in-repo SDK version>`. On
+`0.x`, a caret pins the **minor**: `^0.6.0` means `>=0.6.0 <0.7.0`. Every SDK minor therefore
+orphaned both adapters until they were re-released (`ERESOLVE`).
+
+The floor must match current adapter source. A one-off measurement against
+`vercel-ai-sdk@0.4.0-rc.2` / `mastra@0.3.0-rc.1` found vercel shipped code (`src/aisdk.ts`)
+needs `ExperimentalPassthroughToolExposure` / `experimentalExposePassthrough`, first exported
+in SDK 0.9.1 (94/94 tests). Mastra passed 52/52 on 0.9.1; its shipped code still compiles at
+0.6.0. Publishing `>=0.6.0` would be a false compatibility claim: npm would resolve, then
+vercel would fail on a missing export.
+
+## Decision
+
+**Publish the adapter SDK peer as a floor range, never a caret** — a lower bound that moves
+with each adapter release, and a `<1.0.0` upper bound that does not.
+
+| Half | Where it lives | Does it change? |
+|---|---|---|
+| floor | `SDK_ADAPTER_PEER_FLOOR` in `scripts/release-units.mjs` | **Yes** — bump it to the SDK the adapters are built against when cutting an adapter release. Never lower it. |
+| ceiling | literal `<1.0.0`, same file | **No** — this mechanism is 0.x-only and is deleted at SDK 1.0.0 rather than raised. |
+
+As of this ADR's date that resolves to `>=0.9.1 <1.0.0`. **Every concrete range in this ADR is
+a snapshot, not a constant** — read the live value from `SDK_ADAPTER_PEER_FLOOR`.
+Source manifests stay `workspace:^`; `scripts/pin-adapter-sdk-peer.mjs` applies the range at
+publish.
+
+**This whole mechanism is 0.x-only. Delete it when the SDK reaches 1.0.0** — at `>=1.0.0` a
+caret already means `>=1.2.0 <2.0.0`, which is the range this ADR spells out by hand. Do not
+carry the floor forward into 1.x: the ceiling is a literal `<1.0.0`, so a 1.x floor would
+publish the empty range `>=1.2.0 <1.0.0`. The tripwire is
+`scripts/pin-adapter-sdk-peer.test.mjs`, which asserts the produced range verbatim and fails
+on any floor change.
+
+The floor is true by construction only while it matches what the adapters actually build
+against; the `<1.0.0` ceiling is the additive-evolution policy (AGENTS.md).
+
+The adapter SDK peer **no longer names the in-repo SDK version**, so the old
+`npm view @ratel-ai/sdk@^${sdk_ver}` publish-order guard is gone. Telemetry still pins to
+`'^' +` the in-repo telemetry version; those `npm view` guards stay.
+
+## Consequences
+
+- Adapter minors no longer ship in lockstep with every SDK 0.x minor.
+- Lowering the floor requires making vercel's passthrough SPI usage optional first.
+- Narrowing the published peer is breaking under the 0.x rule in CONTRIBUTING.md (it drops
+  SDK 0.6–0.8 support), so the release carrying it takes a MINOR bump.
+- After an adapter GA publish, move the npm `rc` dist-tag onto that GA version. OIDC Trusted
+  Publishing does not cover `npm dist-tag`, so it is a manual post-publish step; left alone,
+  `@rc` keeps serving a prerelease whose SDK peer is the old caret.

--- a/scripts/pin-adapter-sdk-peer.mjs
+++ b/scripts/pin-adapter-sdk-peer.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+// Rewrite an adapter package.json's @ratel-ai/sdk peer + dev to the floor range
+// from release-units.mjs. Telemetry is untouched (its pin stays inline in
+// release.yml — mastra package-layout.test.ts asserts that text byte-for-byte).
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+import { isMainModule, SDK_ADAPTER_PEER_RANGE } from "./release-units.mjs";
+
+export function pinAdapterSdkPeerFile(file) {
+  const pkg = JSON.parse(readFileSync(file, "utf8"));
+  for (const field of ["peerDependencies", "devDependencies"]) {
+    if (pkg[field]?.["@ratel-ai/sdk"]) pkg[field]["@ratel-ai/sdk"] = SDK_ADAPTER_PEER_RANGE;
+  }
+  writeFileSync(file, `${JSON.stringify(pkg, null, 2)}\n`);
+}
+
+if (isMainModule(import.meta.url)) {
+  pinAdapterSdkPeerFile(process.argv[2]);
+}

--- a/scripts/pin-adapter-sdk-peer.test.mjs
+++ b/scripts/pin-adapter-sdk-peer.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { pinAdapterSdkPeerFile } from "./pin-adapter-sdk-peer.mjs";
+
+test("writes the floor range over the SDK peer and dev, leaving every other dep alone", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ratel-pin-"));
+  const file = join(dir, "package.json");
+  try {
+    writeFileSync(
+      file,
+      `${JSON.stringify(
+        {
+          peerDependencies: { "@ratel-ai/sdk": "workspace:^", "@mastra/core": ">=1.11.0 <2" },
+          devDependencies: { "@ratel-ai/sdk": "workspace:^" },
+          dependencies: { "@ratel-ai/telemetry": "workspace:^" },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    pinAdapterSdkPeerFile(file);
+    const written = JSON.parse(readFileSync(file, "utf8"));
+    assert.equal(written.peerDependencies["@ratel-ai/sdk"], ">=0.9.1 <1.0.0");
+    assert.equal(written.devDependencies["@ratel-ai/sdk"], ">=0.9.1 <1.0.0");
+    assert.equal(written.dependencies["@ratel-ai/telemetry"], "workspace:^");
+    assert.equal(written.peerDependencies["@mastra/core"], ">=1.11.0 <2");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/publish-rc.sh
+++ b/scripts/publish-rc.sh
@@ -59,6 +59,11 @@ FROM_DIR=""
 FROM_RUN=""
 DRY_RUN=0
 declare -a SELECTED=()
+# Adapter publishes pin the live manifests before pack; git checkout restores
+# them on EXIT (crash included). Guarded so a core/telemetry-only run cannot
+# clobber an unrelated uncommitted edit to those two files.
+PINNED_ADAPTERS=0
+trap '[[ $PINNED_ADAPTERS -eq 1 ]] && git -C "$REPO_ROOT" checkout -- src/adapters/ts-mastra/package.json src/adapters/ts-vercel-ai-sdk/package.json' EXIT
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -280,8 +285,9 @@ publish_telemetry_py() {
 
 # ---------- vercel-ai-sdk: @ratel-ai/vercel-ai-sdk on npm, packed locally ----------
 # The Vercel AI SDK framework adapter. Pure-TS like telemetry-ts, with a workspace:^
-# peer on @ratel-ai/sdk and a workspace:^ runtime dep on @ratel-ai/telemetry. `pnpm pack`
-# rewrites both to real version ranges in the tarball, so a plain `npm publish <tarball>`
+# peer on @ratel-ai/sdk (pinned to the ADR-0020 floor range before pack) and a
+# workspace:^ runtime dep on @ratel-ai/telemetry. `pnpm pack` rewrites remaining
+# workspace: specifiers in the tarball, so a plain `npm publish <tarball>`
 # (bootstrap: no OIDC, no provenance) ships a valid manifest.
 publish_vercel_ai_sdk() {
   local version; version="$(resolve_version vercel-ai-sdk)"
@@ -299,6 +305,8 @@ publish_vercel_ai_sdk() {
   # Build the adapter + its @ratel-ai/sdk and @ratel-ai/telemetry workspace
   # dependencies (topo order).
   ( cd "$REPO_ROOT" && pnpm --filter "@ratel-ai/vercel-ai-sdk..." run build )
+  PINNED_ADAPTERS=1
+  ( cd "$REPO_ROOT" && node scripts/pin-adapter-sdk-peer.mjs src/adapters/ts-vercel-ai-sdk/package.json )
   local tgz
   tgz="$( cd "$REPO_ROOT/src/adapters/ts-vercel-ai-sdk" && pnpm pack --pack-destination "$(mktemp -d)" | tail -1 )"
   if [[ $DRY_RUN -eq 1 ]]; then
@@ -336,9 +344,10 @@ publish_telemetry_core() {
 }
 
 # ---------- mastra: @ratel-ai/mastra on npm, packed locally ----------
-# Pure-language framework adapter with a `workspace:^` peer on @ratel-ai/sdk.
-# `pnpm pack` rewrites that specifier to the concrete co-installed version in the
-# tarball, so a plain `npm publish <tarball>` (bootstrap: no OIDC, no provenance)
+# Pure-language framework adapter with a `workspace:^` peer on @ratel-ai/sdk
+# (pinned to the ADR-0020 floor range before pack) and a `workspace:^` runtime
+# dep on @ratel-ai/telemetry. `pnpm pack` rewrites remaining workspace: specifiers
+# in the tarball, so a plain `npm publish <tarball>` (bootstrap: no OIDC, no provenance)
 # ships a valid manifest — same shape as vercel-ai-sdk.
 publish_mastra() {
   local version; version="$(resolve_version mastra)"
@@ -355,6 +364,8 @@ publish_mastra() {
   fi
   # Build the adapter and its @ratel-ai/sdk workspace dependency (topo order).
   ( cd "$REPO_ROOT" && pnpm --filter "@ratel-ai/mastra..." run build )
+  PINNED_ADAPTERS=1
+  ( cd "$REPO_ROOT" && node scripts/pin-adapter-sdk-peer.mjs src/adapters/ts-mastra/package.json )
   local tgz
   tgz="$( cd "$REPO_ROOT/src/adapters/ts-mastra" && pnpm pack --pack-destination "$(mktemp -d)" | tail -1 )"
   if [[ $DRY_RUN -eq 1 ]]; then

--- a/scripts/release-units.mjs
+++ b/scripts/release-units.mjs
@@ -107,7 +107,8 @@ export const UNITS = {
     },
   },
   // Framework adapters: npm-only, pure-language packages that peer-depend on
-  // @ratel-ai/sdk via `workspace:^` (rewritten to a concrete range at pack time).
+  // @ratel-ai/sdk via `workspace:^` (rewritten at pack time to
+  // SDK_ADAPTER_PEER_RANGE — a 0.x caret would pin the minor).
   // Each ships independently on its own tag prefix.
   "vercel-ai-sdk": {
     tagPrefix: "vercel-ai-sdk-v",
@@ -136,6 +137,14 @@ export const UNITS = {
 };
 
 export const UNIT_IDS = Object.keys(UNITS);
+
+// Floor of the published `@ratel-ai/sdk` peer on both adapters. Source manifests
+// stay `workspace:^`; pin-adapter-sdk-peer.mjs rewrites this range at publish.
+// 0.9.1 because vercel shipped code needs ExperimentalPassthroughToolExposure,
+// which first shipped in SDK 0.9.1. Never lower it; bump it to the SDK the
+// adapters are built against when cutting an adapter release (ADR-0020).
+export const SDK_ADAPTER_PEER_FLOOR = "0.9.1";
+export const SDK_ADAPTER_PEER_RANGE = `>=${SDK_ADAPTER_PEER_FLOOR} <1.0.0`;
 
 // Accepted release version: semver with an optional `-rc.N` pre-release.
 export const SEMVER = /^\d+\.\d+\.\d+(?:-rc\.\d+)?$/;

--- a/scripts/workflow-contracts.test.mjs
+++ b/scripts/workflow-contracts.test.mjs
@@ -3,6 +3,8 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 const ciWorkflow = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
+const releaseWorkflow = readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
+const publishRc = readFileSync(new URL("./publish-rc.sh", import.meta.url), "utf8");
 const verifyInstallWorkflow = readFileSync(
   new URL("../.github/workflows/verify-install.yml", import.meta.url),
   "utf8",
@@ -24,6 +26,38 @@ for (const job of ["verify-vercel-ai-sdk", "verify-mastra"]) {
     assert.doesNotMatch(body, /"@ratel-ai\/sdk@\$\{\{/);
   });
 }
+
+for (const job of ["publish-mastra", "publish-vercel-ai-sdk"]) {
+  test(`${job} pins the SDK peer via pin-adapter-sdk-peer.mjs, not a caret of SDK_VER`, () => {
+    const body = jobBody(releaseWorkflow, job);
+    assert.match(body, /node scripts\/pin-adapter-sdk-peer\.mjs/);
+    assert.doesNotMatch(body, /const v='\^'\+process\.env\.SDK_VER/);
+    assert.doesNotMatch(body, /npm view "@ratel-ai\/sdk@\^\$\{sdk_ver\}"/);
+  });
+}
+
+test("publish-vercel-ai-sdk pins telemetry with the release caret on runtime and dev", () => {
+  const body = jobBody(releaseWorkflow, "publish-vercel-ai-sdk");
+  assert.ok(
+    body.includes(
+      "const v='^'+process.env.TELE_VER; p.dependencies['@ratel-ai/telemetry']=v; p.devDependencies['@ratel-ai/telemetry']=v",
+    ),
+  );
+  assert.ok(body.includes('npm view "@ratel-ai/telemetry@^${tele_ver}" version'));
+});
+
+test("publish-rc.sh restores adapter manifests with a git checkout EXIT trap", () => {
+  assert.match(publishRc, /trap .*git .*checkout/);
+});
+
+// Scoped to the `ts` filter on purpose: workflow-contracts and mastra's
+// package-layout test run in the `ts` job, so a release.yml-only PR must trip it.
+// A file-wide match would keep passing if the path moved to another filter.
+test("ts path filter lists release.yml", () => {
+  const ts = ciWorkflow.indexOf("\n            ts:");
+  const next = ciWorkflow.indexOf("\n            python:", ts);
+  assert.ok(ciWorkflow.slice(ts, next).includes("- '.github/workflows/release.yml'"));
+});
 
 function jobBody(workflow, job) {
   const start = workflow.indexOf(`\n  ${job}:`);


### PR DESCRIPTION
## Problem

Both framework adapters publish their `@ratel-ai/sdk` peer as `^<in-repo SDK version>`.
At 0.x a caret pins the **minor** (`^0.6.0` means `>=0.6.0 <0.7.0`), so every SDK minor orphans both adapters.
`npm install @ratel-ai/mastra @ratel-ai/sdk@latest` fails with `ERESOLVE`. Broken since SDK 0.7.0 (2026-08-07).

The daily `verify-install` cron caught it a few times (2026-08-08 -> 2026-08-13), then went green because #148 removed the SDK co-install from the adapter verify jobs. The check stopped exercising the failure mode but the breakage still exists.

## Solution

Publish a floor range instead of a caret: `SDK_ADAPTER_PEER_FLOOR` in `scripts/release-units.mjs` is the single source of truth. `scripts/pin-adapter-sdk-peer.mjs` applies it in both `release.yml` publish jobs and in `publish-rc.sh`.
Source manifests stay `workspace:^`.

The floor is `0.9.1`: vercel's shipped code needs `ExperimentalPassthroughToolExposure`, first exported in SDK 0.9.1 (verified 94/94 and 52/52 against 0.9.1). `>=0.6.0` would resolve and then fail on a missing export. ADR-0020 records the measurement.

The SDK publish-order `npm view` guard is dropped: the peer no longer names the in-repo SDK version, so a floor-range check could never fail. Telemetry pins and their guards are unchanged.

## Notes

- Takes effect on the next adapter release (`vercel-ai-sdk@0.4.0`, `mastra@0.3.0`). This PR does not change any published package by itself.
- `release.yml` added to the `ts` paths filter, so a release.yml-only PR still runs the contract tests that guard the pin
- `publish-rc.sh` restores the manifests through a guarded `git checkout` EXIT trap. A core/telemetry-only run can't clobber an unrelated uncommitted edit
- The mechanism is 0.x-only: at SDK 1.0.0, `^1.2.0` already means `>=1.2.0 <2.0.0`, so we can delete it and let `release.yml` go back to a plain caret. Explained in ADR-0020.
- After both adapters ship, we can restore the `sdk@latest` co-install to `verify-install.yml` so the cron catches this class of drift again. It also needs the `workflow-contracts` "does not interpolate the SDK version" assertion updated.
