### PR TITLE
ci: co-install sdk@latest in adapter verify jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
               - 'rust-toolchain.toml'
               - '.github/workflows/ci.yml'
               - '.github/workflows/release.yml'
+              - '.github/workflows/verify-install.yml'
             # maturin builds the Python native binding from the Rust core; the SDK job
             # also installs the telemetry sibling and exercises the pydantic-ai example.
             python:

--- a/.github/workflows/verify-install.yml
+++ b/.github/workflows/verify-install.yml
@@ -131,10 +131,11 @@ jobs:
           tmp=$(mktemp -d)
           cd "$tmp"
           npm init -y >/dev/null
-          # npm installs the adapter's declared SDK peer. Do not force SDK
-          # `latest`: adapters and the SDK are independent release units.
+          # Co-install the current SDK on purpose: this proves the adapter's
+          # published peer range still admits the newest SDK, which is the drift ADR-0020 fixed.
           npm install --no-audit --no-fund \
             "@ratel-ai/vercel-ai-sdk@${{ steps.ver.outputs.adapter_spec }}" \
+            "@ratel-ai/sdk@latest" \
             "ai@^7.0.0"
           node --input-type=module <<'EOF'
           import { aiSdk } from "@ratel-ai/vercel-ai-sdk";
@@ -213,10 +214,11 @@ jobs:
           tmp=$(mktemp -d)
           cd "$tmp"
           npm init -y >/dev/null
-          # npm installs the adapter's declared SDK peer. Do not force SDK
-          # `latest`: adapters and the SDK are independent release units.
+          # Co-install the current SDK on purpose: this proves the adapter's
+          # published peer range still admits the newest SDK, which is the drift ADR-0020 fixed.
           npm install --no-audit --no-fund \
             "@ratel-ai/mastra@${{ steps.ver.outputs.adapter_spec }}" \
+            "@ratel-ai/sdk@latest" \
             "@mastra/core@^1.11.0" \
             "zod@^4.0.0"
           node --input-type=module <<'EOF'

--- a/scripts/workflow-contracts.test.mjs
+++ b/scripts/workflow-contracts.test.mjs
@@ -20,9 +20,10 @@ test("main push path filtering checks out the repository first", () => {
 });
 
 for (const job of ["verify-vercel-ai-sdk", "verify-mastra"]) {
-  test(`${job} lets npm resolve the adapter's declared SDK peer`, () => {
+  test(`${job} co-installs @ratel-ai/sdk@latest without interpolating a specific SDK version`, () => {
     const body = jobBody(verifyInstallWorkflow, job);
 
+    assert.match(body, /"@ratel-ai\/sdk@latest"/);
     assert.doesNotMatch(body, /"@ratel-ai\/sdk@\$\{\{/);
   });
 }
@@ -57,6 +58,12 @@ test("ts path filter lists release.yml", () => {
   const ts = ciWorkflow.indexOf("\n            ts:");
   const next = ciWorkflow.indexOf("\n            python:", ts);
   assert.ok(ciWorkflow.slice(ts, next).includes("- '.github/workflows/release.yml'"));
+});
+
+test("ts path filter lists verify-install.yml", () => {
+  const ts = ciWorkflow.indexOf("\n            ts:");
+  const next = ciWorkflow.indexOf("\n            python:", ts);
+  assert.ok(ciWorkflow.slice(ts, next).includes("- '.github/workflows/verify-install.yml'"));
 });
 
 function jobBody(workflow, job) {


### PR DESCRIPTION
Re-introducing the `@ratel-ai/sdk` co-install #148 removed from the two adapter `verify-install` jobs: installing the adapter alone always succeeds, since npm takes the old SDK its peer names, so the check went blind to the `^0.6.0` drift #150 fixed.

Both jobs now co-install `@ratel-ai/sdk@latest` and the contract test asserts it, still refusing an interpolated SDK version, which would reintroduce lockstep.

Also adding `verify-install.yml` to `ci.yml`'s `ts` filter, where that test runs. Dispatching an old adapter (`-f version=0.2.0`) will now `ERESOLVE`, which is expected, a real incompatibility, so no `--legacy-peer-deps` fallback.