### PR TITLE
release: bump affected packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "ratel-ai-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bm25",
  "candle-core",
@@ -1710,11 +1710,11 @@ dependencies = [
 
 [[package]]
 name = "ratel-ai-telemetry"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "ratel-sdk-python-native"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "pyo3",
  "pythonize",
@@ -1724,7 +1724,7 @@ dependencies = [
 
 [[package]]
 name = "ratel-sdk-ts-native"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "napi",
  "napi-build",

--- a/src/adapters/ts-mastra/CHANGELOG.md
+++ b/src/adapters/ts-mastra/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-21
+
+### Added
+
+- Preserve a tool's experimental searchable-description projection while ingesting Mastra definitions, allowing protocol-v2 retrieval text to differ from the model-facing description.
+
 ## [0.3.0] - 2026-08-17
 
 ### Added

--- a/src/adapters/ts-mastra/package.json
+++ b/src/adapters/ts-mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/mastra",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Mastra adapter for Ratel — adapts the context-engineering core to @mastra/core tool and message shapes, with a per-turn recall input processor.",
   "private": false,
   "type": "module",

--- a/src/adapters/ts-vercel-ai-sdk/CHANGELOG.md
+++ b/src/adapters/ts-vercel-ai-sdk/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-21
+
+### Added
+
+- Preserve a tool's experimental searchable-description projection while ingesting Vercel AI SDK definitions, allowing protocol-v2 retrieval text to differ from the model-facing description.
+
 ## [0.4.0] - 2026-08-17
 
 ### Added

--- a/src/adapters/ts-vercel-ai-sdk/package.json
+++ b/src/adapters/ts-vercel-ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/vercel-ai-sdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Vercel AI SDK adapter for Ratel — adapts the context-engineering core to the AI SDK's (ai@5-7) tool and message shapes, with per-turn recall helpers.",
   "private": false,
   "type": "module",

--- a/src/core/CHANGELOG.md
+++ b/src/core/CHANGELOG.md
@@ -6,7 +6,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-21
+
 ### Added
+
+- Experimental, opt-in `CatalogDefinition` trace events for changed tool, skill, and fact definitions. Events carry the public definition fields, effective searchable description, override state, and a canonical SHA-256 content hash; unchanged definitions are suppressed.
 
 - **Per-entry searchable-description projections (ADR-0021).** `Tool`, `Skill`, and `Fact` each gained `experimental_searchable_description: Option<String>`, an override for the description component BM25 and dense retrieval actually rank — so retrieval text can be tuned without touching the model-facing `description`, the schemas, or the payload. The override replaces *only* that component: the name stays indexed (whole and identifier-split) and skill/fact tags stay indexed, including when the override is the empty string, so optimizing a description can never make an entry undiscoverable by its own identifier. For a tool, supplying the override additionally opts that entry out of schema indexing — input and output schemas stay model-facing but stop contributing tokens. `None` leaves the stable ADR-0004 projection untouched: tools still rank description plus schema tokens, skills and facts still rank their authored description. Schema exclusion is per-entry opt-in, not a new default.
 

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratel-ai-core"
-version = "0.10.0" # core-v* release unit (ADR-0008)
+version = "0.11.0" # core-v* release unit (ADR-0008)
 edition.workspace = true
 license = "Apache-2.0"
 repository.workspace = true

--- a/src/sdk/python/CHANGELOG.md
+++ b/src/sdk/python/CHANGELOG.md
@@ -6,8 +6,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-08-21
+
 ### Added
 
+- Experimental catalog-definition telemetry. `experimental_catalog_definitions=True` publishes change-sensitive `catalog_definition` runtime events; OpenTelemetry export additionally requires `RATEL_EXPERIMENTAL_CATALOG_DEFINITIONS=true` and EventRecord content capture. Definitions use RFC 8785 canonical hashes, omit unsafe numeric schemas, and preserve critical identity fields when payloads are bounded.
 - `experimental_searchable_description` on `Tool`, `Skill`, and `Fact` (ADR-0021): an override for the description component BM25 and embeddings actually rank, so retrieval text can be tuned without changing the `description` the model reads or the `body` it receives. Names stay indexed, skill and fact tags stay indexed, and for a tool the override additionally opts that entry out of schema indexing — schemas stay model-facing but stop contributing tokens. Omit it and nothing changes: tools still rank description plus schema tokens, skills and facts still rank their authored description. Experimental, so it may change or be removed without a major-version bump.
 
   Unlike the Rust core — where the equivalent public field is source-breaking for struct literals — this is additive here. The field is appended last on each dataclass with a `None` default, so every keyword construction is untouched. The one caveat is positional construction of `ExecutableTool`, whose `execute` sits last after the inherited fields and so shifts by one; construct it by keyword, as the SDK and its own docs do everywhere.

--- a/src/sdk/python/native/Cargo.toml
+++ b/src/sdk/python/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratel-sdk-python-native"
-version = "0.11.0" # locked to ratel-ai (PyPI); ships in the sdk-py-v* unit (ADR-0008)
+version = "0.12.0" # locked to ratel-ai (PyPI); ships in the sdk-py-v* unit (ADR-0008)
 edition.workspace = true
 license = "MIT"
 repository.workspace = true

--- a/src/sdk/python/pyproject.toml
+++ b/src/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ratel-ai"
-version = "0.11.0"
+version = "0.12.0"
 description = "Python SDK for Ratel — context engineering platform for AI agents. BM25 tool retrieval, MCP ingestion, framework-neutral capability tools."
 readme = "README.md"
 license = { file = "LICENSE.md" }

--- a/src/sdk/ts/CHANGELOG.md
+++ b/src/sdk/ts/CHANGELOG.md
@@ -6,8 +6,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-08-21
+
 ### Added
 
+- Experimental catalog-definition telemetry. `events.experimentalCatalogDefinitions: true` publishes change-sensitive `catalog_definition` runtime events; OpenTelemetry export additionally requires `RATEL_EXPERIMENTAL_CATALOG_DEFINITIONS=true` and EventRecord content capture. Definitions use canonical hashes, omit unsafe numeric schemas, and preserve critical identity fields when payloads are bounded.
 - Experimental definition overrides through runtime attach: `catalog.experimentalAttachDefinitionOverrides({ source })` takes any `ExperimentalDefinitionOverlaySource` — `@ratel-ai/cloud-sdk` is the first one — which performs the initial pull and serialized, ETag-aware refreshes. Responses are runtime-validated with bounded entry fields and named `DefinitionOverlayError` failures; tool, skill, and fact updates roll back together on failure without advancing the ETag or override-ownership latch. Complete overlays restore local values on clear and warn when an override shadows an explicit local value. Calling it is one-way opt-in for the life of the process.
 - `experimentalSearchableDescription` on tool, skill, and fact registrations, and on `CatalogRegistration` (ADR-0021): an override for the description component BM25 and embeddings actually rank, so retrieval text can be tuned without changing the `description` the model reads or the `body` it receives. Names stay indexed, skill and fact tags stay indexed, and for a tool the override additionally opts that entry out of schema indexing — `inputSchema` / `outputSchema` stay model-facing but stop contributing tokens. Leave it out and nothing changes: tools still rank description plus schema tokens, skills and facts still rank their authored description. Optional everywhere it appears, so existing registrations compile and rank exactly as before. Experimental, so it may change or be removed without a major-version bump.
 

--- a/src/sdk/ts/native/Cargo.toml
+++ b/src/sdk/ts/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratel-sdk-ts-native"
-version = "0.11.0" # locked to @ratel-ai/sdk; ships in the sdk-ts-v* unit (ADR-0008)
+version = "0.12.0" # locked to @ratel-ai/sdk; ships in the sdk-ts-v* unit (ADR-0008)
 edition.workspace = true
 license = "MIT"
 repository.workspace = true

--- a/src/sdk/ts/npm/darwin-arm64/package.json
+++ b/src/sdk/ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/sdk-darwin-arm64",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "cpu": [
     "arm64"
   ],

--- a/src/sdk/ts/npm/darwin-x64/package.json
+++ b/src/sdk/ts/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/sdk-darwin-x64",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "cpu": [
     "x64"
   ],

--- a/src/sdk/ts/npm/linux-arm64-gnu/package.json
+++ b/src/sdk/ts/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/sdk-linux-arm64-gnu",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "cpu": [
     "arm64"
   ],

--- a/src/sdk/ts/npm/linux-x64-gnu/package.json
+++ b/src/sdk/ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/sdk-linux-x64-gnu",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "cpu": [
     "x64"
   ],

--- a/src/sdk/ts/npm/win32-x64-msvc/package.json
+++ b/src/sdk/ts/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/sdk-win32-x64-msvc",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "cpu": [
     "x64"
   ],

--- a/src/sdk/ts/package.json
+++ b/src/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/sdk",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "TypeScript SDK for Ratel \u2014 context engineering platform for AI agents. BM25 tool retrieval, MCP ingestion, framework-neutral capability tools.",
   "private": false,
   "type": "module",

--- a/src/telemetry/core/CHANGELOG.md
+++ b/src/telemetry/core/CHANGELOG.md
@@ -6,9 +6,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-21
+
 ### Added
 
-- `RATEL_CATALOG_USE_DEFINITION_OVERRIDES` for definition events emitted by runtimes using externally-sourced definition overrides.
+- Experimental catalog-definition telemetry vocabulary: `RATEL_CATALOG_DEFINITION`, its `ratel.catalog.*` attribute constants, `EXPERIMENTAL_CATALOG_DEFINITIONS_ENV`, and `RATEL_CATALOG_USE_DEFINITION_OVERRIDES` for runtimes using externally-sourced definition overrides.
 
 ## [0.3.0] - 2026-08-17
 

--- a/src/telemetry/core/Cargo.toml
+++ b/src/telemetry/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratel-ai-telemetry"
-version = "0.3.0" # telemetry-core-v* release unit (ADR-0008)
+version = "0.4.0" # telemetry-core-v* release unit (ADR-0008)
 edition.workspace = true
 license = "MIT"
 repository.workspace = true

--- a/src/telemetry/python/CHANGELOG.md
+++ b/src/telemetry/python/CHANGELOG.md
@@ -6,9 +6,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-21
+
 ### Added
 
-- `RATEL_CATALOG_USE_DEFINITION_OVERRIDES` for definition events emitted by runtimes using externally-sourced definition overrides.
+- Experimental catalog-definition telemetry vocabulary: `RATEL_CATALOG_DEFINITION`, its `ratel.catalog.*` attribute constants, `EXPERIMENTAL_CATALOG_DEFINITIONS_ENV`, and `RATEL_CATALOG_USE_DEFINITION_OVERRIDES` for runtimes using externally-sourced definition overrides.
 
 ## [0.4.0] - 2026-08-17
 

--- a/src/telemetry/python/pyproject.toml
+++ b/src/telemetry/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ratel-ai-telemetry"
-version = "0.4.0"
+version = "0.5.0"
 description = "Ratel telemetry conventions — the ratel.* overlay on OpenTelemetry gen_ai spans and EventRecords."
 readme = "README.md"
 license = { file = "LICENSE.md" }

--- a/src/telemetry/ts/CHANGELOG.md
+++ b/src/telemetry/ts/CHANGELOG.md
@@ -6,9 +6,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-21
+
 ### Added
 
-- `RATEL_CATALOG_USE_DEFINITION_OVERRIDES` for definition events emitted by runtimes using externally-sourced definition overrides.
+- Experimental catalog-definition telemetry vocabulary: `RATEL_CATALOG_DEFINITION`, its `ratel.catalog.*` attribute constants, `EXPERIMENTAL_CATALOG_DEFINITIONS_ENV`, and `RATEL_CATALOG_USE_DEFINITION_OVERRIDES` for runtimes using externally-sourced definition overrides.
 
 ## [0.4.0] - 2026-08-17
 

--- a/src/telemetry/ts/package.json
+++ b/src/telemetry/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/telemetry",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Ratel telemetry conventions — the ratel.* overlay on OpenTelemetry gen_ai spans and EventRecords. OTel-free vocabulary + content-capture gate.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Summary

- release minors for all eight units changed by #154, #155, and #152
- include telemetry packages required by `@ratel-ai/cloud-sdk`
- update every per-unit changelog via `/changelog`

## Versions

- core 0.11.0
- TS/Python SDKs 0.12.0
- telemetry core 0.4.0
- telemetry TS/Python 0.5.0
- Vercel AI SDK adapter 0.5.0
- Mastra adapter 0.4.0

## Verification

- all eight tag gates
- release tooling tests (39)
- pnpm build/typecheck/lint/test
- cargo test/clippy/fmt + crates.io dry-runs
- Python telemetry ruff/mypy/pytest
- Python SDK ruff/mypy/pytest against local telemetry 0.5.0