### PR TITLE
fix(ci): restore main checks

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -2,5 +2,7 @@
 ^https://www\.npmjs\.com/package/@ratel-ai/sdk$
 ^https://pyo3\.rs/?$
 ^https://tsx\.is/?$
+# OpenTelemetry language docs intermittently reject GitHub-hosted Lychee requests.
+^https://opentelemetry\.io/docs/languages/(python|js)/$
 # ADR-0012 ships in this branch; its blob/main URL 404s until merge. Remove once on main.
 ^https://github\.com/ratel-ai/ratel/blob/main/docs/adr/0012-configurable-embedding-models\.md$

--- a/src/core/src/embedding_config.rs
+++ b/src/core/src/embedding_config.rs
@@ -1290,7 +1290,7 @@ mod tests {
         };
         assert_eq!(
             with_pool.configured_fingerprint(),
-            format!("local|path=11:/models/foo|pool=3:cls|q=3:q: |d=3:d: ")
+            "local|path=11:/models/foo|pool=3:cls|q=3:q: |d=3:d: ".to_string()
         );
     }
 


### PR DESCRIPTION
## Summary

- replace Rust 1.98-invalid literal-only `format!` in the existing fingerprint test
- exclude two repeatedly unreachable OpenTelemetry language-doc URLs from Lychee

## Verification

- `cargo +1.98.0 fmt --check --all`
- `cargo +1.98.0 clippy --workspace --all-targets -- -D warnings`
- `cargo +1.98.0 build --workspace`
- `cargo +1.98.0 test --workspace`
- full Lychee 0.24.2 workflow command: 392 links, 0 errors